### PR TITLE
Add pip cache to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-          cache: 'pip'
-          cache-dependency-path: backend/requirements.txt
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('backend/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- update the CI workflow to use actions/cache for pip

## Testing
- `flake8 .` *(fails: many existing lint errors)*
- `pytest -q`
- `npm test` *(fails: 6 failing tests)*
- `npm run lint`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6840d2a294f0832c9c159513c8a33ca5