### PR TITLE
Fix dev launcher ports and log MCP info

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -20,6 +20,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
 from sqlalchemy import text
 from typing import Dict, Any
+import json
 
 # Explicitly import schema models to ensure they are loaded early for Pydantic to resolve forward references
 from .schemas import (
@@ -191,6 +192,16 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.error(f"Failed to initialize database: {e}")
         raise
+
+    # Display MCP server info for developers
+    server_addr = os.getenv("MCP_SERVER_ADDRESS", "http://localhost:8000")
+    cursor_info = {
+        "mcp_server": server_addr,
+        "openapi_url": f"{server_addr}/openapi.json",
+        "tools_url": f"{server_addr}/mcp-docs"
+    }
+    logger.info(f"MCP server running at {server_addr}")
+    logger.info(f"Cursor IDE integration JSON: {json.dumps(cursor_info)}")
 
     yield
     # Log routes and MCP tools after startup

--- a/dev_launcher.js
+++ b/dev_launcher.js
@@ -71,7 +71,7 @@ async function main() {
         ? path.join(projectRoot, 'backend', '.venv', 'Scripts', 'python.exe')
         : path.join(projectRoot, 'backend', '.venv', 'bin', 'python');
     
-    const backendArgs = ['-m', 'uvicorn', 'backend.main:app', '--host', '0.0.0.0', '--port', '8080', '--reload'];
+    const backendArgs = ['-m', 'uvicorn', 'backend.main:app', '--host', '0.0.0.0', '--port', '8000', '--reload'];
     
     const backendProcess = spawn(backendPath, backendArgs, {
         cwd: projectRoot,

--- a/dev_launcher.ps1
+++ b/dev_launcher.ps1
@@ -24,8 +24,8 @@ function Clear-Port {
 }
 
 # Clear ports
-Write-Host "Checking and clearing ports 7500 and 3000..." -ForegroundColor Yellow
-Clear-Port -Port 7500
+Write-Host "Checking and clearing ports 8000 and 3000..." -ForegroundColor Yellow
+Clear-Port -Port 8000
 Clear-Port -Port 3000
 Write-Host ""
 
@@ -35,10 +35,10 @@ Set-Location $projectRoot
 
 # Start Backend Server
 Write-Host "Starting Backend Server (Python/FastAPI)..." -ForegroundColor Yellow
-Write-Host "Backend will be available at: http://localhost:7500" -ForegroundColor Cyan
-Write-Host "API Documentation at: http://localhost:7500/docs" -ForegroundColor Cyan
+Write-Host "Backend will be available at: http://localhost:8000" -ForegroundColor Cyan
+Write-Host "API Documentation at: http://localhost:8000/docs" -ForegroundColor Cyan
 
-$backendCommand = "backend\.venv\Scripts\python.exe -m uvicorn backend.main:app --host 0.0.0.0 --port 7500 --reload"
+$backendCommand = "backend\.venv\Scripts\python.exe -m uvicorn backend.main:app --host 0.0.0.0 --port 8000 --reload"
 Start-Process -FilePath "pwsh.exe" -ArgumentList "-NoExit", "-Command", $backendCommand -WindowStyle Normal
 
 # Wait for backend to start
@@ -59,9 +59,9 @@ Write-Host "========================================" -ForegroundColor Cyan
 Write-Host "          Servers Starting..." -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
-Write-Host "Backend:  http://localhost:7500" -ForegroundColor Green
-Write-Host "Frontend: http://localhost:3000" -ForegroundColor Green  
-Write-Host "API Docs: http://localhost:7500/docs" -ForegroundColor Green
+Write-Host "Backend:  http://localhost:8000" -ForegroundColor Green
+Write-Host "Frontend: http://localhost:3000" -ForegroundColor Green
+Write-Host "API Docs: http://localhost:8000/docs" -ForegroundColor Green
 Write-Host ""
 Write-Host "Both servers are launching in separate windows." -ForegroundColor White
 Write-Host "Press any key to exit launcher..." -ForegroundColor Gray


### PR DESCRIPTION
## Summary
- run backend on port 8000 in dev_launcher.js and dev_launcher.ps1
- log MCP server address and integration JSON at backend startup

## Testing
- `python -m pytest -q`
- `npm test` *(fails: Cannot read properties of undefined (reading 'matches'))*

------
https://chatgpt.com/codex/tasks/task_e_684099823ffc832caa253030923a8171