### PR TITLE
feat: make final_integration configurable

### DIFF
--- a/AEROSPACE_GRADE_DOCUMENTATION.md
+++ b/AEROSPACE_GRADE_DOCUMENTATION.md
@@ -289,7 +289,7 @@ The system employs a multi-layered testing approach following NASA standards:
 ### 7.1 System Startup Procedures
 ```bash
 # Standard Startup Sequence
-1. python final_integration.py    # System validation
+1. python final_integration.py --mode all    # Validation + integration tests
 2. python start_system.py         # System startup
 3. Verify health endpoints        # System verification
 4. Monitor performance metrics    # Ongoing monitoring

--- a/README.md
+++ b/README.md
@@ -268,6 +268,21 @@ If you encounter any issues:
 2. Check if the ports 8000 and 3000 are available
 3. If services fail to start, check the logs for detailed error messages
 
+## System Validation & Testing
+
+Use `final_integration.py` to verify the entire suite or run integration tests.
+
+```bash
+# Validate only
+python final_integration.py --mode validate
+
+# Integration tests only
+python final_integration.py --mode test
+
+# Run both validation and tests (default)
+python final_integration.py --mode all
+```
+
 ## License
 
 ISC


### PR DESCRIPTION
## Summary
- add argparse to configure `final_integration.py`
- document new `--mode` option in README
- update startup procedure in Aerospace docs

## Testing
- `flake8 .`
- `pytest -q`
- `npm run lint`
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_6840baf37d0c832c86ba809a1d370164