### PR TITLE
Add store state mutation tests

### DIFF
--- a/frontend/src/store/__tests__/agentStore.test.ts
+++ b/frontend/src/store/__tests__/agentStore.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { act } from 'react-dom/test-utils'
 import { useAgentStore } from '../agentStore'
 import * as api from '@/services/api'
 
@@ -31,7 +32,9 @@ describe('agentStore', () => {
     const agents = [{ id: '1', name: 'Alpha', created_at: '2024-01-01' }]
     mockedApi.getAgents.mockResolvedValueOnce(agents)
 
-    await useAgentStore.getState().fetchAgents(0, 10)
+    await act(async () => {
+      await useAgentStore.getState().fetchAgents(0, 10)
+    })
 
     expect(mockedApi.getAgents).toHaveBeenCalledWith(0, 10, undefined, 'all', false)
     expect(useAgentStore.getState().agents).toEqual(agents)
@@ -42,7 +45,9 @@ describe('agentStore', () => {
     const newAgent = { id: '2', name: 'Beta', created_at: '2024-01-02' }
     mockedApi.createAgent.mockResolvedValueOnce(newAgent)
 
-    await useAgentStore.getState().addAgent({ name: 'Beta' } as any)
+    await act(async () => {
+      await useAgentStore.getState().addAgent({ name: 'Beta' } as any)
+    })
 
     expect(mockedApi.createAgent).toHaveBeenCalledWith({ name: 'Beta' })
     expect(useAgentStore.getState().agents[0]).toEqual(newAgent)

--- a/frontend/src/store/__tests__/authStore.test.ts
+++ b/frontend/src/store/__tests__/authStore.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act } from "react-dom/test-utils";
+import { useAuthStore } from "../authStore";
+
+describe("authStore", () => {
+  beforeEach(() => {
+    useAuthStore.setState({
+      token: null,
+      setToken: useAuthStore.getState().setToken,
+      clearToken: useAuthStore.getState().clearToken,
+    });
+  });
+
+  it("setToken stores token", () => {
+    act(() => {
+      useAuthStore.getState().setToken("abc");
+    });
+    expect(useAuthStore.getState().token).toBe("abc");
+  });
+
+  it("clearToken removes token", () => {
+    useAuthStore.setState({
+      token: "xyz",
+      setToken: useAuthStore.getState().setToken,
+      clearToken: useAuthStore.getState().clearToken,
+    });
+    act(() => {
+      useAuthStore.getState().clearToken();
+    });
+    expect(useAuthStore.getState().token).toBeNull();
+  });
+});

--- a/frontend/src/store/__tests__/baseStore.test.ts
+++ b/frontend/src/store/__tests__/baseStore.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act } from "react-dom/test-utils";
+import { createBaseStore, withLoading, BaseState } from "../baseStore";
+
+type CounterActions = {
+  increment: () => void;
+  incrementAsync: () => Promise<void>;
+  failAsync: () => Promise<void>;
+};
+
+interface CounterState extends BaseState, CounterActions {
+  count: number;
+}
+
+const useCounterStore = createBaseStore<CounterState, CounterActions>(
+  { count: 0 },
+  (set, get) => ({
+    increment: () => set({ count: get().count + 1 }),
+    incrementAsync: () =>
+      withLoading(set, async () => {
+        set({ count: get().count + 1 });
+      }),
+    failAsync: () =>
+      withLoading(set, async () => {
+        throw new Error("fail");
+      }),
+  }),
+  { name: "counter", persist: false },
+);
+
+describe("baseStore", () => {
+  beforeEach(() => {
+    useCounterStore.setState({
+      count: 0,
+      loading: false,
+      error: null,
+      clearError: useCounterStore.getState().clearError,
+      increment: useCounterStore.getState().increment,
+      incrementAsync: useCounterStore.getState().incrementAsync,
+      failAsync: useCounterStore.getState().failAsync,
+    });
+  });
+
+  it("increment updates count", () => {
+    act(() => {
+      useCounterStore.getState().increment();
+    });
+    expect(useCounterStore.getState().count).toBe(1);
+  });
+
+  it("incrementAsync sets loading and updates count", async () => {
+    await act(async () => {
+      await useCounterStore.getState().incrementAsync();
+    });
+    expect(useCounterStore.getState().count).toBe(1);
+    expect(useCounterStore.getState().loading).toBe(false);
+  });
+
+  it("failAsync sets error state", async () => {
+    await expect(
+      act(async () => {
+        await useCounterStore.getState().failAsync();
+      }),
+    ).rejects.toThrow("fail");
+    expect(useCounterStore.getState().error).toBe("fail");
+    expect(useCounterStore.getState().loading).toBe(false);
+  });
+
+  it("clearError resets error", () => {
+    useCounterStore.setState({ error: "oops" });
+    act(() => {
+      useCounterStore.getState().clearError();
+    });
+    expect(useCounterStore.getState().error).toBeNull();
+  });
+});

--- a/frontend/src/store/__tests__/projectStore.test.ts
+++ b/frontend/src/store/__tests__/projectStore.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { act } from 'react-dom/test-utils'
 import { useProjectStore } from '../projectStore'
 import { useTaskStore } from '../taskStore'
 import * as api from '@/services/api'
@@ -32,7 +33,9 @@ describe('projectStore', () => {
     const projects = [{ id: 'p1', name: 'Project 1', created_at: '2024-01-01' }]
     mockedApi.getProjects.mockResolvedValueOnce(projects)
 
-    await useProjectStore.getState().fetchProjects()
+    await act(async () => {
+      await useProjectStore.getState().fetchProjects()
+    })
 
     expect(mockedApi.getProjects).toHaveBeenCalled()
     expect(useProjectStore.getState().projects).toEqual(projects)
@@ -44,7 +47,9 @@ describe('projectStore', () => {
     useProjectStore.setState({ ...initialState, projects: [{ id: 'p1', name: 'Project 1', created_at: '2024-01-01' }] } as any)
     mockedApi.deleteProject.mockResolvedValueOnce({} as any)
 
-    await useProjectStore.getState().removeProject('p1')
+    await act(async () => {
+      await useProjectStore.getState().removeProject('p1')
+    })
 
     expect(mockedApi.deleteProject).toHaveBeenCalledWith('p1')
     expect(removeTasksMock).toHaveBeenCalledWith('p1')

--- a/frontend/src/store/__tests__/taskStore.test.ts
+++ b/frontend/src/store/__tests__/taskStore.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { act } from 'react-dom/test-utils'
 import { useTaskStore } from '../taskStore'
 import * as api from '@/services/api'
 import { TaskStatus } from '@/types/task'
@@ -48,7 +49,9 @@ describe('taskStore', () => {
     const tasks = [{ project_id: 'p1', task_number: 1, title: 'T1', status: TaskStatus.TO_DO, created_at: '2024' }]
     mockedApi.getAllTasks.mockResolvedValueOnce(tasks)
 
-    await useTaskStore.getState().fetchTasks()
+    await act(async () => {
+      await useTaskStore.getState().fetchTasks()
+    })
 
     expect(mockedApi.getAllTasks).toHaveBeenCalled()
     expect(useTaskStore.getState().tasks).toEqual(tasks)
@@ -60,7 +63,9 @@ describe('taskStore', () => {
     mockedApi.getProjects.mockResolvedValueOnce([])
     mockedApi.getAgents.mockResolvedValueOnce([])
 
-    await useTaskStore.getState().addTask({ project_id: 'p1', title: 'New' } as any)
+    await act(async () => {
+      await useTaskStore.getState().addTask({ project_id: 'p1', title: 'New' } as any)
+    })
 
     expect(mockedApi.createTask).toHaveBeenCalledWith('p1', { project_id: 'p1', title: 'New' })
     expect(useTaskStore.getState().tasks[0]).toEqual(newTask)


### PR DESCRIPTION
## Summary
- add tests for authStore and baseStore
- wrap store tests in act()

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d2ae16d8832c9375cd5d58f7cb62