### PR TITLE
refactor: centralize task category helper

### DIFF
--- a/frontend/src/hooks/useFilteredTasks.ts
+++ b/frontend/src/hooks/useFilteredTasks.ts
@@ -75,24 +75,3 @@ export const useFilteredTasks = (
   }, [tasks, filters]);
 };
 
-// Note: You'll need to move or ensure `getTaskCategory` is accessible.
-// It might be better in a shared utility file, e.g., `src/lib/taskUtils.ts`.
-// For now, assuming it's made available, e.g., by moving it to `lib/taskUtils.ts`
-// and importing it here. If `getTaskCategory` itself uses `mapStatusToStatusID`
-// and `getStatusAttributes`, those also need to be correctly pathed or moved.
-
-// Placeholder for getTaskCategory if not refactored yet, to make hook self-contained for now.
-// This should be replaced by a proper import from a utility file.
-// const getTaskCategory = (task: Task): string => {
-//   if (!task.status) return "todo";
-//   // const canonicalStatusId = mapStatusToStatusID(task.status); // Needs mapStatusToStatusID
-//   // const attributes = getStatusAttributes(canonicalStatusId); // Needs getStatusAttributes
-//   // return attributes ? attributes.category : "todo";
-//   // Simplified for placeholder:
-//   const statusLower = task.status.toLowerCase();
-//   if (statusLower.includes("done") || statusLower.includes("complete")) return "completed";
-//   if (statusLower.includes("progress")) return "inProgress";
-//   if (statusLower.includes("block")) return "blocked";
-//   if (statusLower.includes("fail")) return "failed";
-//   return "todo";
-// };


### PR DESCRIPTION
## Summary
- remove placeholder getTaskCategory implementation
- rely on shared utility from `src/lib/taskUtils`

## Testing
- `npm run lint`
- `npm run lint:frontend`


------
https://chatgpt.com/codex/tasks/task_e_6840bb0304f8832c99a2826a54c0b43a