### PR TITLE
Implement advanced status workflow

### DIFF
--- a/backend/enums.py
+++ b/backend/enums.py
@@ -10,6 +10,17 @@ class TaskStatusEnum(enum.Enum):
     COMPLETED = "Completed"
     BLOCKED = "Blocked"
     CANCELLED = "Cancelled"
+    CONTEXT_ACQUIRED = "Context Acquired"
+    PLANNING_COMPLETE = "Planning Complete"
+    EXECUTION_IN_PROGRESS = "Execution In Progress"
+    PENDING_VERIFICATION = "Pending Verification"
+    VERIFICATION_COMPLETE = "Verification Complete"
+    VERIFICATION_FAILED = "Verification Failed"
+    COMPLETED_AWAITING_PROJECT_MANAGER = "Completed Awaiting Project Manager"
+    COMPLETED_HANDOFF = "Completed Handoff"
+    FAILED = "Failed"
+    IN_PROGRESS_AWAITING_SUBTASK = "In Progress Awaiting Subtask"
+    PENDING_RECOVERY_ATTEMPT = "Pending Recovery Attempt"
 
 class UserRoleEnum(enum.Enum):
     """Enum for user roles."""

--- a/backend/init_db.py
+++ b/backend/init_db.py
@@ -88,6 +88,17 @@ async def create_seed_data():
                 TaskStatus(id=3, name="Blocked", description="Task is blocked", order=3, is_final=False),
                 TaskStatus(id=4, name="Completed", description="Task is completed", order=4, is_final=True),
                 TaskStatus(id=5, name="Cancelled", description="Task is cancelled", order=5, is_final=True),
+                TaskStatus(id=6, name="Context Acquired", description="Agent gathered context", order=6, is_final=False),
+                TaskStatus(id=7, name="Planning Complete", description="Planning phase finished", order=7, is_final=False),
+                TaskStatus(id=8, name="Execution In Progress", description="Agent executing task", order=8, is_final=False),
+                TaskStatus(id=9, name="Pending Verification", description="Awaiting verification", order=9, is_final=False),
+                TaskStatus(id=10, name="Verification Complete", description="Verification succeeded", order=10, is_final=False),
+                TaskStatus(id=11, name="Verification Failed", description="Verification failed", order=11, is_final=False),
+                TaskStatus(id=12, name="Completed Awaiting Project Manager", description="Waiting for PM review", order=12, is_final=True),
+                TaskStatus(id=13, name="Completed Handoff", description="Completed with handoff", order=13, is_final=True),
+                TaskStatus(id=14, name="Failed", description="Task failed", order=14, is_final=True),
+                TaskStatus(id=15, name="In Progress Awaiting Subtask", description="Waiting for subtask", order=15, is_final=False),
+                TaskStatus(id=16, name="Pending Recovery Attempt", description="Recovery in progress", order=16, is_final=False),
             ]
 
             for status in statuses:

--- a/frontend/src/lib/statusUtils.ts
+++ b/frontend/src/lib/statusUtils.ts
@@ -43,12 +43,34 @@ export type StatusID =
   | "Completed"
   | "Blocked"
   | "Cancelled"
+  | "Context Acquired"
+  | "Planning Complete"
+  | "Execution In Progress"
+  | "Pending Verification"
+  | "Verification Complete"
+  | "Verification Failed"
+  | "Completed Awaiting Project Manager"
+  | "Completed Handoff"
+  | "Failed"
+  | "In Progress Awaiting Subtask"
+  | "Pending Recovery Attempt"
   | "TO_DO"
   | "IN_PROGRESS"
   | "IN_REVIEW"
   | "COMPLETED"
   | "BLOCKED"
