### PR TITLE
feat(api): type project template endpoints

### DIFF
--- a/frontend/src/services/api/project_templates.ts
+++ b/frontend/src/services/api/project_templates.ts
@@ -1,11 +1,6 @@
 import { request } from "./request";
 import { buildApiUrl, API_CONFIG } from "./config";
-// TODO: Import or define types for ProjectTemplate, ProjectTemplateCreate, ProjectTemplateUpdate
-
-// Placeholder types (replace with real types if available)
-export type ProjectTemplate = any;
-export type ProjectTemplateCreate = any;
-export type ProjectTemplateUpdate = any;
+import { ProjectTemplate, ProjectTemplateCreate, ProjectTemplateUpdate } from "@/types";
 
 export const projectTemplatesApi = {
   // Create a new project template
@@ -52,7 +47,8 @@ export const projectTemplatesApi = {
     return request<{ message: string }>(
       buildApiUrl("/project-templates/", `/${templateId}`),
       {
-        method: "DELETE" }
+        method: "DELETE",
+      }
     );
   },
-}; 
+};

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -7,6 +7,7 @@ export * from "./memory";
 export * from "./comment";
 export * from "./rules";
 export * from "./mcp";
+export * from "./project_template";
 
 // Common types used across the application
 // Canonical shared sort direction type for all entities

--- a/frontend/src/types/project_template.ts
+++ b/frontend/src/types/project_template.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+export const projectTemplateSchema = z.object({
+  id: z.string(),
+  name: z.string().min(1, "Name is required"),
+  description: z.string().nullable().optional(),
+  template_data: z.record(z.any()),
+  created_at: z.string(),
+  updated_at: z.string().optional(),
+});
+
+export type ProjectTemplate = z.infer<typeof projectTemplateSchema>;
+
+export const projectTemplateCreateSchema = projectTemplateSchema.omit({
+  id: true,
+  created_at: true,
+  updated_at: true,
+});
+
+export type ProjectTemplateCreate = z.infer<typeof projectTemplateCreateSchema>;
+
+export const projectTemplateUpdateSchema = projectTemplateCreateSchema.partial();
+
+export type ProjectTemplateUpdate = z.infer<typeof projectTemplateUpdateSchema>;


### PR DESCRIPTION
## Summary
- define ProjectTemplate types using Zod
- expose new types through `index.ts`
- update project template API service to use typed data

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6840bb037bb0832c8846f1592c3fbfff