### PR TITLE
Add integration test for frontend validator

### DIFF
--- a/frontend/src/__tests__/integration/README.md
+++ b/frontend/src/__tests__/integration/README.md
@@ -19,5 +19,6 @@ graph TD
 ## File List
 
 - `task-management.test.tsx`
+- `validate-frontend.test.ts`
 
 <!-- File List End -->

--- a/frontend/src/__tests__/integration/mock-missing-files.cjs
+++ b/frontend/src/__tests__/integration/mock-missing-files.cjs
@@ -1,0 +1,20 @@
+const fs = require('fs')
+const path = require('path')
+
+const originalExistsSync = fs.existsSync
+const originalReaddirSync = fs.readdirSync
+
+fs.existsSync = function (p) {
+  if (p.endsWith(path.join('frontend', '.env.local'))) {
+    return false
+  }
+  return originalExistsSync.call(this, p)
+}
+
+fs.readdirSync = function (p, options) {
+  let result = originalReaddirSync.call(this, p, options)
+  if (p.includes(path.join('frontend', 'src', 'services', 'api'))) {
+    result = result.filter((f) => f !== 'config.ts')
+  }
+  return result
+}

--- a/frontend/src/__tests__/integration/validate-frontend.test.ts
+++ b/frontend/src/__tests__/integration/validate-frontend.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { spawnSync } from 'child_process'
+import path from 'path'
+
+const repoRoot = path.resolve(__dirname, '../../../..')
+const script = path.join(repoRoot, 'validate_frontend.js')
+const mock = path.join(__dirname, 'mock-missing-files.cjs')
+
+describe('validate_frontend.js', () => {
+  it('should report success for current project', () => {
+    const result = spawnSync('node', [script], { cwd: repoRoot, encoding: 'utf8' })
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('Validation Summary')
+    expect(result.stdout).toMatch(/Frontend integration is (EXCELLENT|GOOD)/)
+  })
+
+  it('should fail when required files are missing', () => {
+    const result = spawnSync('node', ['-r', mock, script], { cwd: repoRoot, encoding: 'utf8' })
+    expect(result.status).not.toBe(0)
+    expect(result.stdout).toContain('Frontend integration needs IMPROVEMENT')
+  })
+})

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -19,7 +19,10 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/__tests__/setup.ts'],
-    include: ['src/lib/__tests__/utils.test.tsx'],
+    include: [
+      'src/lib/__tests__/utils.test.tsx',
+      'src/__tests__/integration/**/*.{ts,tsx}'
+    ],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary
- test `validate_frontend.js` happy path and failure modes
- simulate missing files with a CommonJS mock
- list new test file in integration README
- include integration tests in vitest config

## Testing
- `npx vitest run src/__tests__/integration/validate-frontend.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6840baf627f0832c85d52074bea7da5d