### PR TITLE
feat(api): add typed error handling

### DIFF
--- a/frontend/src/services/api/request.ts
+++ b/frontend/src/services/api/request.ts
@@ -1,5 +1,18 @@
 import { StatusID } from "@/lib/statusUtils";
 
+/** Error type thrown when API requests fail */
+export class ApiError extends Error {
+  status: number;
+  url: string;
+
+  constructor(message: string, status: number, url: string) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.url = url;
+  }
+}
+
 // Helper to normalize status string to a known StatusID (now simplified since formats match)
 export const normalizeToStatusID = (
   backendStatus: string | null | undefined,
@@ -10,11 +23,18 @@ export const normalizeToStatusID = (
   }
   if (backendStatus) {
     // Direct mapping since frontend and backend now use the same format
-    const validStatuses: StatusID[] = ["To Do", "In Progress", "In Review", "Completed", "Blocked", "Cancelled"];
+    const validStatuses: StatusID[] = [
+      "To Do",
+      "In Progress",
+      "In Review",
+      "Completed",
+      "Blocked",
+      "Cancelled",
+    ];
     if (validStatuses.includes(backendStatus as StatusID)) {
       return backendStatus as StatusID;
     }
-    
+
     // Fallback for unknown status strings
     console.warn(
       `Unknown backend status string: "${backendStatus}". Defaulting to "To Do".`,
@@ -40,10 +60,16 @@ export async function request<T>(
     (headers as Record<string, string>)["Content-Type"] = "application/json";
   }
 
-  const response = await fetch(url, {
-    ...options,
-    headers, // Use the modified headers object
-  });
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      ...options,
+      headers, // Use the modified headers object
+    });
+  } catch (err) {
+    throw new ApiError((err as Error).message || "Network Error", 0, url);
+  }
+
   if (!response.ok) {
     console.error(`API request failed for URL: ${url}`, {
       status: response.status,
@@ -65,22 +91,26 @@ export async function request<T>(
       console.warn(`Failed to parse error response as JSON for URL: ${url}`, e);
       errorDetail = response.statusText || errorDetail;
     }
-    throw new Error(errorDetail);
+    throw new ApiError(errorDetail, response.status, url);
   }
   // For DELETE requests, backend might return the deleted object or no content
   if (response.status === 204) {
     return null as T; // Or handle as needed, maybe a specific type for no content
   }
-  
+
   const responseData = await response.json();
-  
+
   // Handle standardized backend response formats
   // Check if this is a DataResponse<T> or ListResponse<T> wrapper
-  if (responseData && typeof responseData === 'object' && 'data' in responseData) {
+  if (
+    responseData &&
+    typeof responseData === "object" &&
+    "data" in responseData
+  ) {
     // This is a wrapped response from the backend
     return responseData.data as T;
   }
-  
+
   // For backwards compatibility, return the raw response if it's not wrapped
   return responseData as T;
 }

--- a/frontend/src/store/__tests__/apiError.test.ts
+++ b/frontend/src/store/__tests__/apiError.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { request, ApiError } from "@/services/api/request";
+import { getTasks } from "@/services/api/tasks";
+import { server } from "@/__tests__/mocks/server";
+import { http, HttpResponse } from "msw";
+
+const API_URL = "http://localhost:8000/api/projects/project-1/tasks";
+
+describe("ApiError handling", () => {
+  it("request throws ApiError for non-ok response", async () => {
+    server.use(
+      http.get(API_URL, () =>
+        HttpResponse.json({ detail: "Not found" }, { status: 404 }),
+      ),
+    );
+
+    await expect(request(API_URL)).rejects.toMatchObject({
+      message: "Not found",
+      status: 404,
+      url: API_URL,
+    });
+  });
+
+  it("request wraps network errors in ApiError", async () => {
+    server.use(
+      http.get(API_URL, () => {
+        throw new Error("Network fail");
+      }),
+    );
+
+    await expect(request(API_URL)).rejects.toBeInstanceOf(ApiError);
+  });
+
+  it("service functions propagate ApiError", async () => {
+    server.use(
+      http.get(API_URL, () =>
+        HttpResponse.json({ detail: "Server boom" }, { status: 500 }),
+      ),
+    );
+
+    await expect(getTasks("project-1")).rejects.toBeInstanceOf(ApiError);
+  });
+});


### PR DESCRIPTION
## Summary
- add `ApiError` class and throw it from `request`
- add tests for `ApiError` handling

## Testing
- `npx vitest run src/store/__tests__/apiError.test.ts`
- `npx eslint src/services/api/request.ts src/store/__tests__/apiError.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6840d2adae24832c81aec0700e30721b