### PR TITLE
fix(api): correct user service URLs

### DIFF
--- a/frontend/src/services/api/users.ts
+++ b/frontend/src/services/api/users.ts
@@ -1,46 +1,69 @@
 import { request } from "./request";
-import { User, UserCreateData, UserUpdateData, LoginRequest, LoginResponse } from "@/types/user"; // Anticipating user types
+import {
+  User,
+  UserCreateData,
+  UserUpdateData,
+  LoginRequest,
+  LoginResponse,
+} from "@/types/user"; // Anticipating user types
 import { buildApiUrl, API_CONFIG } from "./config";
 
 // Create a new user
 export const createUser = async (userData: UserCreateData): Promise<User> => {
-  return request<User>(`buildApiUrl(API_CONFIG.ENDPOINTS.USERS/`, { method: "POST", body: JSON.stringify(userData) });
+  return request<User>(buildApiUrl(API_CONFIG.ENDPOINTS.USERS, "/"), {
+    method: "POST",
+    body: JSON.stringify(userData),
+  });
 };
 
 // Fetch a single user by ID
 export const getUserById = async (userId: string): Promise<User> => {
-  return request<User>(`buildApiUrl(API_CONFIG.ENDPOINTS.USERS/${userId}`);
+  return request<User>(buildApiUrl(API_CONFIG.ENDPOINTS.USERS, `/${userId}`));
 };
 
 // Fetch a list of users
-export const getUsers = async (skip: number = 0, limit: number = 100): Promise<User[]> => {
+export const getUsers = async (
+  skip: number = 0,
+  limit: number = 100,
+): Promise<User[]> => {
   const queryParams = new URLSearchParams();
   queryParams.append("skip", String(skip));
   queryParams.append("limit", String(limit));
   const queryString = queryParams.toString();
-  const url = `buildApiUrl(API_CONFIG.ENDPOINTS.USERS/${queryString ? `?${queryString}` : ""}`;;
+  const url = buildApiUrl(
+    API_CONFIG.ENDPOINTS.USERS,
+    queryString ? `?${queryString}` : "",
+  );
   return request<User[]>(url);
 };
 
 // Update an existing user
 export const updateUser = async (
   userId: string,
-  userData: UserUpdateData
+  userData: UserUpdateData,
 ): Promise<User> => {
-  return request<User>(`buildApiUrl(API_CONFIG.ENDPOINTS.USERS/${userId}`, { method: "PUT", body: JSON.stringify(userData) });
+  return request<User>(buildApiUrl(API_CONFIG.ENDPOINTS.USERS, `/${userId}`), {
+    method: "PUT",
+    body: JSON.stringify(userData),
+  });
 };
 
 // Delete a user
 export const deleteUser = async (userId: string): Promise<User> => {
-  return request<User>(`buildApiUrl(API_CONFIG.ENDPOINTS.USERS/${userId}`, { method: "DELETE" });
+  return request<User>(buildApiUrl(API_CONFIG.ENDPOINTS.USERS, `/${userId}`), {
+    method: "DELETE",
+  });
 };
 
 // Login (placeholder for token, returns user info from backend)
 export const login = async (formData: LoginRequest): Promise<LoginResponse> => {
-  // Note: Backend expects OAuth2 form data, but we'll send JSON for now
-  return request<LoginResponse>(`buildApiUrl(API_CONFIG.ENDPOINTS.USERS/token`, { 
-    method: "POST", 
-    headers: { "Content-Type": "application/x-www-form-urlencoded" }, // Backend expects form data
-    body: new URLSearchParams(formData as Record<string, string>).toString(), // Sending as form data
-  });
-}; 
+  // Note: Backend expects OAuth2 form data, but we'll send form-encoded data
+  return request<LoginResponse>(
+    buildApiUrl(API_CONFIG.ENDPOINTS.USERS, "/token"),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams(formData as Record<string, string>).toString(),
+    },
+  );
+};


### PR DESCRIPTION
## Summary
- fix API URL builder usage in the user service
- clean up template strings and formatting
- verify users service compiles with a minimal tsconfig

## Testing
- `npx prettier -w frontend/src/services/api/users.ts`
- `npx eslint src/services/api/users.ts --fix --config ./eslint.config.cjs` *(file ignored)*
- `npx tsc -p tsconfig.tmp.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6840bb061eac832c8d64dca58f03b74e