### PR TITLE
Update READMEs with automatic file lists

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -21,3 +21,10 @@ This directory stores configurations and templates specific to the project's Git
         -   The badge at the top of the main `README.md` ( [![CI - Main](...ci.yml/badge.svg...)](...ci.yml) ) usually reflects the status of this CI workflow.
 
 These configurations are standard for GitHub-hosted projects and aim to improve collaboration, code quality, and automation. 
+
+<!-- File List Start -->
+## File List
+
+- `PULL_REQUEST_TEMPLATE.md`
+
+<!-- File List End -->

--- a/README.md
+++ b/README.md
@@ -291,3 +291,38 @@ Key files and directories:
 *   `docs/`: Placeholder for additional documentation (currently empty).
 *   `.cursor/`: Contains MCP rules and agent configurations.
 
+
+<!-- File List Start -->
+## File List
+
+- `.cursorignore`
+- `.gitignore`
+- `.npmignore`
+- `AEROSPACE_GRADE_DOCUMENTATION.md`
+- `BACKEND_FRONTEND_ALIGNMENT_REPORT.md`
+- `CLEANUP_SUMMARY.md`
+- `DEV_LAUNCHER_COMPLETE.md`
+- `DEV_LAUNCHER_GUIDE.md`
+- `LICENSE`
+- `SYSTEM_GUIDE.md`
+- `TEST_ENHANCEMENT_REPORT.md`
+- `THE_BUILDERS_COMPLETION_REPORT.md`
+- `dev_launcher.bat`
+- `dev_launcher.js`
+- `dev_launcher.ps1`
+- `final_integration.py`
+- `image-dark.png`
+- `image-light.png`
+- `package-lock.json`
+- `package.json`
+- `run_backend.py`
+- `run_core_backend.py`
+- `run_minimal_backend.py`
+- `run_production_backend.py`
+- `sql_app.db`
+- `start_system.py`
+- `test_openapi.py`
+- `validate_alignment.py`
+- `validate_frontend.js`
+
+<!-- File List End -->

--- a/backend/README.md
+++ b/backend/README.md
@@ -192,3 +192,48 @@ Key files and directories:
 *   `database.py`: Database connection and session setup.
 *   `requirements.txt`: Python project dependencies.
 *   `auth.py`: Authentication related code.
+
+<!-- File List Start -->
+## File List
+
+- `.env`
+- `.flake8`
+- `__init__.py`
+- `alembic.ini`
+- `auth.py`
+- `check_routes.py`
+- `comprehensive_flake8_fixer.py`
+- `comprehensive_indent_fix.py`
+- `database.py`
+- `debug_tables.py`
+- `debug_test_db.py`
+- `enums.py`
+- `fix_all_indentation.py`
+- `fix_comprehensive_flake8.py`
+- `fix_conftest.py`
+- `fix_flake8.py`
+- `fix_indentation.py`
+- `fix_line.py`
+- `fix_mcp_indentation.py`
+- `fix_project_indentation.py`
+- `flake8_output.txt`
+- `fresh_flake8_output.txt`
+- `init_db.py`
+- `main.py`
+- `middleware.py`
+- `post_fix_flake8.txt`
+- `pytest.ini`
+- `quick_fix_project_service.py`
+- `quick_indent_fix.py`
+- `requirements.txt`
+- `security.py`
+- `test_app_import.py`
+- `test_basic_imports.py`
+- `test_endpoints.py`
+- `test_individual_models.py`
+- `test_lazy_imports.py`
+- `test_openapi.json`
+- `test_router_imports.py`
+- `validation.py`
+
+<!-- File List End -->

