### PR TITLE
Fix README Windows dev tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ npm run dev
 The frontend application will be available at `http://localhost:3000`.
 
 **Windows Development Tip:**
-A `dev_launcher.bat` script is available in the project root. This batch file attempts to clear ports 8080 (for backend) and 3000 (for frontend) and then launches the backend (`npm run dev:backend`) and frontend (`npm run dev:frontend`) development servers in separate terminal windows. You can run it by double-clicking or executing `dev_launcher.bat` in your terminal from the project root.
+A `dev_launcher.bat` script is available in the project root. This batch file attempts to clear ports 8000 (for backend) and 3000 (for frontend) and then starts the backend server with `uvicorn` and the frontend with `npm run dev` in separate command windows. You can run it by double-clicking or executing `dev_launcher.bat` in your terminal from the project root.
 
 ## How It Works
 


### PR DESCRIPTION
## Summary
- fix Windows dev launcher port to 8000
- clarify dev_launcher.bat instructions

## Testing
- `pip install -r backend/requirements.txt`
- `pytest backend/tests/test_simple.py -q` *(fails: ImportError: cannot import name 'datetime')*

------
https://chatgpt.com/codex/tasks/task_e_68408855bdc0832c8b97477a9d4f69d2