### PR TITLE
Expose all FastAPI endpoints as MCP tools

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -337,7 +337,6 @@ if FastApiMCP is not None:
         app,
         name="Task Manager MCP",
         description="MCP server for task manager",
-        include_tags=["mcp-tools"],
     )
     mcp.mount()
     app.state.mcp_instance = mcp


### PR DESCRIPTION
## Summary
- expose all API routes as tools by removing `include_tags` filter

## Testing
- `python -m flake8`
- `pytest -q`
- `npm test` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6840ac3c0774832c8477124915202173