### PR TITLE
test: share react test helpers

### DIFF
--- a/frontend/src/__tests__/integration/task-management.test.tsx
+++ b/frontend/src/__tests__/integration/task-management.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, screen, waitFor, fireEvent, within } from '@/__tests__/utils/test-utils'
+import { render, screen, waitFor, fireEvent, within } from '@/__tests__/utils'
 import { server } from '@/__tests__/mocks/server'
 import { http, HttpResponse } from 'msw'
 import { 

--- a/frontend/src/__tests__/utils/index.ts
+++ b/frontend/src/__tests__/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './test-utils';

--- a/frontend/src/components/ThemeToggleButton/__tests__/ThemeToggleButton.test.tsx
+++ b/frontend/src/components/ThemeToggleButton/__tests__/ThemeToggleButton.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import ThemeToggleButton from '../ThemeToggleButton';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/__tests__/AgentList.test.tsx
+++ b/frontend/src/components/__tests__/AgentList.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
 import AgentList from '../AgentList';
 

--- a/frontend/src/components/__tests__/ClientOnly.test.tsx
+++ b/frontend/src/components/__tests__/ClientOnly.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import ClientOnly from '../ClientOnly';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/__tests__/Dashboard.test.tsx
+++ b/frontend/src/components/__tests__/Dashboard.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import Dashboard from '../Dashboard';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/__tests__/LoadingSkeleton.test.tsx
+++ b/frontend/src/components/__tests__/LoadingSkeleton.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import LoadingSkeleton from '../LoadingSkeleton';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/__tests__/MCPDevTools.test.tsx
+++ b/frontend/src/components/__tests__/MCPDevTools.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen } from "@/__tests__/utils";
 import userEvent from "@testing-library/user-event";
