### PR TITLE
feat(theme): add typography tokens

### DIFF
--- a/frontend/DESIGN_TOKENS.md
+++ b/frontend/DESIGN_TOKENS.md
@@ -1,6 +1,6 @@
 # Design Token System Documentation
 
-This document outlines the structure and usage of the design tokens for this project. The **single source of truth (SSOT)** for all design tokens is the TypeScript files: `frontend/src/tokens/colors.ts`, `frontend/src/tokens/sizing.ts`, `frontend/src/tokens/typography.ts`, and `frontend/src/tokens/index.ts`.
+This document outlines the structure and usage of the design tokens for this project. The **single source of truth (SSOT)** for all design tokens is the TypeScript files: `frontend/src/tokens/colors.ts`, `frontend/src/tokens/sizing.ts`, `frontend/src/tokens/fontFamily.ts`, `frontend/src/tokens/fontSize.ts`, `frontend/src/tokens/typography.ts`, and `frontend/src/tokens/index.ts`.
 
 ## Philosophy
 

--- a/frontend/src/theme/chakra-theme.ts
+++ b/frontend/src/theme/chakra-theme.ts
@@ -2,6 +2,8 @@ import { extendTheme, type ThemeConfig } from "@chakra-ui/react";
 import {
   colorPrimitives,
   semanticColors as appSemanticColors, // Rename to avoid conflict with Chakra's theme structure
+  fontFamily,
+  fontSize,
   typography,
   sizing,
 } from "../tokens"; // Assuming this path is correct relative to chakra-theme.ts
@@ -60,11 +62,11 @@ const customTheme = extendTheme({
     },
   },
   fonts: {
-    heading: typography.fontFamily.heading.join(", "),
-    body: typography.fontFamily.sans.join(", "),
-    mono: typography.fontFamily.mono.join(", "),
+    heading: fontFamily.heading.join(", "),
+    body: fontFamily.sans.join(", "),
+    mono: fontFamily.mono.join(", "),
   },
-  fontSizes: typography.fontSize,
+  fontSizes: fontSize,
   fontWeights: typography.fontWeight,
   lineHeights: typography.lineHeight,
   space: sizing.spacing,

--- a/frontend/src/tokens/README.md
+++ b/frontend/src/tokens/README.md
@@ -5,7 +5,9 @@ This directory contains the definition of design tokens used throughout the fron
 Key files:
 
 *   `colors.ts`: Defines the color palette.
-*   `typography.ts`: Defines font sizes, weights, line heights, etc.
+*   `fontFamily.ts`: Defines the application's font family stacks.
+*   `fontSize.ts`: Defines the font size scale.
+*   `typography.ts`: Aggregates typography tokens like font families, sizes, weights, and line heights.
 *   `spacing.ts`: Defines the spacing scale (padding, margin, gaps).
 *   `sizing.ts`: Defines size values for components and elements.
 *   `breakpoints.ts`: Defines screen breakpoints for responsive design.
@@ -32,6 +34,8 @@ graph TD
 - `blur.ts`
 - `breakpoints.ts`
 - `colors.ts`
+- `fontFamily.ts`
+- `fontSize.ts`
 - `index.ts`
 - `opacity.ts`
 - `shadows.ts`

--- a/frontend/src/tokens/fontFamily.ts
+++ b/frontend/src/tokens/fontFamily.ts
@@ -1,0 +1,38 @@
+export const fontFamily = {
+  sans: [
+    "Geist Sans",
+    "-apple-system",
+    "BlinkMacSystemFont",
+    "Segoe UI",
+    "Roboto",
+    "Helvetica Neue",
+    "Arial",
+    "Noto Sans",
+    "sans-serif",
+    "Apple Color Emoji",
+    "Segoe UI Emoji",
+    "Segoe UI Symbol",
+    "Noto Color Emoji",
+  ],
+  heading: [
+    "Geist Sans",
+    "-apple-system",
+    "BlinkMacSystemFont",
+    "Segoe UI",
+    "Roboto",
+    "Helvetica Neue",
+    "Arial",
+    "Noto Sans",
+    "sans-serif",
+  ],
+  mono: [
+    "Menlo",
+    "Monaco",
+    "Consolas",
+    "Liberation Mono",
+    "Courier New",
+    "monospace",
+  ],
+};
+
+export type FontFamily = typeof fontFamily;