-  | "CANCELLED";
+  | "CANCELLED"
+  | "CONTEXT_ACQUIRED"
+  | "PLANNING_COMPLETE"
+  | "EXECUTION_IN_PROGRESS"
+  | "PENDING_VERIFICATION"
+  | "VERIFICATION_COMPLETE"
+  | "VERIFICATION_FAILED"
+  | "COMPLETED_AWAITING_PROJECT_MANAGER"
+  | "COMPLETED_HANDOFF_TO_..."
+  | "FAILED"
+  | "IN_PROGRESS_AWAITING_SUBTASK"
+  | "PENDING_RECOVERY_ATTEMPT";
 
 /**
  * Represents the full set of attributes for a canonical task status.
@@ -198,6 +220,230 @@ const STATUS_MAP: Readonly<Record<StatusID, StatusAttributeObject>> = {
     colorScheme: "red",
     icon: "CloseIcon",
     isTerminal: true,
+    isDynamic: false,
+  },
+  "Context Acquired": {
+    id: "Context Acquired",
+    displayName: "Context Acquired",
+    category: "inProgress",
+    description: "Agent has gathered necessary context.",
+    colorScheme: "blue",
+    icon: "InfoIcon",
+    isTerminal: false,
+    isDynamic: false,
+  },
+  CONTEXT_ACQUIRED: {
+    id: "Context Acquired",
+    displayName: "Context Acquired",
+    category: "inProgress",
+    description: "Agent has gathered necessary context.",
+    colorScheme: "blue",
+    icon: "InfoIcon",
+    isTerminal: false,
+    isDynamic: false,
+  },
+  "Planning Complete": {
+    id: "Planning Complete",
+    displayName: "Planning Complete",
+    category: "inProgress",
+    description: "Planning phase finished.",
+    colorScheme: "purple",
+    icon: "CalendarIcon",
+    isTerminal: false,
+    isDynamic: false,
+  },
+  PLANNING_COMPLETE: {
+    id: "Planning Complete",
+    displayName: "Planning Complete",
+    category: "inProgress",
+    description: "Planning phase finished.",
+    colorScheme: "purple",
+    icon: "CalendarIcon",
+    isTerminal: false,
+    isDynamic: false,
+  },
+  "Execution In Progress": {
+    id: "Execution In Progress",
+    displayName: "Execution In Progress",
+    category: "inProgress",
+    description: "Agent is executing the task.",
+    colorScheme: "blue",
+    icon: "TimeIcon",
+    isTerminal: false,
+    isDynamic: false,
+  },
+  EXECUTION_IN_PROGRESS: {
+    id: "Execution In Progress",
+    displayName: "Execution In Progress",
+    category: "inProgress",
+    description: "Agent is executing the task.",
+    colorScheme: "blue",
+    icon: "TimeIcon",
+    isTerminal: false,
+    isDynamic: false,
+  },
+  "Pending Verification": {
+    id: "Pending Verification",
+    displayName: "Pending Verification",
+    category: "pendingInput",
+    description: "Awaiting verification of results.",
+    colorScheme: "orange",
+    icon: "ViewIcon",
+    isTerminal: false,
+    isDynamic: false,
+  },
+  PENDING_VERIFICATION: {
+    id: "Pending Verification",
+    displayName: "Pending Verification",
+    category: "pendingInput",
+    description: "Awaiting verification of results.",
+    colorScheme: "orange",
+    icon: "ViewIcon",
+    isTerminal: false,
+    isDynamic: false,
+  },
+  "Verification Complete": {
+    id: "Verification Complete",
+    displayName: "Verification Complete",
+    category: "completed",
+    description: "Verification succeeded.",
+    colorScheme: "green",
+    icon: "CheckCircleIcon",
+    isTerminal: false,
+    isDynamic: false,
+  },
+  VERIFICATION_COMPLETE: {
+    id: "Verification Complete",
+    displayName: "Verification Complete",
+    category: "completed",
+    description: "Verification succeeded.",
+    colorScheme: "green",
+    icon: "CheckCircleIcon",
+    isTerminal: false,
+    isDynamic: false,
+  },
+  "Verification Failed": {
+    id: "Verification Failed",
+    displayName: "Verification Failed",
+    category: "failed",
+    description: "Verification failed.",
+    colorScheme: "red",
+    icon: "WarningTwoIcon",
+    isTerminal: false,
+    isDynamic: false,
+  },
+  VERIFICATION_FAILED: {
+    id: "Verification Failed",
+    displayName: "Verification Failed",
+    category: "failed",
+    description: "Verification failed.",
+    colorScheme: "red",
+    icon: "WarningTwoIcon",
+    isTerminal: false,
+    isDynamic: false,
+  },
+  "Completed Awaiting Project Manager": {
+    id: "Completed Awaiting Project Manager",
+    displayName: "Completed Awaiting Project Manager",
+    category: "completed",
+    description: "Waiting for project manager review.",
+    colorScheme: "purple",
+    icon: "TimeIcon",
+    isTerminal: true,
+    isDynamic: false,
+  },
+  COMPLETED_AWAITING_PROJECT_MANAGER: {
+    id: "Completed Awaiting Project Manager",
+    displayName: "Completed Awaiting Project Manager",
+    category: "completed",
+    description: "Waiting for project manager review.",
+    colorScheme: "purple",
+    icon: "TimeIcon",
+    isTerminal: true,
+    isDynamic: false,
+  },
+  "Completed Handoff": {
+    id: "Completed Handoff",
+    displayName: "Completed Handoff",
+    category: "completed",
+    description: "Completed with handoff to another task.",
+    colorScheme: "green",
+    icon: "ArrowForwardIcon",
+    isTerminal: true,
+    isDynamic: true,
+    dynamicPartsExtractor: /^COMPLETED_HANDOFF_TO_(([a-zA-Z0-9-]+(?:\s*,\s*[a-zA-Z0-9-]+)*))$/,
+    dynamicDisplayNamePattern: "Handoff to: {value}",
+  },
+  "COMPLETED_HANDOFF_TO_...": {
+    id: "Completed Handoff",
+    displayName: "Completed Handoff",
+    category: "completed",
+    description: "Completed with handoff to another task.",
+    colorScheme: "green",
+    icon: "ArrowForwardIcon",
+    isTerminal: true,
+    isDynamic: true,
+    dynamicPartsExtractor: /^COMPLETED_HANDOFF_TO_(([a-zA-Z0-9-]+(?:\s*,\s*[a-zA-Z0-9-]+)*))$/,
+    dynamicDisplayNamePattern: "Handoff to: {value}",
+  },
+  Failed: {
+    id: "Failed",
+    displayName: "Failed",
+    category: "failed",
+    description: "Task failed to complete.",
+    colorScheme: "red",
+    icon: "CloseIcon",
+    isTerminal: true,
+    isDynamic: false,
+  },
+  FAILED: {
+    id: "Failed",
+    displayName: "Failed",
+    category: "failed",
+    description: "Task failed to complete.",
+    colorScheme: "red",
+    icon: "CloseIcon",
+    isTerminal: true,
+    isDynamic: false,
+  },
+  "In Progress Awaiting Subtask": {
+    id: "In Progress Awaiting Subtask",
+    displayName: "In Progress Awaiting Subtask",
+    category: "inProgress",
+    description: "Waiting for subtask completion.",
+    colorScheme: "orange",
+    icon: "TimeIcon",
+    isTerminal: false,
+    isDynamic: false,
+  },
+  IN_PROGRESS_AWAITING_SUBTASK: {
+    id: "In Progress Awaiting Subtask",
+    displayName: "In Progress Awaiting Subtask",
+    category: "inProgress",
+    description: "Waiting for subtask completion.",
+    colorScheme: "orange",
+    icon: "TimeIcon",
+    isTerminal: false,
+    isDynamic: false,
+  },
+  "Pending Recovery Attempt": {
+    id: "Pending Recovery Attempt",
+    displayName: "Pending Recovery Attempt",
+    category: "pendingInput",
+    description: "Awaiting recovery attempt.",
+    colorScheme: "orange",
+    icon: "RepeatIcon",
+    isTerminal: false,
+    isDynamic: false,
+  },
+  PENDING_RECOVERY_ATTEMPT: {
+    id: "Pending Recovery Attempt",
+    displayName: "Pending Recovery Attempt",
+    category: "pendingInput",
+    description: "Awaiting recovery attempt.",
+    colorScheme: "orange",
+    icon: "RepeatIcon",
+    isTerminal: false,
     isDynamic: false,
   },
 };

--- a/frontend/src/types/task.ts
+++ b/frontend/src/types/task.ts
@@ -4,11 +4,22 @@ import { z } from "zod";
 // Task Status Enum matching backend TaskStatusEnum exactly
 export enum TaskStatus {
   TO_DO = "To Do",
-  IN_PROGRESS = "In Progress", 
+  IN_PROGRESS = "In Progress",
   IN_REVIEW = "In Review",
   COMPLETED = "Completed",
   BLOCKED = "Blocked",
   CANCELLED = "Cancelled",
+  CONTEXT_ACQUIRED = "Context Acquired",
+  PLANNING_COMPLETE = "Planning Complete",
+  EXECUTION_IN_PROGRESS = "Execution In Progress",
+  PENDING_VERIFICATION = "Pending Verification",
+  VERIFICATION_COMPLETE = "Verification Complete",
+  VERIFICATION_FAILED = "Verification Failed",
+  COMPLETED_AWAITING_PROJECT_MANAGER = "Completed Awaiting Project Manager",
+  COMPLETED_HANDOFF = "Completed Handoff",
+  FAILED = "Failed",
+  IN_PROGRESS_AWAITING_SUBTASK = "In Progress Awaiting Subtask",
+  PENDING_RECOVERY_ATTEMPT = "Pending Recovery Attempt",
 }
 
 export enum TaskPriority {


### PR DESCRIPTION
## Summary
- add advanced task statuses to backend enum and seed data
- expand frontend status utilities to support advanced statuses
- update task type definitions for new statuses

## Testing
- `pytest backend/tests -q`
- `npm run test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840babb88b8832cbc4c4acdc3729d03