### PR TITLE
Align frontend API configuration

### DIFF
--- a/frontend/.env.local
+++ b/frontend/.env.local
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000

--- a/frontend/src/services/api/config.ts
+++ b/frontend/src/services/api/config.ts
@@ -2,7 +2,7 @@
  * Central API configuration for consistent base URLs across all API services
  */
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8001";
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000";
 const API_VERSION = "/api"; // Backend uses /api, not /api/v1
 
 export const API_CONFIG = {


### PR DESCRIPTION
## Summary
- point API base URL defaults to localhost:8000
- add `.env.local` with the same setting

## Testing
- `node validate_frontend.js`
- `python validate_alignment.py` *(fails: cannot connect to backend)*

------
https://chatgpt.com/codex/tasks/task_e_6840948c9ab8832c9b29fcb80cc47424