### PR TITLE
Add mermaid diagrams to docs

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -20,7 +20,16 @@ This directory stores configurations and templates specific to the project's Git
         -   Potentially build the applications.
         -   The badge at the top of the main `README.md` ( [![CI - Main](...ci.yml/badge.svg...)](...ci.yml) ) usually reflects the status of this CI workflow.
 
-These configurations are standard for GitHub-hosted projects and aim to improve collaboration, code quality, and automation. 
+These configurations are standard for GitHub-hosted projects and aim to improve collaboration, code quality, and automation.
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/README.md
+++ b/README.md
@@ -293,6 +293,14 @@ Key files and directories:
 *   `docs/`: Placeholder for additional documentation (currently empty).
 *   `.cursor/`: Contains MCP rules and agent configurations.
 
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/backend/README.md
+++ b/backend/README.md
@@ -196,6 +196,15 @@ Key files and directories:
 *   `requirements.txt`: Python project dependencies.
 *   `auth.py`: Authentication related code.
 
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
+
 <!-- File List Start -->
 ## File List
 

--- a/backend/alembic/README.md
+++ b/backend/alembic/README.md
@@ -27,6 +27,15 @@ Key files and directories:
 
 -   **`
 
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
+
 <!-- File List Start -->
 ## File List
 

--- a/backend/config/README.md
+++ b/backend/config/README.md
@@ -7,7 +7,16 @@ Key files:
 *   `app_config.py`: Contains the main application settings loaded from environment variables using Pydantic Settings.
 *   `router_config.py`: Configures API routers and their dependencies.
 *   `logging_config.py`: Sets up logging for the application.
-*   `__init__.py`: Initializes the config package. 
+*   `__init__.py`: Initializes the config package.
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/backend/crud/README.md
+++ b/backend/crud/README.md
@@ -17,7 +17,16 @@ Key CRUD and validation files include:
 *   `project_members.py`: CRUD operations for project members.
 *   `project_templates.py`: CRUD operations for project templates.
 *   `project_file_associations.py`: CRUD operations for project file associations.
-*   `task_validation.py`, `task_dependency_validation.py`, `task_file_association_validation.py`, `project_validation.py`, `project_member_validation.py`, `comment_validation.py`, `agent_validation.py`, `project_file_association_validation.py`, `user_validation.py`: Files containing validation logic used by CRUD functions. 
+*   `task_validation.py`, `task_dependency_validation.py`, `task_file_association_validation.py`, `project_validation.py`, `project_member_validation.py`, `comment_validation.py`, `agent_validation.py`, `project_file_association_validation.py`, `user_validation.py`: Files containing validation logic used by CRUD functions.
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/backend/crud/utils/README.md
+++ b/backend/crud/utils/README.md
@@ -8,7 +8,16 @@ Key files:
 *   `task_file_utils.py`: Utility functions for task file associations.
 *   `dependency_utils.py`: Utility functions for task dependencies.
 *   `file_association_utils.py`: Utility functions for file associations (likely related to the Memory service).
-*   `__init__.py`: Initializes the utils package. 
+*   `__init__.py`: Initializes the utils package.
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/backend/mcp_tools/README.md
+++ b/backend/mcp_tools/README.md
@@ -7,7 +7,16 @@ Key files:
 *   `task_tools.py`: MCP-specific tools for interacting with tasks.
 *   `memory_tools.py`: MCP-specific tools for interacting with the Memory Service.
 *   `project_tools.py`: MCP-specific tools for interacting with projects.
-*   `__init__.py`: Initializes the mcp_tools package. 
+*   `__init__.py`: Initializes the mcp_tools package.
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/backend/middleware/README.md
+++ b/backend/middleware/README.md
@@ -6,7 +6,16 @@ Key files:
 
 *   `request_middleware.py`: Contains middleware for processing incoming requests.
 *   `error_handlers.py`: Defines custom exception handlers for the application.
-*   `__init__.py`: Initializes the middleware package. 
+*   `__init__.py`: Initializes the middleware package.
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/backend/models/README.md
+++ b/backend/models/README.md
@@ -15,7 +15,16 @@ Key models include:
 *   `AuditLog`: Records audit trails of actions.
 *   `AgentHandoffCriteria`, `AgentVerificationRequirement`, `AgentForbiddenAction`, `AgentErrorProtocol`, `AgentCapability`, `AgentRole`: Models related to agent capabilities and protocols.
 *   `UniversalMandate`: Represents system-wide mandates.
-*   `Workflow`, `ProjectMember`, `ProjectTemplate`, `TaskStatus`, `TaskRelations`, `Core`, `Base`, `Types`: Other supporting models and base classes. 
+*   `Workflow`, `ProjectMember`, `ProjectTemplate`, `TaskStatus`, `TaskRelations`, `Core`, `Base`, `Types`: Other supporting models and base classes.
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/backend/routers/README.md
+++ b/backend/routers/README.md
@@ -38,7 +38,16 @@ This directory contains the FastAPI routers that define the API endpoints for th
     *   `auth/`: Authentication and token generation.
     *   `core/`: Core user management operations.
 
-Interactive API documentation is available at `/docs` and `/redoc` when the backend server is running. 
+Interactive API documentation is available at `/docs` and `/redoc` when the backend server is running.
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/backend/services/README.md
+++ b/backend/services/README.md
@@ -18,7 +18,16 @@ Key service files include:
 *   `project_template_service.py`: Contains logic for managing project templates.
 *   `project_file_association_service.py`: Contains logic for managing associations between projects and files/Memory entities.
 *   `exceptions.py`: Defines custom exceptions used within the services.
-*   `utils.py`: Contains utility functions used across services. 
+*   `utils.py`: Contains utility functions used across services.
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/backend/tests/README.md
+++ b/backend/tests/README.md
@@ -45,6 +45,15 @@
 ## Continuous Integration
 Tests are automatically run on push and pull requests via GitHub Actions.
 
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
+
 <!-- File List Start -->
 ## File List
 

--- a/backend/tests/integration/README.md
+++ b/backend/tests/integration/README.md
@@ -4,7 +4,16 @@ This directory contains integration tests for the backend application. Integrati
 
 Key files:
 
-*   `test_project_task_flow.py`: Tests the integrated flow of project and task management operations. 
+*   `test_project_task_flow.py`: Tests the integrated flow of project and task management operations.
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/backend/tests/unit/README.md
+++ b/backend/tests/unit/README.md
@@ -7,7 +7,16 @@ Subdirectories contain unit tests for different backend layers:
 *   `crud/`: Unit tests for database CRUD functions.
 *   `database/`: Unit tests for database connection and setup.
 *   `routes/`: Unit tests for API router endpoint logic.
-*   `services/`: Unit tests for business logic services. 
+*   `services/`: Unit tests for business logic services.
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/backend/tests/unit/crud/README.md
+++ b/backend/tests/unit/crud/README.md
@@ -4,7 +4,16 @@ This directory contains unit tests specifically for the database CRUD functions 
 
 Key files:
 
-*   `test_projects.py`: Unit tests for project CRUD functions. 
+*   `test_projects.py`: Unit tests for project CRUD functions.
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/backend/tests/unit/database/README.md
+++ b/backend/tests/unit/database/README.md
@@ -2,7 +2,16 @@
 
 This directory is intended to contain unit tests for the database connection and session management logic defined in `backend/database.py`. These tests would verify the correct setup and teardown of database connections and sessions in a controlled environment.
 
-*Note: This directory is currently empty, indicating that database unit tests have not yet been implemented.* 
+*Note: This directory is currently empty, indicating that database unit tests have not yet been implemented.*
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/backend/tests/unit/routes/README.md
+++ b/backend/tests/unit/routes/README.md
@@ -4,7 +4,16 @@ This directory contains unit tests for the API router endpoint logic in the back
 
 Key files:
 
-*   `test_project_routes.py`: Unit tests for project-related API routes. 
+*   `test_project_routes.py`: Unit tests for project-related API routes.
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/backend/tests/unit/services/README.md
+++ b/backend/tests/unit/services/README.md
@@ -4,7 +4,16 @@ This directory contains unit tests for the business logic service layer in the b
 
 Key files:
 
-*   `test_project_service.py`: Unit tests for project-related service logic. 
+*   `test_project_service.py`: Unit tests for project-related service logic.
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -108,6 +108,15 @@ Key files and directories:
 *   `tests-e2e/`: End-to-end tests using Playwright.
 *   `vitest.config.*`: Configuration files for Vitest unit/integration tests.
 
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
+
 <!-- File List Start -->
 ## File List
 

--- a/frontend/public/README.md
+++ b/frontend/public/README.md
@@ -9,7 +9,16 @@ Key files and directories:
 *   `*.svg`: Various SVG icon files.
 *   `api-test.html`: An HTML file likely used for API testing or demonstration purposes.
 *   `next.svg`, `vercel.svg`: Default Next.js and Vercel logos.
-*   Other static files required for the application. 
+*   Other static files required for the application.
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/frontend/public/assets/README.md
+++ b/frontend/public/assets/README.md
@@ -4,7 +4,16 @@ This directory serves as a container for various static assets used by the front
 
 Key subdirectories:
 
-*   `images/`: Contains image files used throughout the application. 
+*   `images/`: Contains image files used throughout the application.
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/frontend/public/assets/images/README.md
+++ b/frontend/public/assets/images/README.md
@@ -5,7 +5,16 @@ This directory contains image files used by the frontend application. These imag
 Key image files:
 
 *   `logo_light.png`, `logo_dark.png`: Logo images for light and dark themes.
-*   `icon_light.png`, `icon_dark.png`: Icon images for light and dark themes. 
+*   `icon_light.png`, `icon_dark.png`: Icon images for light and dark themes.
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/frontend/src/README.md
+++ b/frontend/src/README.md
@@ -115,6 +115,15 @@ The `src/` directory is further organized into the following subdirectories:
 - `types/`: TypeScript type definitions and interfaces used across the application.
 - `__tests__/`: Contains test files, likely for unit or integration testing of the components and logic within the `src/` directory.
 
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
+
 <!-- File List Start -->
 ## File List
 

--- a/frontend/src/__tests__/README.md
+++ b/frontend/src/__tests__/README.md
@@ -9,7 +9,16 @@ Key files and directories:
 *   `factories/`: Test data factories for generating consistent test data.
 *   `mocks/`: Mock implementations for dependencies (e.g., API services).
 *   `utils/`: Test utility functions.
-*   `.gitkeep`: Placeholder file to ensure the directory is included in Git. 
+*   `.gitkeep`: Placeholder file to ensure the directory is included in Git.
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/frontend/src/__tests__/factories/README.md
+++ b/frontend/src/__tests__/factories/README.md
@@ -8,7 +8,16 @@ Key files:
 *   `user.factory.ts`: Factory for generating user data.
 *   `project.factory.ts`: Factory for generating project data.
 *   `task.factory.ts`: Factory for generating task data.
-*   `index.ts`: Barrel file re-exporting the factories. 
+*   `index.ts`: Barrel file re-exporting the factories.
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/frontend/src/__tests__/integration/README.md
+++ b/frontend/src/__tests__/integration/README.md
@@ -4,7 +4,16 @@ This directory contains integration tests for the frontend application. These te
 
 Key files:
 
-*   `task-management.test.tsx`: Integration tests covering task management flows. 
+*   `task-management.test.tsx`: Integration tests covering task management flows.
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/frontend/src/__tests__/mocks/README.md
+++ b/frontend/src/__tests__/mocks/README.md
@@ -5,7 +5,16 @@ This directory contains mock implementations and handlers used for testing purpo
 Key files:
 
 *   `handlers.ts`: Defines request handlers for mocked API endpoints.
-*   `server.ts`: Sets up and configures the mock server (likely using libraries like MSW - Mock Service Worker). 
+*   `server.ts`: Sets up and configures the mock server (likely using libraries like MSW - Mock Service Worker).
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/frontend/src/__tests__/utils/README.md
+++ b/frontend/src/__tests__/utils/README.md
@@ -4,7 +4,16 @@ This directory contains utility functions and helpers specifically designed to s
 
 Key files:
 
-*   `test-utils.tsx`: Contains custom rendering utilities (likely re-exporting or extending `@testing-library/react` methods). 
+*   `test-utils.tsx`: Contains custom rendering utilities (likely re-exporting or extending `@testing-library/react` methods).
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/frontend/src/app/README.md
+++ b/frontend/src/app/README.md
@@ -118,6 +118,15 @@ Key files and directories:
 *   `projects/[projectId]/`: Directory containing the page for individual project details.
 *   `mcp-dev-tools/`: Directory likely related to developer tools/features.
 
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
+
 <!-- File List Start -->
 ## File List
 

--- a/frontend/src/app/mcp-dev-tools/README.md
+++ b/frontend/src/app/mcp-dev-tools/README.md
@@ -12,6 +12,15 @@ This directory defines the Next.js route for the MCP Developer Tools page, acces
 
 The `MCPDevTools` component itself (located in `frontend/src/components/`) is responsible for the actual UI and features of the developer tools panel.
 
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
+
 <!-- File List Start -->
 ## File List
 

--- a/frontend/src/app/projects/[projectId]/README.md
+++ b/frontend/src/app/projects/[projectId]/README.md
@@ -4,7 +4,16 @@ This directory contains the page component for displaying the details of a speci
 
 Key file:
 
-*   `page.tsx`: The page component responsible for fetching project and task data, displaying project information, and rendering the list of tasks for that project. It includes functionality for interacting with tasks (e.g., viewing details, marking complete, archiving, managing dependencies and file associations). 
+*   `page.tsx`: The page component responsible for fetching project and task data, displaying project information, and rendering the list of tasks for that project. It includes functionality for interacting with tasks (e.g., viewing details, marking complete, archiving, managing dependencies and file associations).
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/frontend/src/components/README.md
+++ b/frontend/src/components/README.md
@@ -146,6 +146,15 @@ Key files and directories:
 *   `views/`: Components defining larger view structures or layouts.
 *   Individual component files like `TaskList.tsx`, `ProjectList.tsx`, `AgentList.tsx`, `AddTaskForm.tsx`, etc.
 
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
+
 <!-- File List Start -->
 ## File List
 

--- a/frontend/src/components/ThemeToggleButton/README.md
+++ b/frontend/src/components/ThemeToggleButton/README.md
@@ -4,7 +4,16 @@ This directory contains the reusable component for toggling between light and da
 
 Key file:
 
-*   `ThemeToggleButton.tsx`: A button component that uses the application's theme context to switch between defined color modes. 
+*   `ThemeToggleButton.tsx`: A button component that uses the application's theme context to switch between defined color modes.
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/frontend/src/components/agent/README.md
+++ b/frontend/src/components/agent/README.md
@@ -9,7 +9,16 @@ Key files:
 *   `AgentListHeader.tsx`: Component for the header section of the agent list, potentially including search/filter or add agent buttons.
 *   `AddAgentModal.tsx`: Modal for adding a new agent.
 *   `EditAgentModal.tsx`: Modal for editing an existing agent.
-*   `CliPromptModal.tsx`: Modal related to command-line interface prompts, potentially used in agent interactions. 
+*   `CliPromptModal.tsx`: Modal related to command-line interface prompts, potentially used in agent interactions.
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/frontend/src/components/audit_logs/README.md
+++ b/frontend/src/components/audit_logs/README.md
@@ -4,7 +4,16 @@ This directory contains React components for displaying audit logs related to sp
 
 Key files:
 
-*   `AuditLogListForEntity.tsx`: Component that displays a list of audit log entries filtered by a specific entity (e.g., task ID, project ID). 
+*   `AuditLogListForEntity.tsx`: Component that displays a list of audit log entries filtered by a specific entity (e.g., task ID, project ID).
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/frontend/src/components/common/README.md
+++ b/frontend/src/components/common/README.md
@@ -107,6 +107,15 @@ Key files:
 *   `FilterPanel.tsx`: Panel containing filter controls (likely used within `FilterSidebar`).
 *   `AppIcon.tsx`: Component for displaying application icons.
 
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
+
 <!-- File List Start -->
 ## File List
 

--- a/frontend/src/components/dashboard/README.md
+++ b/frontend/src/components/dashboard/README.md
@@ -80,6 +80,15 @@ Key files:
 *   `CreateProjectModal.tsx`: Modal for creating new projects.
 *   `EditProjectModal.tsx`: Modal for editing project details.
 
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
+
 <!-- File List Start -->
 ## File List
 

--- a/frontend/src/components/forms/README.md
+++ b/frontend/src/components/forms/README.md
@@ -40,6 +40,15 @@ Key files:
 *   `AddAgentForm.tsx`: Form for adding new agents.
 *   `AddTaskForm.tsx`: Form for adding new tasks (likely a specific implementation using `TaskForm.tsx`).
 
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
+
 <!-- File List Start -->
 ## File List
 

--- a/frontend/src/components/layout/README.md
+++ b/frontend/src/components/layout/README.md
@@ -5,7 +5,16 @@ This directory contains components responsible for the overall page layout and s
 Key files:
 
 *   `Sidebar.tsx`: Implements the main application sidebar, containing navigation links, action buttons, and other global controls.
-*   `MainContent.tsx`: Defines the main content area where different views (dashboard, task list, project list, etc.) are rendered. 
+*   `MainContent.tsx`: Defines the main content area where different views (dashboard, task list, project list, etc.) are rendered.
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/frontend/src/components/modals/README.md
+++ b/frontend/src/components/modals/README.md
@@ -50,6 +50,15 @@ Key files:
 *   `DevToolsDrawer.tsx`: Likely a modal or drawer component for developer tools.
 *   `README.md`: This file.
 
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
+
 <!-- File List Start -->
 ## File List
 

--- a/frontend/src/components/project/README.md
+++ b/frontend/src/components/project/README.md
@@ -7,7 +7,16 @@ Key files:
 *   `ProjectList.tsx`: Component for displaying a list of projects.
 *   `ProjectDetail.tsx`: Component for displaying the detailed information of a single project.
 *   `ProjectFiles.tsx`: Component for displaying and managing files associated with a project.
-*   `ProjectMembers.tsx`: Component for displaying and managing members associated with a project. 
+*   `ProjectMembers.tsx`: Component for displaying and managing members associated with a project.
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/frontend/src/components/task/README.md
+++ b/frontend/src/components/task/README.md
@@ -133,6 +133,15 @@ Key files:
 *   `TaskItem.styles.ts`: Contains styling definitions for task components.
 *   `README.md`: This file.
 
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
+
 <!-- File List Start -->
 ## File List
 

--- a/frontend/src/components/views/README.md
+++ b/frontend/src/components/views/README.md
@@ -38,6 +38,15 @@ Key files:
 
 These view components allow users to switch between different perspectives when examining their data, catering to various workflow preferences.
 
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
+
 <!-- File List Start -->
 ## File List
 

--- a/frontend/src/contexts/README.md
+++ b/frontend/src/contexts/README.md
@@ -16,6 +16,15 @@ Key files:
 
 ### `ProjectContext.tsx`
 
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
+
 <!-- File List Start -->
 ## File List
 

--- a/frontend/src/lib/README.md
+++ b/frontend/src/lib/README.md
@@ -84,6 +84,15 @@ Defines the structure and provides a list of available MCP (Multi-Context Person
       - Planning: `generate_planning_prompt`
     - Each tool definition specifies its HTTP method, path, parameters (including their type, whether they are required, and if they are path, query, or body parameters), and a brief description.
 
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
+
 <!-- File List Start -->
 ## File List
 

--- a/frontend/src/providers/README.md
+++ b/frontend/src/providers/README.md
@@ -45,6 +45,15 @@ This directory contains React components that act as context providers, setting 
 - **Exports**: `ModalProvider` (Default React Functional Component).
 - **Usage**: This provider is intended to be used high up in the component tree. In this project, it is conveniently wrapped by `ChakraProviderWrapper`.
 
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
+
 <!-- File List Start -->
 ## File List
 

--- a/frontend/src/services/README.md
+++ b/frontend/src/services/README.md
@@ -45,6 +45,15 @@ This is the primary file in this directory and serves as the central hub for all
 
 The Zustand stores (in `frontend/src/store/`) extensively use these API service functions to fetch and mutate data, with the `api.ts` module acting as the sole interface to the backend, ensuring consistency and separation of concerns.
 
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
+
 <!-- File List Start -->
 ## File List
 

--- a/frontend/src/store/README.md
+++ b/frontend/src/store/README.md
@@ -63,6 +63,15 @@ These stores centralize application state and logic for handling data related to
 
 These stores are fundamental to the application's reactivity and data flow, providing a structured way to manage and interact with backend data on the client side.
 
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
+
 <!-- File List Start -->
 ## File List
 

--- a/frontend/src/theme/README.md
+++ b/frontend/src/theme/README.md
@@ -5,7 +5,16 @@ This directory contains the configuration for the application's visual theme, pr
 Key files:
 
 *   `chakra-theme.ts`: Defines the custom theme object for Chakra UI, including color palettes, typography, component styles, and semantic tokens.
-*   `__tests__/`: Contains unit tests for the theme configuration. 
+*   `__tests__/`: Contains unit tests for the theme configuration.
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/frontend/src/tokens/README.md
+++ b/frontend/src/tokens/README.md
@@ -15,7 +15,16 @@ Key files:
 *   `opacity.ts`: Defines opacity values.
 *   `blur.ts`: Defines blur values.
 *   `index.ts`: Barrel file re-exporting all tokens.
-*   `__tests__/`: Contains unit tests for the design tokens. 
+*   `__tests__/`: Contains unit tests for the design tokens.
+
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
 
 <!-- File List Start -->
 ## File List

--- a/frontend/src/types/README.md
+++ b/frontend/src/types/README.md
@@ -67,6 +67,15 @@ This directory centralizes all TypeScript type definitions, interfaces, enums, a
   - `TaskSortOptions`: Interface for task sorting options.
   - `TaskError`, `TaskResponse`, `TaskListResponse`: API-related types for tasks.
 
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
+
 <!-- File List Start -->
 ## File List
 

--- a/frontend/src/utils/README.md
+++ b/frontend/src/utils/README.md
@@ -6,6 +6,15 @@ These might include functions for data formatting, validation, calculations, or 
 
 Currently, this directory is empty. As common, reusable utility functions are identified or developed, they can be placed here.
 
+## Architecture Diagram
+```mermaid
+graph TD
+    user((User)) -->|interacts with| frontend(Frontend)
+    frontend -->|API requests| backend(Backend)
+    backend -->|persists| database[(Database)]
+    backend -->|integrates| mcp(MCP Server)
+```
+
 <!-- File List Start -->
 ## File List
 


### PR DESCRIPTION
## Summary
- add an Architecture Diagram section to every README

## Testing
- `npm test` *(fails: Missing script)*
- `pytest` *(fails: ImportError for `requests`)*

------
https://chatgpt.com/codex/tasks/task_e_6840946dd134832c8c03fe730cb25d12