### PR TITLE
feat(api): centralize error handling

### DIFF
--- a/frontend/src/components/dashboard/useDashboardData.ts
+++ b/frontend/src/components/dashboard/useDashboardData.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback } from "react";
+import { handleApiError } from "@/lib/apiErrorHandler";
 import { Project } from "@/types/project";
 import { Task } from "@/types/task";
 import * as api from "@/services/api";
@@ -24,6 +25,7 @@ export function useDashboardData() {
         "Error fetching all projects/tasks for dashboard totals:",
         error,
       );
+      handleApiError(error, "Failed to load dashboard data");
       const errorMessage =
         error instanceof Error
           ? error.message

--- a/frontend/src/lib/apiErrorHandler.ts
+++ b/frontend/src/lib/apiErrorHandler.ts
@@ -1,0 +1,37 @@
+import { createStandaloneToast, UseToastOptions } from "@chakra-ui/react";
+
+export class ApiError extends Error {
+  status?: number;
+  code?: string | number;
+  constructor(message: string, status?: number, code?: string | number) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+}
+
+const { toast } = createStandaloneToast();
+
+export function handleApiError(
+  error: unknown,
+  title = "API Error",
+  options?: Partial<UseToastOptions>,
+): void {
+  let description = "An unexpected error occurred.";
+  if (error instanceof ApiError) {
+    description = error.message;
+  } else if (error instanceof Error) {
+    description = error.message;
+  } else if (typeof error === "string") {
+    description = error;
+  }
+
+  toast({
+    title,
+    description,
+    status: "error",
+    duration: 5000,
+    isClosable: true,
+    ...options,
+  });
+}

--- a/frontend/src/services/api/request.ts
+++ b/frontend/src/services/api/request.ts
@@ -1,4 +1,5 @@
 import { StatusID } from "@/lib/statusUtils";
+import { ApiError } from "@/lib/apiErrorHandler";
 
 // Helper to normalize status string to a known StatusID (now simplified since formats match)
 export const normalizeToStatusID = (
@@ -65,7 +66,7 @@ export async function request<T>(
       console.warn(`Failed to parse error response as JSON for URL: ${url}`, e);
       errorDetail = response.statusText || errorDetail;
     }
-    throw new Error(errorDetail);
+    throw new ApiError(errorDetail, response.status);
   }
   // For DELETE requests, backend might return the deleted object or no content
   if (response.status === 204) {


### PR DESCRIPTION
## Summary
- add `handleApiError` utility with Chakra toast support
- throw `ApiError` in request helper
- show dashboard loading errors using new handler

## Testing
- `npm run lint`
- `npm run test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_6840d2b26574832c984d17eb7ea8274f