### PR TITLE
Align validation utilities with backend

### DIFF
--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -22,8 +22,8 @@ from backend.crud.users import (
     update_user,
     delete_user,
     authenticate_user as crud_authenticate_user,
-    username_exists
-)  # Import configuration settings
+)
+from backend.crud.user_validation import username_exists
 from backend.config import SECRET_KEY, ALGORITHM, ACCESS_TOKEN_EXPIRE_MINUTES
 
 from sqlalchemy.ext.asyncio import AsyncSession  # Import AsyncSession


### PR DESCRIPTION
## Summary
- update validate_alignment script to automatically start the backend
- login using default credentials and include auth header for checks
- adjust API routes to use `/api/v1` prefix
- clean up stop logic
- fix UserService import for `username_exists`

## Testing
- `node validate_frontend.js`
- `pytest -q`
- `python validate_alignment.py` *(fails to retrieve auth token)*

------
https://chatgpt.com/codex/tasks/task_e_68409449f8ec832ca1771e1fc2525ec9