### PR TITLE
Fix backend lint errors

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -4,19 +4,18 @@ sys.path.insert(0, os.path.abspath(
     os.path.join(os.path.dirname(__file__), '..', '..')))
 
 # ADD THIS LINE TO EXPLICITLY IMPORT MODELS
-from backend.models import (
+from backend.models import (  # noqa: F401,E402
     Project,
     Agent,
     Task,
     MemoryEntity,
     MemoryObservation,
-    MemoryRelation
+    MemoryRelation,
 )
-from backend.models import Base  # Adjusted import
-from alembic import context
-from sqlalchemy import pool
-from sqlalchemy import engine_from_config
-from logging.config import fileConfig
+from backend.models import Base  # noqa: F401,E402
+from alembic import context  # noqa: E402
+# from sqlalchemy import engine_from_config  # noqa: F401,E402
+from logging.config import fileConfig  # noqa: E402
 
 # this is the Alembic Config object,
 # which provides access to the values within the .ini file in use.

--- a/backend/tests/test_memory_service.py
+++ b/backend/tests/test_memory_service.py
@@ -1,4 +1,3 @@
-import pytest
 from unittest.mock import MagicMock
 
 from backend.services.memory_service import MemoryService

--- a/backend/tests/test_simple.py
+++ b/backend/tests/test_simple.py
@@ -73,7 +73,6 @@ async def test_async_function():
     assert result == 8
 
 
-
 class TestClassExample:
     """Test class with multiple test methods."""
 


### PR DESCRIPTION
## Summary
- ignore Alembic imports to satisfy flake8
- clean unused import in memory service test
- remove excess blank line in test_simple

## Testing
- `pytest -q`
- `flake8 alembic/env.py tests/test_memory_service.py tests/test_simple.py`


------
https://chatgpt.com/codex/tasks/task_e_6840ac8a1130832c9d638ed5597975c4