### PR TITLE
Fix deletion in MemoryService

### DIFF
--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -35,6 +35,10 @@ class MemoryService:
         """Retrieve a MemoryEntity by ID."""
         return get_memory_entity(self.db, entity_id)
 
+    def get_memory_entity_by_id(self, entity_id: int) -> Optional[models.MemoryEntity]:
+        """Alias for get_entity for backwards compatibility."""
+        return self.get_entity(entity_id)
+
     def get_entities(self, skip: int = 0, limit: int = 100) -> List[models.MemoryEntity]:
         """Retrieve multiple MemoryEntities."""
         return get_memory_entities(self.db, skip, limit)
@@ -133,7 +137,7 @@ class MemoryService:
 
     def delete_memory_entity(self, entity_id: int) -> Optional[models.MemoryEntity]:
         """Deletes a memory entity and its associated observations and relations."""
-        db_entity = self.get_memory_entity_by_id(db_entity)
+        db_entity = self.get_entity(entity_id)
         if db_entity:
             self.db.delete(db_entity)
             self.db.commit()

--- a/backend/tests/test_memory_service.py
+++ b/backend/tests/test_memory_service.py
@@ -1,0 +1,17 @@
+import pytest
+from unittest.mock import MagicMock
+
+from backend.services.memory_service import MemoryService
+
+
+def test_delete_memory_entity_no_error():
+    session = MagicMock()
+    service = MemoryService(session)
+    dummy_entity = MagicMock()
+    service.get_entity = MagicMock(return_value=dummy_entity)
+
+    result = service.delete_memory_entity(1)
+
+    service.db.delete.assert_called_once_with(dummy_entity)
+    service.db.commit.assert_called_once()
+    assert result == dummy_entity


### PR DESCRIPTION
## Summary
- fix incorrect call in `delete_memory_entity`
- add helper `get_memory_entity_by_id`
- add unit test for deletion logic

## Testing
- `pytest backend/tests/test_memory_service.py -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_6840885a582c832caaa6cf1cb6ef1bad