### PR TITLE
Add basic CLI tests

### DIFF
--- a/tests/cli/help.test.js
+++ b/tests/cli/help.test.js
@@ -1,0 +1,12 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const cliPath = path.resolve('cli.js');
+
+test('cli.js --help displays help information', () => {
+  const result = spawnSync('node', [cliPath, '--help'], { encoding: 'utf8' });
+  assert.strictEqual(result.status, 0, 'expected exit code 0');
+  assert.ok(result.stdout.length > 0, 'stdout should not be empty');
+});


### PR DESCRIPTION
## Summary
- add Node test checking `node cli.js --help`

## Testing
- `node --test tests/cli/help.test.js` *(fails: expected exit code 0)*

------
https://chatgpt.com/codex/tasks/task_e_6840d2a7af58832c8139b8737cf5aa43