-import { TestWrapper } from "@/__tests__/utils/test-utils";
+import { TestWrapper } from "@/__tests__/utils";
 import MCPDevTools from "../MCPDevTools";
 
 vi.mock("@chakra-ui/react", async () => {

--- a/frontend/src/components/__tests__/NoTasks.test.tsx
+++ b/frontend/src/components/__tests__/NoTasks.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@/__tests__/utils/test-utils';
+import { render, screen } from '@/__tests__/utils';
 import NoTasks from '../NoTasks';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/__tests__/ProjectList.test.tsx
+++ b/frontend/src/components/__tests__/ProjectList.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import ProjectList from '../ProjectList';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/__tests__/SettingsContent.test.tsx
+++ b/frontend/src/components/__tests__/SettingsContent.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import SettingsContent from '../SettingsContent';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/__tests__/TaskAgentTag.test.tsx
+++ b/frontend/src/components/__tests__/TaskAgentTag.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import TaskAgentTag from '../TaskAgentTag';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/__tests__/TaskControls.test.tsx
+++ b/frontend/src/components/__tests__/TaskControls.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import TaskControls from '../TaskControls';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/__tests__/TaskError.test.tsx
+++ b/frontend/src/components/__tests__/TaskError.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@/__tests__/utils/test-utils';
+import { render, screen } from '@/__tests__/utils';
 import TaskError from '../TaskError';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/__tests__/TaskItemModals.test.tsx
+++ b/frontend/src/components/__tests__/TaskItemModals.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import TaskItemModals from '../TaskItemModals';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/__tests__/TaskList.test.tsx
+++ b/frontend/src/components/__tests__/TaskList.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor, fireEvent } from '@/__tests__/utils/test-utils'
+import { render, screen, waitFor, fireEvent } from '@/__tests__/utils'
 import { createMockTask, createMockTasks } from '@/__tests__/factories'
 import TaskList from '../TaskList'
 import { useTaskStore } from '@/store/taskStore'

--- a/frontend/src/components/__tests__/TaskList.utils.test.tsx
+++ b/frontend/src/components/__tests__/TaskList.utils.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import TaskListUtils from '../TaskList.utils';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/__tests__/TaskLoading.test.tsx
+++ b/frontend/src/components/__tests__/TaskLoading.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@/__tests__/utils/test-utils';
+import { render, screen } from '@/__tests__/utils';
 import TaskLoading from '../TaskLoading';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/__tests__/TaskProjectTag.test.tsx
+++ b/frontend/src/components/__tests__/TaskProjectTag.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import TaskProjectTag from '../TaskProjectTag';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/__tests__/TaskStatusTag.test.tsx
+++ b/frontend/src/components/__tests__/TaskStatusTag.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { render, screen } from '@/__tests__/utils/test-utils'
+import { render, screen } from '@/__tests__/utils'
 import { CheckIcon, TimeIcon, WarningIcon } from '@chakra-ui/icons'
 import TaskStatusTag from '../TaskStatusTag'
 

--- a/frontend/src/components/__tests__/ThemeToggleButton.test.tsx
+++ b/frontend/src/components/__tests__/ThemeToggleButton.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@/__tests__/utils/test-utils';
+import { render, screen } from '@/__tests__/utils';
 import ThemeToggleButton from '../ThemeToggleButton';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/__tests__/VirtualizedList.test.tsx
+++ b/frontend/src/components/__tests__/VirtualizedList.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@/__tests__/utils/test-utils';
+import { render, screen } from '@/__tests__/utils';
 import VirtualizedList from '../VirtualizedList';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/__tests__/useTaskItemStyles.test.tsx
+++ b/frontend/src/components/__tests__/useTaskItemStyles.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
 import useTaskItemStyles from '../useTaskItemStyles';
 

--- a/frontend/src/components/agent/__tests__/AddAgentModal.test.tsx
+++ b/frontend/src/components/agent/__tests__/AddAgentModal.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import AddAgentModal from '../AddAgentModal';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/agent/__tests__/AgentCard.test.tsx
+++ b/frontend/src/components/agent/__tests__/AgentCard.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import AgentCard from '../AgentCard';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/agent/__tests__/AgentList.test.tsx
+++ b/frontend/src/components/agent/__tests__/AgentList.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import AgentList from '../AgentList';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/agent/__tests__/AgentListHeader.test.tsx
+++ b/frontend/src/components/agent/__tests__/AgentListHeader.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import AgentListHeader from '../AgentListHeader';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/agent/__tests__/CliPromptModal.test.tsx
+++ b/frontend/src/components/agent/__tests__/CliPromptModal.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import CliPromptModal from '../CliPromptModal';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/agent/__tests__/EditAgentModal.test.tsx
+++ b/frontend/src/components/agent/__tests__/EditAgentModal.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import EditAgentModal from '../EditAgentModal';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/audit_logs/__tests__/AuditLogListForEntity.test.tsx
+++ b/frontend/src/components/audit_logs/__tests__/AuditLogListForEntity.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import AuditLogListForEntity from '../AuditLogListForEntity';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/common/__tests__/AddFormBase.test.tsx
+++ b/frontend/src/components/common/__tests__/AddFormBase.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import AddFormBase from '../AddFormBase';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/common/__tests__/AppIcon.test.tsx
+++ b/frontend/src/components/common/__tests__/AppIcon.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import AppIcon from '../AppIcon';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/common/__tests__/ConfirmationModal.test.tsx
+++ b/frontend/src/components/common/__tests__/ConfirmationModal.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import ConfirmationModal from '../ConfirmationModal';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/common/__tests__/EditModalBase.test.tsx
+++ b/frontend/src/components/common/__tests__/EditModalBase.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import EditModalBase from '../EditModalBase';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/common/__tests__/FilterPanel.test.tsx
+++ b/frontend/src/components/common/__tests__/FilterPanel.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import FilterPanel from '../FilterPanel';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/common/__tests__/FilterSidebar.test.tsx
+++ b/frontend/src/components/common/__tests__/FilterSidebar.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import FilterSidebar from '../FilterSidebar';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/common/__tests__/TaskActionsMenu.test.tsx
+++ b/frontend/src/components/common/__tests__/TaskActionsMenu.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import TaskActionsMenu from '../TaskActionsMenu';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/common/__tests__/TaskAgentTag.test.tsx
+++ b/frontend/src/components/common/__tests__/TaskAgentTag.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import TaskAgentTag from '../TaskAgentTag';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/common/__tests__/TaskDependencyTag.test.tsx
+++ b/frontend/src/components/common/__tests__/TaskDependencyTag.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import TaskDependencyTag from '../TaskDependencyTag';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/common/__tests__/TaskDescriptionEditor.test.tsx
+++ b/frontend/src/components/common/__tests__/TaskDescriptionEditor.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import TaskDescriptionEditor from '../TaskDescriptionEditor';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/common/__tests__/TaskProjectTag.test.tsx
+++ b/frontend/src/components/common/__tests__/TaskProjectTag.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import TaskProjectTag from '../TaskProjectTag';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/common/__tests__/TaskStatusTag.test.tsx
+++ b/frontend/src/components/common/__tests__/TaskStatusTag.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import TaskStatusTag from '../TaskStatusTag';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/common/__tests__/TaskTitleEditor.test.tsx
+++ b/frontend/src/components/common/__tests__/TaskTitleEditor.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import TaskTitleEditor from '../TaskTitleEditor';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/dashboard/__tests__/AgentWorkloadChart.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/AgentWorkloadChart.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import AgentWorkloadChart from '../AgentWorkloadChart';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/dashboard/__tests__/CreateProjectModal.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/CreateProjectModal.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import CreateProjectModal from '../CreateProjectModal';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/dashboard/__tests__/DashboardError.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/DashboardError.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import DashboardError from '../DashboardError';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/dashboard/__tests__/DashboardLoading.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/DashboardLoading.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import DashboardLoading from '../DashboardLoading';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/dashboard/__tests__/DashboardSection.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/DashboardSection.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import DashboardSection from '../DashboardSection';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/dashboard/__tests__/DashboardStatsGrid.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/DashboardStatsGrid.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import DashboardStatsGrid from '../DashboardStatsGrid';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/dashboard/__tests__/EditProjectModal.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/EditProjectModal.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import EditProjectModal from '../EditProjectModal';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/dashboard/__tests__/ProjectProgressChart.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/ProjectProgressChart.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import ProjectProgressChart from '../ProjectProgressChart';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/dashboard/__tests__/RecentActivityList.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/RecentActivityList.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import RecentActivityList from '../RecentActivityList';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/dashboard/__tests__/TaskStatusChart.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/TaskStatusChart.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import TaskStatusChart from '../TaskStatusChart';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/dashboard/__tests__/TasksOverTimeChart.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/TasksOverTimeChart.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import TasksOverTimeChart from '../TasksOverTimeChart';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/dashboard/__tests__/TopPerformersLists.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/TopPerformersLists.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import TopPerformersLists from '../TopPerformersLists';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/dashboard/__tests__/UnassignedTasksList.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/UnassignedTasksList.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import UnassignedTasksList from '../UnassignedTasksList';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/dashboard/__tests__/useDashboardData.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/useDashboardData.test.tsx
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-// import { screen, fireEvent, waitFor } from '@testing-library/react';
+// import { screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
 import useDashboardData from '../useDashboardData';
-// import { renderHook } from '@testing-library/react';
+// import { renderHook } from '@/__tests__/utils';
 
 vi.mock('@chakra-ui/react', async () => {
   const actual = await vi.importActual('@chakra-ui/react');

--- a/frontend/src/components/forms/__tests__/AddAgentForm.test.tsx
+++ b/frontend/src/components/forms/__tests__/AddAgentForm.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import AddAgentForm from '../AddAgentForm';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/forms/__tests__/AddProjectForm.test.tsx
+++ b/frontend/src/components/forms/__tests__/AddProjectForm.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import AddProjectForm from '../AddProjectForm';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/forms/__tests__/AddTaskForm.test.tsx
+++ b/frontend/src/components/forms/__tests__/AddTaskForm.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import AddTaskForm from '../AddTaskForm';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/forms/__tests__/EditAgentForm.test.tsx
+++ b/frontend/src/components/forms/__tests__/EditAgentForm.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import EditAgentForm from '../EditAgentForm';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/forms/__tests__/TaskForm.test.tsx
+++ b/frontend/src/components/forms/__tests__/TaskForm.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import TaskForm from '../TaskForm';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/layout/__tests__/MainContent.test.tsx
+++ b/frontend/src/components/layout/__tests__/MainContent.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import MainContent from '../MainContent';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/frontend/src/components/layout/__tests__/Sidebar.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import Sidebar from '../Sidebar';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/modals/__tests__/AddAgentModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/AddAgentModal.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import AddAgentModal from '../AddAgentModal';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/modals/__tests__/AddProjectModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/AddProjectModal.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import AddProjectModal from '../AddProjectModal';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/modals/__tests__/AddTaskModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/AddTaskModal.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import AddTaskModal from '../AddTaskModal';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/modals/__tests__/AgentAssignmentModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/AgentAssignmentModal.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import AgentAssignmentModal from '../AgentAssignmentModal';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/modals/__tests__/CreateProjectModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/CreateProjectModal.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import CreateProjectModal from '../CreateProjectModal';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/modals/__tests__/DevToolsDrawer.test.tsx
+++ b/frontend/src/components/modals/__tests__/DevToolsDrawer.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import DevToolsDrawer from '../DevToolsDrawer';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/modals/__tests__/EditAgentModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/EditAgentModal.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import EditAgentModal from '../EditAgentModal';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/modals/__tests__/EditProjectModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/EditProjectModal.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import EditProjectModal from '../EditProjectModal';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/modals/__tests__/EditTaskModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/EditTaskModal.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import EditTaskModal from '../EditTaskModal';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/modals/__tests__/ImportPlanModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/ImportPlanModal.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import ImportPlanModal from '../ImportPlanModal';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/modals/__tests__/TaskDetailsModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/TaskDetailsModal.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import TaskDetailsModal from '../TaskDetailsModal';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/project/__tests__/ProjectDetail.test.tsx
+++ b/frontend/src/components/project/__tests__/ProjectDetail.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import ProjectDetail from '../ProjectDetail';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/project/__tests__/ProjectFiles.test.tsx
+++ b/frontend/src/components/project/__tests__/ProjectFiles.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import ProjectFiles from '../ProjectFiles';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/project/__tests__/ProjectList.test.tsx
+++ b/frontend/src/components/project/__tests__/ProjectList.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import ProjectList from '../ProjectList';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/project/__tests__/ProjectMembers.test.tsx
+++ b/frontend/src/components/project/__tests__/ProjectMembers.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import ProjectMembers from '../ProjectMembers';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/task/__tests__/TaskFilters.test.tsx
+++ b/frontend/src/components/task/__tests__/TaskFilters.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { render, screen, fireEvent } from '@/__tests__/utils';
+import { TestWrapper } from '@/__tests__/utils';
 import TaskFilters from '../TaskFilters';
 
 describe('TaskFilters', () => {

--- a/frontend/src/components/task/__tests__/TaskItem.styles.test.tsx
+++ b/frontend/src/components/task/__tests__/TaskItem.styles.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import TaskItemStyles from '../TaskItem.styles';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/task/__tests__/TaskItem.test.tsx
+++ b/frontend/src/components/task/__tests__/TaskItem.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import TaskItem from '../TaskItem';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/task/__tests__/TaskItem.types.test.tsx
+++ b/frontend/src/components/task/__tests__/TaskItem.types.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import TaskItemTypes from '../TaskItem.types';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/task/__tests__/TaskItem.utils.test.tsx
+++ b/frontend/src/components/task/__tests__/TaskItem.utils.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import TaskItemUtils from '../TaskItem.utils';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/task/__tests__/TaskItemDetailsSection.test.tsx
+++ b/frontend/src/components/task/__tests__/TaskItemDetailsSection.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import TaskItemDetailsSection from '../TaskItemDetailsSection';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/task/__tests__/TaskItemMainSection.test.tsx
+++ b/frontend/src/components/task/__tests__/TaskItemMainSection.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import TaskItemMainSection from '../TaskItemMainSection';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/task/__tests__/TaskPagination.test.tsx
+++ b/frontend/src/components/task/__tests__/TaskPagination.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { render, screen, fireEvent } from '@/__tests__/utils';
+import { TestWrapper } from '@/__tests__/utils';
 import TaskPagination from '../TaskPagination';
 
 describe('TaskPagination', () => {

--- a/frontend/src/components/task/__tests__/TaskRow.test.tsx
+++ b/frontend/src/components/task/__tests__/TaskRow.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { render, screen, fireEvent } from '@/__tests__/utils';
+import { TestWrapper } from '@/__tests__/utils';
 import { createMockTask } from '@/__tests__/factories';
 import TaskRow from '../TaskRow';
 

--- a/frontend/src/components/user/__tests__/LoginForm.test.tsx
+++ b/frontend/src/components/user/__tests__/LoginForm.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import LoginForm from '../LoginForm';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/user/__tests__/UserProfile.test.tsx
+++ b/frontend/src/components/user/__tests__/UserProfile.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import UserProfile from '../UserProfile';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/views/__tests__/KanbanColumn.test.tsx
+++ b/frontend/src/components/views/__tests__/KanbanColumn.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import KanbanColumn from '../KanbanColumn';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/views/__tests__/KanbanView.test.tsx
+++ b/frontend/src/components/views/__tests__/KanbanView.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import KanbanView from '../KanbanView';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/views/__tests__/ListGroup.test.tsx
+++ b/frontend/src/components/views/__tests__/ListGroup.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import ListGroup from '../ListGroup';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/views/__tests__/ListSubgroup.test.tsx
+++ b/frontend/src/components/views/__tests__/ListSubgroup.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import ListSubgroup from '../ListSubgroup';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/views/__tests__/ListTaskItem.test.tsx
+++ b/frontend/src/components/views/__tests__/ListTaskItem.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import ListTaskItem from '../ListTaskItem';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/views/__tests__/ListTaskMobile.test.tsx
+++ b/frontend/src/components/views/__tests__/ListTaskMobile.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import ListTaskMobile from '../ListTaskMobile';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/views/__tests__/ListView.test.tsx
+++ b/frontend/src/components/views/__tests__/ListView.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import ListView from '../ListView';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/components/views/__tests__/ListView.types.test.tsx
+++ b/frontend/src/components/views/__tests__/ListView.types.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import { ListViewTypes } from '../ListView.types';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/contexts/__tests__/ThemeContext.test.tsx
+++ b/frontend/src/contexts/__tests__/ThemeContext.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import { ThemeContext } from '../ThemeContext';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/hooks/__tests__/useFilteredProjects.test.tsx
+++ b/frontend/src/hooks/__tests__/useFilteredProjects.test.tsx
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Remove screen, fireEvent, waitFor imports
-// import { screen, fireEvent, waitFor } from '@testing-library/react';
+// import { screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
 // Change default import to named import
 import { useFilteredProjects } from '../useFilteredProjects';
 // Add renderHook import
-// import { renderHook } from '@testing-library/react';
+// import { renderHook } from '@/__tests__/utils';
 
 vi.mock('@chakra-ui/react', async () => {
   const actual = await vi.importActual('@chakra-ui/react');

--- a/frontend/src/hooks/__tests__/useFilteredTasks.test.tsx
+++ b/frontend/src/hooks/__tests__/useFilteredTasks.test.tsx
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Remove screen, fireEvent, waitFor imports
-// import { screen, fireEvent, waitFor } from '@testing-library/react';
+// import { screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
 // Change default import to named import
 import { useFilteredTasks } from '../useFilteredTasks';
 // Add renderHook import
-// import { renderHook } from '@testing-library/react';
+// import { renderHook } from '@/__tests__/utils';
 
 vi.mock('@chakra-ui/react', async () => {
   const actual = await vi.importActual('@chakra-ui/react');

--- a/frontend/src/providers/__tests__/ChakraProviderWrapper.test.tsx
+++ b/frontend/src/providers/__tests__/ChakraProviderWrapper.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import ChakraProviderWrapper from '../ChakraProviderWrapper';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/providers/__tests__/ModalProvider.test.tsx
+++ b/frontend/src/providers/__tests__/ModalProvider.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils';
 import ModalProvider from '../ModalProvider';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/services/api/__tests__/planning.test.tsx
+++ b/frontend/src/services/api/__tests__/planning.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
 import planning from '../planning';
 

--- a/frontend/src/services/api/__tests__/users.test.tsx
+++ b/frontend/src/services/api/__tests__/users.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils';
 import userEvent from '@testing-library/user-event';
 import users from '../users';
 


### PR DESCRIPTION
## Summary
- add central test utility exports
- use custom render helper in all component tests

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6840d2b12cb4832c85db72cf549e9821