### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt
+          pip install mypy
+      - name: Lint backend
+        run: |
+          cd backend
+          flake8 .
+      - name: Type check backend
+        run: |
+          cd backend
+          mypy .
+      - name: Test backend
+        run: |
+          cd backend
+          pytest -v
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install frontend dependencies
+        run: |
+          cd frontend
+          npm ci
+      - name: Lint frontend
+        run: |
+          cd frontend
+          npm run lint
+      - name: Type check frontend
+        run: |
+          cd frontend
+          npm run type-check
+      - name: Test frontend
+        run: |
+          cd frontend
+          npm run test:ci
+      - name: Build frontend
+        run: |
+          cd frontend
+          npm run build
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for backend and frontend

## Testing
- `flake8 .` *(fails: line too long etc.)*
- `pytest -q`
- `mypy .` *(fails: versions.bak-20250524220718 is not a valid Python package name)*
- `npm ci` *(fails: lockfile mismatch)*
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*
- `npm run type-check` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68409b03be5c832ca43fb9a561b855ba