### PR TITLE
docs: provide env setup example

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,2 @@
+# Example environment configuration for the frontend
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.local.example
 
 # vercel
 .vercel

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,6 +2,16 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
+### Environment Setup
+
+Copy the example environment file and adjust the API URL if needed:
+
+```bash
+cp .env.local.example .env.local
+```
+
+`NEXT_PUBLIC_API_BASE_URL` points to your backend server and defaults to `http://localhost:8000`.
+
 First, run the development server:
 
 ```bash


### PR DESCRIPTION
## Summary
- document Next.js environment variable setup
- provide `.env.local.example` file for the frontend
- allow committing the example env file

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840baf902dc832ca42e87973914715f