--- a/frontend/src/tokens/fontSize.ts
+++ b/frontend/src/tokens/fontSize.ts
@@ -1,0 +1,20 @@
+export const fontSize = {
+  xs: "0.75rem",
+  sm: "0.875rem",
+  base: "1rem",
+  md: "1rem",
+  lg: "1.125rem",
+  xl: "1.25rem",
+  h6: "1.25rem",
+  h5: "1.5rem",
+  h4: "1.875rem",
+  h3: "2.25rem",
+  h2: "3rem",
+  h1: "3.75rem",
+  display1: "4.5rem",
+  display2: "6rem",
+  caption: "0.75rem",
+  button: "0.875rem",
+};
+
+export type FontSize = typeof fontSize;

--- a/frontend/src/tokens/index.ts
+++ b/frontend/src/tokens/index.ts
@@ -1,4 +1,6 @@
 export * from "./colors";
+export * from "./fontFamily";
+export * from "./fontSize";
 export * from "./typography";
 export * from "./sizing";
 export * from "./shadows";
@@ -9,6 +11,8 @@ export * from "./opacity";
 export * from "./blur";
 
 import { colorPrimitives, semanticColors } from "./colors";
+import { fontFamily } from "./fontFamily";
+import { fontSize } from "./fontSize";
 import { typography } from "./typography";
 import { sizing } from "./sizing";
 import { shadows } from "./shadows";
@@ -20,6 +24,8 @@ import { blur } from "./blur";
 
 export const tokens = {
   colors: { ...colorPrimitives, ...semanticColors },
+  fontFamily,
+  fontSize,
   typography,
   sizing,
   shadows,

--- a/frontend/src/tokens/typography.ts
+++ b/frontend/src/tokens/typography.ts
@@ -1,58 +1,7 @@
-export const fontFamily = {
-  sans: [
-    "Geist Sans",
-    "-apple-system",
-    "BlinkMacSystemFont",
-    "Segoe UI",
-    "Roboto",
-    "Helvetica Neue",
-    "Arial",
-    "Noto Sans",
-    "sans-serif",
-    "Apple Color Emoji",
-    "Segoe UI Emoji",
-    "Segoe UI Symbol",
-    "Noto Color Emoji",
-  ],
-  heading: [
-    "Geist Sans",
-    "-apple-system",
-    "BlinkMacSystemFont",
-    "Segoe UI",
-    "Roboto",
-    "Helvetica Neue",
-    "Arial",
-    "Noto Sans",
-    "sans-serif",
-  ],
-  mono: [
-    "Menlo",
-    "Monaco",
-    "Consolas",
-    "Liberation Mono",
-    "Courier New",
-    "monospace",
-  ],
-};
+import { fontFamily } from "./fontFamily";
+import { fontSize } from "./fontSize";
 
-export const fontSize = {
-  xs: "0.75rem",
-  sm: "0.875rem",
-  base: "1rem",
-  md: "1rem",
-  lg: "1.125rem",
-  xl: "1.25rem",
-  h6: "1.25rem",
-  h5: "1.5rem",
-  h4: "1.875rem",
-  h3: "2.25rem",
-  h2: "3rem",
-  h1: "3.75rem",
-  display1: "4.5rem",
-  display2: "6rem",
-  caption: "0.75rem",
-  button: "0.875rem",
-};
+export { fontFamily, fontSize };
 
 export const fontWeight = {
   light: "300",


### PR DESCRIPTION
## Summary
- add `fontFamily` and `fontSize` token files
- export new tokens and update Chakra theme usage
- document new tokens in README and DESIGN_TOKENS

## Testing
- `npm run lint`
- `npm run test:run` *(fails: 6 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6840d29ed234832cb467970ea2eb6d3a