--- a/backend/alembic/README.md
+++ b/backend/alembic/README.md
@@ -26,3 +26,12 @@ Key files and directories:
 ## Key Files and Directories
 
 -   **`
+
+<!-- File List Start -->
+## File List
+
+- `README`
+- `env.py`
+- `script.py.mako`
+
+<!-- File List End -->

--- a/backend/config/README.md
+++ b/backend/config/README.md
@@ -8,3 +8,13 @@ Key files:
 *   `router_config.py`: Configures API routers and their dependencies.
 *   `logging_config.py`: Sets up logging for the application.
 *   `__init__.py`: Initializes the config package. 
+
+<!-- File List Start -->
+## File List
+
+- `__init__.py`
+- `app_config.py`
+- `logging_config.py`
+- `router_config.py`
+
+<!-- File List End -->

--- a/backend/crud/README.md
+++ b/backend/crud/README.md
@@ -18,3 +18,33 @@ Key CRUD and validation files include:
 *   `project_templates.py`: CRUD operations for project templates.
 *   `project_file_associations.py`: CRUD operations for project file associations.
 *   `task_validation.py`, `task_dependency_validation.py`, `task_file_association_validation.py`, `project_validation.py`, `project_member_validation.py`, `comment_validation.py`, `agent_validation.py`, `project_file_association_validation.py`, `user_validation.py`: Files containing validation logic used by CRUD functions. 
+
+<!-- File List Start -->
+## File List
+
+- `__init__.py`
+- `agent_rules.py`
+- `agent_validation.py`
+- `agents.py`
+- `audit_logs.py`
+- `comment_validation.py`
+- `comments.py`
+- `memory.py`
+- `project_file_association_validation.py`
+- `project_file_associations.py`
+- `project_member_validation.py`
+- `project_members.py`
+- `project_templates.py`
+- `project_validation.py`
+- `projects.py`
+- `rules.py`
+- `task_dependencies.py`
+- `task_dependency_validation.py`
+- `task_file_association_validation.py`
+- `task_file_associations.py`
+- `task_validation.py`
+- `tasks.py`
+- `user_validation.py`
+- `users.py`
+
+<!-- File List End -->

--- a/backend/crud/utils/README.md
+++ b/backend/crud/utils/README.md
@@ -9,3 +9,14 @@ Key files:
 *   `dependency_utils.py`: Utility functions for task dependencies.
 *   `file_association_utils.py`: Utility functions for file associations (likely related to the Memory service).
 *   `__init__.py`: Initializes the utils package. 
+
+<!-- File List Start -->
+## File List
+
+- `__init__.py`
+- `dependency_utils.py`
+- `file_association_utils.py`
+- `task_file_utils.py`
+- `user_utils.py`
+
+<!-- File List End -->

--- a/backend/mcp_tools/README.md
+++ b/backend/mcp_tools/README.md
@@ -8,3 +8,13 @@ Key files:
 *   `memory_tools.py`: MCP-specific tools for interacting with the Memory Service.
 *   `project_tools.py`: MCP-specific tools for interacting with projects.
 *   `__init__.py`: Initializes the mcp_tools package. 
+
+<!-- File List Start -->
+## File List
+
+- `__init__.py`
+- `memory_tools.py`
+- `project_tools.py`
+- `task_tools.py`
+
+<!-- File List End -->

--- a/backend/middleware/README.md
+++ b/backend/middleware/README.md
@@ -7,3 +7,12 @@ Key files:
 *   `request_middleware.py`: Contains middleware for processing incoming requests.
 *   `error_handlers.py`: Defines custom exception handlers for the application.
 *   `__init__.py`: Initializes the middleware package. 
+
+<!-- File List Start -->
+## File List
+
+- `__init__.py`
+- `error_handlers.py`
+- `request_middleware.py`
+
+<!-- File List End -->

--- a/backend/models/README.md
+++ b/backend/models/README.md
@@ -16,3 +16,35 @@ Key models include:
 *   `AgentHandoffCriteria`, `AgentVerificationRequirement`, `AgentForbiddenAction`, `AgentErrorProtocol`, `AgentCapability`, `AgentRole`: Models related to agent capabilities and protocols.
 *   `UniversalMandate`: Represents system-wide mandates.
 *   `Workflow`, `ProjectMember`, `ProjectTemplate`, `TaskStatus`, `TaskRelations`, `Core`, `Base`, `Types`: Other supporting models and base classes. 
+
+<!-- File List Start -->
+## File List
+
+- `__init__.py`
+- `agent.py`
+- `agent_capability.py`
+- `agent_error_protocol.py`
+- `agent_forbidden_action.py`
+- `agent_handoff_criteria.py`
+- `agent_role.py`
+- `agent_verification_requirement.py`
+- `audit.py`
+- `base.py`
+- `comment.py`
+- `core.py`
+- `memory.py`
+- `project.py`
+- `project_member.py`
+- `project_template.py`
+- `task.py`
+- `task_dependency.py`
+- `task_file_association.py`
+- `task_relations.py`
+- `task_status.py`
+- `types.py`
+- `universal_mandate.py`
+- `user.py`
+- `user_role.py`
+- `workflow.py`
+
+<!-- File List End -->

--- a/backend/routers/README.md
+++ b/backend/routers/README.md
@@ -39,3 +39,11 @@ This directory contains the FastAPI routers that define the API endpoints for th
     *   `core/`: Core user management operations.
 
 Interactive API documentation is available at `/docs` and `/redoc` when the backend server is running. 
+
+<!-- File List Start -->
+## File List
+
+- `__init__.py`
+- `admin.py`
+
+<!-- File List End -->

--- a/backend/services/README.md
+++ b/backend/services/README.md
@@ -19,3 +19,26 @@ Key service files include:
 *   `project_file_association_service.py`: Contains logic for managing associations between projects and files/Memory entities.
 *   `exceptions.py`: Defines custom exceptions used within the services.
 *   `utils.py`: Contains utility functions used across services. 
+
+<!-- File List Start -->
+## File List
+
+- `__init__.py`
+- `agent_service.py`
+- `audit_log_service.py`
+- `comment_service.py`
+- `exceptions.py`
+- `memory_service.py`
+- `project_file_association_service.py`
+- `project_member_service.py`
+- `project_service.py`
+- `project_template_service.py`
+- `rules_service.py`
+- `task_dependency_service.py`
+- `task_file_association_service.py`
+- `task_service.py`
+- `user_role_service.py`
+- `user_service.py`
+- `utils.py`
+
+<!-- File List End -->

--- a/backend/tests/README.md
+++ b/backend/tests/README.md
@@ -44,3 +44,18 @@
 
 ## Continuous Integration
 Tests are automatically run on push and pull requests via GitHub Actions.
+
+<!-- File List Start -->
+## File List
+
+- `__init__.py`
+- `audit_logs_flake8_output.txt`
+- `conftest.py`
+- `conftest.py.backup`
+- `conftest_backup.py`
+- `test_crud.py`
+- `test_integration.py`
+- `test_openapi.py`
+- `test_simple.py`
+
+<!-- File List End -->

--- a/backend/tests/integration/README.md
+++ b/backend/tests/integration/README.md
@@ -5,3 +5,10 @@ This directory contains integration tests for the backend application. Integrati
 Key files:
 
 *   `test_project_task_flow.py`: Tests the integrated flow of project and task management operations. 
+
+<!-- File List Start -->
+## File List
+
+- `test_project_task_flow.py`
+
+<!-- File List End -->

--- a/backend/tests/unit/README.md
+++ b/backend/tests/unit/README.md
@@ -8,3 +8,9 @@ Subdirectories contain unit tests for different backend layers:
 *   `database/`: Unit tests for database connection and setup.
 *   `routes/`: Unit tests for API router endpoint logic.
 *   `services/`: Unit tests for business logic services. 
+
+<!-- File List Start -->
+## File List
+
+
+<!-- File List End -->

--- a/backend/tests/unit/crud/README.md
+++ b/backend/tests/unit/crud/README.md
@@ -5,3 +5,9 @@ This directory contains unit tests specifically for the database CRUD functions 
 Key files:
 
 *   `test_projects.py`: Unit tests for project CRUD functions. 
+
+<!-- File List Start -->
+## File List
+
+
+<!-- File List End -->

--- a/backend/tests/unit/database/README.md
+++ b/backend/tests/unit/database/README.md
@@ -3,3 +3,9 @@
 This directory is intended to contain unit tests for the database connection and session management logic defined in `backend/database.py`. These tests would verify the correct setup and teardown of database connections and sessions in a controlled environment.
 
 *Note: This directory is currently empty, indicating that database unit tests have not yet been implemented.* 
+
+<!-- File List Start -->
+## File List
+
+
+<!-- File List End -->

--- a/backend/tests/unit/routes/README.md
+++ b/backend/tests/unit/routes/README.md
@@ -5,3 +5,9 @@ This directory contains unit tests for the API router endpoint logic in the back
 Key files:
 
 *   `test_project_routes.py`: Unit tests for project-related API routes. 
+
+<!-- File List Start -->
+## File List
+
+
+<!-- File List End -->

--- a/backend/tests/unit/services/README.md
+++ b/backend/tests/unit/services/README.md
@@ -5,3 +5,9 @@ This directory contains unit tests for the business logic service layer in the b
 Key files:
 
 *   `test_project_service.py`: Unit tests for project-related service logic. 
+
+<!-- File List Start -->
+## File List
+
+
+<!-- File List End -->

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -107,3 +107,32 @@ Key files and directories:
 *   `tailwind.config.ts`: Tailwind CSS configuration file.
 *   `tests-e2e/`: End-to-end tests using Playwright.
 *   `vitest.config.*`: Configuration files for Vitest unit/integration tests.
+
+<!-- File List Start -->
+## File List
+
+- `.gitignore`
+- `ARCHITECTURE.md`
+- `BRAND_ASSETS_GUIDE.md`
+- `COMPONENT_AUDIT_AND_REFACTOR_PLAN.md`
+- `DESIGN_TOKENS.md`
+- `TESTING_FRAMEWORK.md`
+- `TESTING_FRAMEWORK_COMPLETE.md`
+- `UI_UX_DESIGN_SYSTEM_SPECIFICATION.md`
+- `dev_start.js`
+- `eslint.config.cjs`
+- `generate-comprehensive-tests.cjs`
+- `generate-tests.js`
+- `next.config.ts`
+- `package-lock.json`
+- `package.json`
+- `playwright.config.ts`
+- `postcss.config.mjs`
+- `tailwind.config.ts`
+- `test-runner.js`
+- `tsconfig.json`
+- `validate-testing-framework.js`
+- `vitest.config.js`
+- `vitest.config.ts`
+
+<!-- File List End -->

--- a/frontend/public/README.md
+++ b/frontend/public/README.md
@@ -10,3 +10,19 @@ Key files and directories:
 *   `api-test.html`: An HTML file likely used for API testing or demonstration purposes.
 *   `next.svg`, `vercel.svg`: Default Next.js and Vercel logos.
 *   Other static files required for the application. 
+
+<!-- File List Start -->
+## File List
+
+- `api-test.html`
+- `favicon_dark_32.png`
+- `favicon_dark_64.png`
+- `favicon_light_32.png`
+- `favicon_light_64.png`
+- `file.svg`
+- `globe.svg`
+- `next.svg`
+- `vercel.svg`
+- `window.svg`
+
+<!-- File List End -->

--- a/frontend/public/assets/README.md
+++ b/frontend/public/assets/README.md
@@ -5,3 +5,9 @@ This directory serves as a container for various static assets used by the front
 Key subdirectories:
 
 *   `images/`: Contains image files used throughout the application. 
+
+<!-- File List Start -->
+## File List
+
+
+<!-- File List End -->

--- a/frontend/public/assets/images/README.md
+++ b/frontend/public/assets/images/README.md
@@ -6,3 +6,13 @@ Key image files:
 
 *   `logo_light.png`, `logo_dark.png`: Logo images for light and dark themes.
 *   `icon_light.png`, `icon_dark.png`: Icon images for light and dark themes. 
+
+<!-- File List Start -->
+## File List
+
+- `icon_dark.png`
+- `icon_light.png`
+- `logo_dark.png`
+- `logo_light.png`
+
+<!-- File List End -->

--- a/frontend/src/README.md
+++ b/frontend/src/README.md
@@ -114,3 +114,9 @@ The `src/` directory is further organized into the following subdirectories:
 - `theme/`: May contain more granular theme customizations, overrides, or theme-related assets (although `theme.ts` is at the `src/` root).
 - `types/`: TypeScript type definitions and interfaces used across the application.
 - `__tests__/`: Contains test files, likely for unit or integration testing of the components and logic within the `src/` directory.
+
+<!-- File List Start -->
+## File List
+
+
+<!-- File List End -->

--- a/frontend/src/__tests__/README.md
+++ b/frontend/src/__tests__/README.md
@@ -10,3 +10,11 @@ Key files and directories:
 *   `mocks/`: Mock implementations for dependencies (e.g., API services).
 *   `utils/`: Test utility functions.
 *   `.gitkeep`: Placeholder file to ensure the directory is included in Git. 
+
+<!-- File List Start -->
+## File List
+
+- `.gitkeep`
+- `setup.ts`
+
+<!-- File List End -->

--- a/frontend/src/__tests__/factories/README.md
+++ b/frontend/src/__tests__/factories/README.md
@@ -9,3 +9,14 @@ Key files:
 *   `project.factory.ts`: Factory for generating project data.
 *   `task.factory.ts`: Factory for generating task data.
 *   `index.ts`: Barrel file re-exporting the factories. 
+
+<!-- File List Start -->
+## File List
+
+- `comprehensive.factory.ts`
+- `index.ts`
+- `project.factory.ts`
+- `task.factory.ts`
+- `user.factory.ts`
+
+<!-- File List End -->

--- a/frontend/src/__tests__/integration/README.md
+++ b/frontend/src/__tests__/integration/README.md
@@ -5,3 +5,10 @@ This directory contains integration tests for the frontend application. These te
 Key files:
 
 *   `task-management.test.tsx`: Integration tests covering task management flows. 
+
+<!-- File List Start -->
+## File List
+
+- `task-management.test.tsx`
+
+<!-- File List End -->

--- a/frontend/src/__tests__/mocks/README.md
+++ b/frontend/src/__tests__/mocks/README.md
@@ -6,3 +6,11 @@ Key files:
 
 *   `handlers.ts`: Defines request handlers for mocked API endpoints.
 *   `server.ts`: Sets up and configures the mock server (likely using libraries like MSW - Mock Service Worker). 
+
+<!-- File List Start -->
+## File List
+
+- `handlers.ts`
+- `server.ts`
+
+<!-- File List End -->

--- a/frontend/src/__tests__/utils/README.md
+++ b/frontend/src/__tests__/utils/README.md
@@ -5,3 +5,10 @@ This directory contains utility functions and helpers specifically designed to s
 Key files:
 
 *   `test-utils.tsx`: Contains custom rendering utilities (likely re-exporting or extending `@testing-library/react` methods). 
+
+<!-- File List Start -->
+## File List
+
+- `test-utils.tsx`
+
+<!-- File List End -->

--- a/frontend/src/app/README.md
+++ b/frontend/src/app/README.md
@@ -117,3 +117,13 @@ Key files and directories:
 *   `favicon.ico`: Application favicon.
 *   `projects/[projectId]/`: Directory containing the page for individual project details.
 *   `mcp-dev-tools/`: Directory likely related to developer tools/features.
+
+<!-- File List Start -->
+## File List
+
+- `favicon.ico`
+- `globals.css`
+- `layout.tsx`
+- `page.tsx`
+
+<!-- File List End -->

--- a/frontend/src/app/mcp-dev-tools/README.md
+++ b/frontend/src/app/mcp-dev-tools/README.md
@@ -11,3 +11,10 @@ This directory defines the Next.js route for the MCP Developer Tools page, acces
 - **Functionality**: As a result, navigating to `/mcp-dev-tools` in the browser will render the `MCPDevTools` component, which provides a dedicated interface for development and debugging related to MCP functionalities.
 
 The `MCPDevTools` component itself (located in `frontend/src/components/`) is responsible for the actual UI and features of the developer tools panel.
+
+<!-- File List Start -->
+## File List
+
+- `page.tsx`
+
+<!-- File List End -->

--- a/frontend/src/app/projects/[projectId]/README.md
+++ b/frontend/src/app/projects/[projectId]/README.md
@@ -5,3 +5,10 @@ This directory contains the page component for displaying the details of a speci
 Key file:
 
 *   `page.tsx`: The page component responsible for fetching project and task data, displaying project information, and rendering the list of tasks for that project. It includes functionality for interacting with tasks (e.g., viewing details, marking complete, archiving, managing dependencies and file associations). 
+
+<!-- File List Start -->
+## File List
+
+- `page.tsx`
+
+<!-- File List End -->

--- a/frontend/src/components/README.md
+++ b/frontend/src/components/README.md
@@ -145,3 +145,30 @@ Key files and directories:
 *   `task/`: Components for displaying and interacting with individual tasks.
 *   `views/`: Components defining larger view structures or layouts.
 *   Individual component files like `TaskList.tsx`, `ProjectList.tsx`, `AgentList.tsx`, `AddTaskForm.tsx`, etc.
+
+<!-- File List Start -->
+## File List
+
+- `AgentList.tsx`
+- `ClientOnly.tsx`
+- `Dashboard.tsx`
+- `LoadingSkeleton.tsx`
+- `MCPDevTools.tsx`
+- `NoTasks.tsx`
+- `ProjectList.tsx`
+- `SettingsContent.tsx`
+- `TaskAgentTag.tsx`
+- `TaskControls.tsx`
+- `TaskError.tsx`
+- `TaskItemModals.tsx`
+- `TaskList.tsx`
+- `TaskList.utils.ts`
+- `TaskLoading.tsx`
+- `TaskProjectTag.tsx`
+- `TaskStatusTag.tsx`
+- `ThemeToggleButton.tsx`
+- `VirtualizedList.tsx`
+- `useTaskItemStyles.ts`
+- `useTaskListState.ts`
+
+<!-- File List End -->

--- a/frontend/src/components/ThemeToggleButton/README.md
+++ b/frontend/src/components/ThemeToggleButton/README.md
@@ -5,3 +5,10 @@ This directory contains the reusable component for toggling between light and da
 Key file:
 
 *   `ThemeToggleButton.tsx`: A button component that uses the application's theme context to switch between defined color modes. 
+
+<!-- File List Start -->
+## File List
+
+- `ThemeToggleButton.tsx`
+
+<!-- File List End -->

--- a/frontend/src/components/agent/README.md
+++ b/frontend/src/components/agent/README.md
@@ -10,3 +10,15 @@ Key files:
 *   `AddAgentModal.tsx`: Modal for adding a new agent.
 *   `EditAgentModal.tsx`: Modal for editing an existing agent.
 *   `CliPromptModal.tsx`: Modal related to command-line interface prompts, potentially used in agent interactions. 
+
+<!-- File List Start -->
+## File List
+
+- `AddAgentModal.tsx`
+- `AgentCard.tsx`
+- `AgentList.tsx`
+- `AgentListHeader.tsx`
+- `CliPromptModal.tsx`
+- `EditAgentModal.tsx`
+
+<!-- File List End -->

--- a/frontend/src/components/audit_logs/README.md
+++ b/frontend/src/components/audit_logs/README.md
@@ -5,3 +5,10 @@ This directory contains React components for displaying audit logs related to sp
 Key files:
 
 *   `AuditLogListForEntity.tsx`: Component that displays a list of audit log entries filtered by a specific entity (e.g., task ID, project ID). 
+
+<!-- File List Start -->
+## File List
+
+- `AuditLogListForEntity.tsx`
+
+<!-- File List End -->

--- a/frontend/src/components/common/README.md
+++ b/frontend/src/components/common/README.md
@@ -106,3 +106,22 @@ Key files:
 *   `TaskDescriptionEditor.tsx`: Inline editor for task descriptions.
 *   `FilterPanel.tsx`: Panel containing filter controls (likely used within `FilterSidebar`).
 *   `AppIcon.tsx`: Component for displaying application icons.
+
+<!-- File List Start -->
+## File List
+
+- `AddFormBase.tsx`
+- `AppIcon.tsx`
+- `ConfirmationModal.tsx`
+- `EditModalBase.tsx`
+- `FilterPanel.tsx`
+- `FilterSidebar.tsx`
+- `TaskActionsMenu.tsx`
+- `TaskAgentTag.tsx`
+- `TaskDependencyTag.tsx`
+- `TaskDescriptionEditor.tsx`
+- `TaskProjectTag.tsx`
+- `TaskStatusTag.tsx`
+- `TaskTitleEditor.tsx`
+
+<!-- File List End -->

--- a/frontend/src/components/dashboard/README.md
+++ b/frontend/src/components/dashboard/README.md
@@ -79,3 +79,23 @@ Key files:
 *   `DashboardSection.tsx`: Reusable component for structuring sections within the dashboard.
 *   `CreateProjectModal.tsx`: Modal for creating new projects.
 *   `EditProjectModal.tsx`: Modal for editing project details.
+
+<!-- File List Start -->
+## File List
+
+- `AgentWorkloadChart.tsx`
+- `CreateProjectModal.tsx`
+- `DashboardError.tsx`
+- `DashboardLoading.tsx`
+- `DashboardSection.tsx`
+- `DashboardStatsGrid.tsx`
+- `EditProjectModal.tsx`
+- `ProjectProgressChart.tsx`
+- `RecentActivityList.tsx`
+- `TaskStatusChart.tsx`
+- `TasksOverTimeChart.tsx`
+- `TopPerformersLists.tsx`
+- `UnassignedTasksList.tsx`
+- `useDashboardData.ts`
+
+<!-- File List End -->

--- a/frontend/src/components/forms/README.md
+++ b/frontend/src/components/forms/README.md
@@ -39,3 +39,14 @@ Key files:
 *   `EditAgentForm.tsx`: Form for editing existing agent details.
 *   `AddAgentForm.tsx`: Form for adding new agents.
 *   `AddTaskForm.tsx`: Form for adding new tasks (likely a specific implementation using `TaskForm.tsx`).
+
+<!-- File List Start -->
+## File List
+
+- `AddAgentForm.tsx`
+- `AddProjectForm.tsx`
+- `AddTaskForm.tsx`
+- `EditAgentForm.tsx`
+- `TaskForm.tsx`
+
+<!-- File List End -->

--- a/frontend/src/components/layout/README.md
+++ b/frontend/src/components/layout/README.md
@@ -6,3 +6,11 @@ Key files:
 
 *   `Sidebar.tsx`: Implements the main application sidebar, containing navigation links, action buttons, and other global controls.
 *   `MainContent.tsx`: Defines the main content area where different views (dashboard, task list, project list, etc.) are rendered. 
+
+<!-- File List Start -->
+## File List
+
+- `MainContent.tsx`
+- `Sidebar.tsx`
+
+<!-- File List End -->

--- a/frontend/src/components/modals/README.md
+++ b/frontend/src/components/modals/README.md
@@ -49,3 +49,20 @@ Key files:
 *   `ImportPlanModal.tsx`: Modal for importing project plans from a file or text.
 *   `DevToolsDrawer.tsx`: Likely a modal or drawer component for developer tools.
 *   `README.md`: This file.
+
+<!-- File List Start -->
+## File List
+
+- `AddAgentModal.tsx`
+- `AddProjectModal.tsx`
+- `AddTaskModal.tsx`
+- `AgentAssignmentModal.tsx`
+- `CreateProjectModal.tsx`
+- `DevToolsDrawer.tsx`
+- `EditAgentModal.tsx`
+- `EditProjectModal.tsx`
+- `EditTaskModal.tsx`
+- `ImportPlanModal.tsx`
+- `TaskDetailsModal.tsx`
+
+<!-- File List End -->

--- a/frontend/src/components/project/README.md
+++ b/frontend/src/components/project/README.md
@@ -8,3 +8,13 @@ Key files:
 *   `ProjectDetail.tsx`: Component for displaying the detailed information of a single project.
 *   `ProjectFiles.tsx`: Component for displaying and managing files associated with a project.
 *   `ProjectMembers.tsx`: Component for displaying and managing members associated with a project. 
+
+<!-- File List Start -->
+## File List
+
+- `ProjectDetail.tsx`
+- `ProjectFiles.tsx`
+- `ProjectList.tsx`
+- `ProjectMembers.tsx`
+
+<!-- File List End -->

--- a/frontend/src/components/task/README.md
+++ b/frontend/src/components/task/README.md
@@ -132,3 +132,15 @@ Key files:
 *   `TaskItem.types.ts`: Defines TypeScript types for task components.
 *   `TaskItem.styles.ts`: Contains styling definitions for task components.
 *   `README.md`: This file.
+
+<!-- File List Start -->
+## File List
+
+- `TaskItem.styles.ts`
+- `TaskItem.tsx`
+- `TaskItem.types.ts`
+- `TaskItem.utils.ts`
+- `TaskItemDetailsSection.tsx`
+- `TaskItemMainSection.tsx`
+
+<!-- File List End -->

--- a/frontend/src/components/views/README.md
+++ b/frontend/src/components/views/README.md
@@ -37,3 +37,17 @@ Key files:
     - Could be a more detailed or tabular alternative to simpler list components like `TaskList.tsx` or `ProjectList.tsx`, or it might be a generic, configurable list component.
 
 These view components allow users to switch between different perspectives when examining their data, catering to various workflow preferences.
+
+<!-- File List Start -->
+## File List
+
+- `KanbanColumn.tsx`
+- `KanbanView.tsx`
+- `ListGroup.tsx`
+- `ListSubgroup.tsx`
+- `ListTaskItem.tsx`
+- `ListTaskMobile.tsx`
+- `ListView.tsx`
+- `ListView.types.ts`
+
+<!-- File List End -->

--- a/frontend/src/contexts/README.md
+++ b/frontend/src/contexts/README.md
@@ -15,3 +15,11 @@ Key files:
 ## Files
 
 ### `ProjectContext.tsx`
+
+<!-- File List Start -->
+## File List
+
+- `ProjectContext.tsx`
+- `ThemeContext.tsx`
+
+<!-- File List End -->

--- a/frontend/src/lib/README.md
+++ b/frontend/src/lib/README.md
@@ -83,3 +83,15 @@ Defines the structure and provides a list of available MCP (Multi-Context Person
       - Tasks: `create_task`, `get_task_list`, `get_task_by_id`, `update_task`, `delete_task`
       - Planning: `generate_planning_prompt`
     - Each tool definition specifies its HTTP method, path, parameters (including their type, whether they are required, and if they are path, query, or body parameters), and a brief description.
+
+<!-- File List Start -->
+## File List
+
+- `mcpTools.ts`
+- `promptUtils.ts`
+- `statusUtils.test.ts`
+- `statusUtils.ts`
+- `taskUtils.ts`
+- `utils.ts`
+
+<!-- File List End -->

--- a/frontend/src/providers/README.md
+++ b/frontend/src/providers/README.md
@@ -44,3 +44,11 @@ This directory contains React components that act as context providers, setting 
 - **Props**: `children: React.ReactNode`.
 - **Exports**: `ModalProvider` (Default React Functional Component).
 - **Usage**: This provider is intended to be used high up in the component tree. In this project, it is conveniently wrapped by `ChakraProviderWrapper`.
+
+<!-- File List Start -->
+## File List
+
+- `ChakraProviderWrapper.tsx`
+- `ModalProvider.tsx`
+
+<!-- File List End -->

--- a/frontend/src/services/README.md
+++ b/frontend/src/services/README.md
@@ -44,3 +44,9 @@ This is the primary file in this directory and serves as the central hub for all
 ### Usage:
 
 The Zustand stores (in `frontend/src/store/`) extensively use these API service functions to fetch and mutate data, with the `api.ts` module acting as the sole interface to the backend, ensuring consistency and separation of concerns.
+
+<!-- File List Start -->
+## File List
+
+
+<!-- File List End -->

--- a/frontend/src/store/README.md
+++ b/frontend/src/store/README.md
@@ -62,3 +62,14 @@ These stores centralize application state and logic for handling data related to
 - **Usage**: Provides a single, convenient import point for accessing any of the store hooks or types (e.g., `import { useTaskStore, useProjectStore } from '@/store';`).
 
 These stores are fundamental to the application's reactivity and data flow, providing a structured way to manage and interact with backend data on the client side.
+
+<!-- File List Start -->
+## File List
+
+- `agentStore.ts`
+- `baseStore.ts`
+- `index.ts`
+- `projectStore.ts`
+- `taskStore.ts`
+
+<!-- File List End -->

--- a/frontend/src/theme/README.md
+++ b/frontend/src/theme/README.md
@@ -6,3 +6,10 @@ Key files:
 
 *   `chakra-theme.ts`: Defines the custom theme object for Chakra UI, including color palettes, typography, component styles, and semantic tokens.
 *   `__tests__/`: Contains unit tests for the theme configuration. 
+
+<!-- File List Start -->
+## File List
+
+- `chakra-theme.ts`
+
+<!-- File List End -->

--- a/frontend/src/tokens/README.md
+++ b/frontend/src/tokens/README.md
@@ -16,3 +16,19 @@ Key files:
 *   `blur.ts`: Defines blur values.
 *   `index.ts`: Barrel file re-exporting all tokens.
 *   `__tests__/`: Contains unit tests for the design tokens. 
+
+<!-- File List Start -->
+## File List
+
+- `blur.ts`
+- `breakpoints.ts`
+- `colors.ts`
+- `index.ts`
+- `opacity.ts`
+- `shadows.ts`
+- `sizing.ts`
+- `transitions.ts`
+- `typography.ts`
+- `zIndex.ts`
+
+<!-- File List End -->

--- a/frontend/src/types/README.md
+++ b/frontend/src/types/README.md
@@ -66,3 +66,19 @@ This directory centralizes all TypeScript type definitions, interfaces, enums, a
   - `TaskFilters`: Interface for task filtering criteria.
   - `TaskSortOptions`: Interface for task sorting options.
   - `TaskError`, `TaskResponse`, `TaskListResponse`: API-related types for tasks.
+
+<!-- File List Start -->
+## File List
+
+- `agent.ts`
+- `audit_log.ts`
+- `comment.ts`
+- `index.ts`
+- `mcp.ts`
+- `memory.ts`
+- `project.ts`
+- `rules.ts`
+- `task.ts`
+- `user.ts`
+
+<!-- File List End -->

--- a/frontend/src/utils/README.md
+++ b/frontend/src/utils/README.md
@@ -5,3 +5,9 @@ This directory is intended to store general-purpose utility functions that can b
 These might include functions for data formatting, validation, calculations, or other helper routines that don't fit neatly into other categories like `lib` (which might be more for core/shared business logic or type-safe utilities) or specific component/module logic.
 
 Currently, this directory is empty. As common, reusable utility functions are identified or developed, they can be placed here.
+
+<!-- File List Start -->
+## File List
+
+
+<!-- File List End -->

--- a/scripts/update_readmes.py
+++ b/scripts/update_readmes.py
@@ -1,0 +1,30 @@
+import os
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+START_MARK = "<!-- File List Start -->"
+END_MARK = "<!-- File List End -->"
+
+for dirpath, dirnames, filenames in os.walk(REPO_ROOT):
+    if "README.md" in filenames:
+        readme_path = Path(dirpath) / "README.md"
+        file_list = sorted(
+            f for f in filenames if f != "README.md"
+        )
+        lines = [START_MARK, "## File List", ""]
+        lines += [f"- `{name}`" for name in file_list]
+        lines += ["", END_MARK, ""]
+        new_block = "\n".join(lines)
+        text = readme_path.read_text()
+        if START_MARK in text and END_MARK in text:
+            start_idx = text.index(START_MARK)
+            end_idx = text.index(END_MARK) + len(END_MARK)
+            text = text[:start_idx] + new_block + text[end_idx:]
+        else:
+            if not text.endswith("\n"):
+                text += "\n"
+            text += "\n" + new_block
+        readme_path.write_text(text)
+
+print("README files updated.")


### PR DESCRIPTION
## Summary
- add a script to sync README contents with actual files
- update all README.md files with a generated file list

## Testing
- `pip install -r backend/requirements.txt`
- `pytest backend/tests` *(fails: ImportError: cannot import name 'datetime' from 'typing')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68408c154fc4832c92b05bbf1f67ab1c