### PR TITLE
Fix backend test imports and add frontend matchMedia stub

### DIFF
--- a/backend/crud/users.py
+++ b/backend/crud/users.py
@@ -85,12 +85,16 @@ async def update_user(db: AsyncSession, user_id: str, user_update: UserUpdate) -
                         result_existing_email = await db.execute(select(models.User).filter(models.User.email == update_data["email"]))
                         existing_user_with_email = result_existing_email.scalar_one_or_none()
                         if existing_user_with_email and existing_user_with_email.id != user_id:
-                            raise ValueError(f"Email '{update_data["email"]}' already exists for another user")  # Check for duplicate username if username is being updated
+                            raise ValueError(
+                                f"Email '{update_data['email']}' already exists for another user"
+                            )
                         if "username" in update_data and update_data["username"] is not None and update_data["username"] != db_user.username:
                             result_existing_username = await db.execute(select(models.User).filter(models.User.username == update_data["username"]))
                             existing_user_with_username = result_existing_username.scalar_one_or_none()
                             if existing_user_with_username and existing_user_with_username.id != user_id:
-                                raise ValueError(f"Username '{update_data["username"]}' already exists for another user")
+                                raise ValueError(
+                                    f"Username '{update_data['username']}' already exists for another user"
+                                )
 
                     # Apply updates for all fields in update_data
                     for key, value in update_data.items():

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,4 +14,5 @@ pytest
 pytest-asyncio
 pytest-cov
 httpx
-aiosqlite 
+aiosqlite
+aiohttp

--- a/backend/schemas/user.py
+++ b/backend/schemas/user.py
@@ -5,7 +5,8 @@
 # Timestamp: <timestamp>
 
 from pydantic import BaseModel, ConfigDict, Field
-from typing import Optional, List, datetime
+from typing import Optional, List
+from datetime import datetime
 
 # Import UserRoleEnum
 from ..enums import UserRoleEnum

--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -77,3 +77,18 @@ global.ResizeObserver = vi.fn().mockImplementation(() => ({
   unobserve: vi.fn(),
   disconnect: vi.fn(),
 }))
+
+// Mock matchMedia used by Chakra UI
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+})


### PR DESCRIPTION
## Summary
- fix invalid datetime import in `User` schema
- correct f-string quoting in `users` CRUD module
- add `aiohttp` dependency for integration tests
- stub `window.matchMedia` in frontend test setup

## Testing
- `pytest backend/tests -q`
- `npm run test:run` *(fails: Element type invalid, matchMedia issues)*

------
https://chatgpt.com/codex/tasks/task_e_68408540548c832ca510000ea1d1c6ff