### PR TITLE
test: strengthen component tests

### DIFF
--- a/frontend/src/components/__tests__/NoTasks.test.tsx
+++ b/frontend/src/components/__tests__/NoTasks.test.tsx
@@ -1,7 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { render, screen } from '@/__tests__/utils/test-utils';
 import NoTasks from '../NoTasks';
 
 vi.mock('@chakra-ui/react', async () => {
@@ -14,55 +12,15 @@ vi.mock('@chakra-ui/react', async () => {
 });
 
 describe('NoTasks', () => {
-  const user = userEvent.setup();
-
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('should render without crashing', () => {
-    render(
-      <TestWrapper>
-        <NoTasks />
-      </TestWrapper>
-    );
-    expect(document.body).toBeInTheDocument();
-  });
-
-  it('should handle props correctly', () => {
-    const props = { 
-      testId: 'test-component',
-      'data-testid': 'test-component'
-    };
-    
-    render(
-      <TestWrapper>
-        <NoTasks {...props} />
-      </TestWrapper>
-    );
-    
-    const component = screen.queryByTestId('test-component');
-    expect(component || document.body).toBeInTheDocument();
-  });
-
-  it('should handle user interactions', async () => {
-    render(
-      <TestWrapper>
-        <NoTasks />
-      </TestWrapper>
-    );
-    
-    const buttons = screen.queryAllByRole('button');
-    const inputs = screen.queryAllByRole('textbox');
-    
-    if (buttons.length > 0) {
-      await user.click(buttons[0]);
-    }
-    
-    if (inputs.length > 0) {
-      await user.type(inputs[0], 'test input');
-    }
-    
-    expect(document.body).toBeInTheDocument();
+  it('shows empty state and calls add', async () => {
+    const add = vi.fn();
+    render(<NoTasks onAddTask={add} />);
+    expect(screen.getByText('No Tasks Found')).toBeInTheDocument();
+    await screen.getByRole('button', { name: /add your first task/i }).click();
+    expect(add).toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/__tests__/TaskError.test.tsx
+++ b/frontend/src/components/__tests__/TaskError.test.tsx
@@ -1,7 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { render, screen } from '@/__tests__/utils/test-utils';
 import TaskError from '../TaskError';
 
 vi.mock('@chakra-ui/react', async () => {
@@ -14,55 +12,15 @@ vi.mock('@chakra-ui/react', async () => {
 });
 
 describe('TaskError', () => {
-  const user = userEvent.setup();
-
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('should render without crashing', () => {
-    render(
-      <TestWrapper>
-        <TaskError />
-      </TestWrapper>
-    );
-    expect(document.body).toBeInTheDocument();
-  });
-
-  it('should handle props correctly', () => {
-    const props = { 
-      testId: 'test-component',
-      'data-testid': 'test-component'
-    };
-    
-    render(
-      <TestWrapper>
-        <TaskError {...props} />
-      </TestWrapper>
-    );
-    
-    const component = screen.queryByTestId('test-component');
-    expect(component || document.body).toBeInTheDocument();
-  });
-
-  it('should handle user interactions', async () => {
-    render(
-      <TestWrapper>
-        <TaskError />
-      </TestWrapper>
-    );
-    
-    const buttons = screen.queryAllByRole('button');
-    const inputs = screen.queryAllByRole('textbox');
-    
-    if (buttons.length > 0) {
-      await user.click(buttons[0]);
-    }
-    
-    if (inputs.length > 0) {
-      await user.type(inputs[0], 'test input');
-    }
-    
-    expect(document.body).toBeInTheDocument();
+  it('displays error and retry', async () => {
+    const retry = vi.fn();
+    render(<TaskError error="Oops" onRetry={retry} />);
+    expect(screen.getByText('Oops')).toBeInTheDocument();
+    await screen.getByRole('button', { name: /retry/i }).click();
+    expect(retry).toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/__tests__/TaskLoading.test.tsx
+++ b/frontend/src/components/__tests__/TaskLoading.test.tsx
@@ -1,7 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { render, screen } from '@/__tests__/utils/test-utils';
 import TaskLoading from '../TaskLoading';
 
 vi.mock('@chakra-ui/react', async () => {
@@ -14,55 +12,12 @@ vi.mock('@chakra-ui/react', async () => {
 });
 
 describe('TaskLoading', () => {
-  const user = userEvent.setup();
-
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('should render without crashing', () => {
-    render(
-      <TestWrapper>
-        <TaskLoading />
-      </TestWrapper>
-    );
-    expect(document.body).toBeInTheDocument();
-  });
-
-  it('should handle props correctly', () => {
-    const props = { 
-      testId: 'test-component',
-      'data-testid': 'test-component'
-    };
-    
-    render(
-      <TestWrapper>
-        <TaskLoading {...props} />
-      </TestWrapper>
-    );
-    
-    const component = screen.queryByTestId('test-component');
-    expect(component || document.body).toBeInTheDocument();
-  });
-
-  it('should handle user interactions', async () => {
-    render(
-      <TestWrapper>
-        <TaskLoading />
-      </TestWrapper>
-    );
-    
-    const buttons = screen.queryAllByRole('button');
-    const inputs = screen.queryAllByRole('textbox');
-    
-    if (buttons.length > 0) {
-      await user.click(buttons[0]);
-    }
-    
-    if (inputs.length > 0) {
-      await user.type(inputs[0], 'test input');
-    }
-    
-    expect(document.body).toBeInTheDocument();
+  it('renders loading text', () => {
+    render(<TaskLoading />);
+    expect(screen.getByText('Loading tasks...')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/__tests__/ThemeToggleButton.test.tsx
+++ b/frontend/src/components/__tests__/ThemeToggleButton.test.tsx
@@ -1,7 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { render, screen } from '@/__tests__/utils/test-utils';
 import ThemeToggleButton from '../ThemeToggleButton';
 
 vi.mock('@chakra-ui/react', async () => {
@@ -14,55 +12,19 @@ vi.mock('@chakra-ui/react', async () => {
 });
 
 describe('ThemeToggleButton', () => {
-  const user = userEvent.setup();
-
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('should render without crashing', () => {
-    render(
-      <TestWrapper>
-        <ThemeToggleButton />
-      </TestWrapper>
-    );
-    expect(document.body).toBeInTheDocument();
-  });
+  it('calls toggle function', async () => {
+    const toggle = vi.fn();
+    vi.mocked(require('@chakra-ui/react').useColorMode).mockReturnValue({
+      colorMode: 'light',
+      toggleColorMode: toggle,
+    } as any);
 
-  it('should handle props correctly', () => {
-    const props = { 
-      testId: 'test-component',
-      'data-testid': 'test-component'
-    };
-    
-    render(
-      <TestWrapper>
-        <ThemeToggleButton {...props} />
-      </TestWrapper>
-    );
-    
-    const component = screen.queryByTestId('test-component');
-    expect(component || document.body).toBeInTheDocument();
-  });
-
-  it('should handle user interactions', async () => {
-    render(
-      <TestWrapper>
-        <ThemeToggleButton />
-      </TestWrapper>
-    );
-    
-    const buttons = screen.queryAllByRole('button');
-    const inputs = screen.queryAllByRole('textbox');
-    
-    if (buttons.length > 0) {
-      await user.click(buttons[0]);
-    }
-    
-    if (inputs.length > 0) {
-      await user.type(inputs[0], 'test input');
-    }
-    
-    expect(document.body).toBeInTheDocument();
+    render(<ThemeToggleButton />);
+    await screen.getByRole('button').click();
+    expect(toggle).toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/__tests__/VirtualizedList.test.tsx
+++ b/frontend/src/components/__tests__/VirtualizedList.test.tsx
@@ -1,7 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { render, screen } from '@/__tests__/utils/test-utils';
 import VirtualizedList from '../VirtualizedList';
 
 vi.mock('@chakra-ui/react', async () => {
@@ -14,55 +12,19 @@ vi.mock('@chakra-ui/react', async () => {
 });
 
 describe('VirtualizedList', () => {
-  const user = userEvent.setup();
-
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('should render without crashing', () => {
-    render(
-      <TestWrapper>
-        <VirtualizedList />
-      </TestWrapper>
+  it('shows empty and loading states', () => {
+    const { rerender } = render(
+      <VirtualizedList items={[]} itemHeight={10} renderItem={() => null} isLoading={false} />,
     );
-    expect(document.body).toBeInTheDocument();
-  });
+    expect(screen.getByText('No items to display')).toBeInTheDocument();
 
-  it('should handle props correctly', () => {
-    const props = { 
-      testId: 'test-component',
-      'data-testid': 'test-component'
-    };
-    
-    render(
-      <TestWrapper>
-        <VirtualizedList {...props} />
-      </TestWrapper>
+    rerender(
+      <VirtualizedList items={[]} itemHeight={10} renderItem={() => null} isLoading />,
     );
-    
-    const component = screen.queryByTestId('test-component');
-    expect(component || document.body).toBeInTheDocument();
-  });
-
-  it('should handle user interactions', async () => {
-    render(
-      <TestWrapper>
-        <VirtualizedList />
-      </TestWrapper>
-    );
-    
-    const buttons = screen.queryAllByRole('button');
-    const inputs = screen.queryAllByRole('textbox');
-    
-    if (buttons.length > 0) {
-      await user.click(buttons[0]);
-    }
-    
-    if (inputs.length > 0) {
-      await user.type(inputs[0], 'test input');
-    }
-    
-    expect(document.body).toBeInTheDocument();
+    expect(screen.getByText('Loading items...')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- replace trivial assertions in component tests with meaningful checks

## Testing
- `npm run test:components` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840baf9ab98832ca3141a83225082b5