### PR TITLE
feat: add global error boundary

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import ChakraProviderWrapper from "@/providers/ChakraProviderWrapper";
 import ClientOnly from "@/components/ClientOnly";
+import ErrorBoundary from "@/components/ErrorBoundary";
 
 // Import Geist and Geist Mono fonts from next/font/google
 import { Geist, Geist_Mono } from "next/font/google";
@@ -56,7 +57,9 @@ export default function RootLayout({
     >
       <body suppressHydrationWarning>
         <ClientOnly>
-          <ChakraProviderWrapper>{children}</ChakraProviderWrapper>
+          <ErrorBoundary>
+            <ChakraProviderWrapper>{children}</ChakraProviderWrapper>
+          </ErrorBoundary>
         </ClientOnly>
       </body>
     </html>

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import React from "react";
+import { Box, Heading, Text } from "@chakra-ui/react";
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error("ErrorBoundary caught an error", error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return <>{this.props.fallback}</>;
+      }
+      return (
+        <Box role="alert" textAlign="center" p={6}>
+          <Heading size="md" mb={2}>
+            Something went wrong.
+          </Heading>
+          <Text>Try refreshing the page.</Text>
+        </Box>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/frontend/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/frontend/src/components/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@/__tests__/utils/test-utils';
+import ErrorBoundary from '../ErrorBoundary';
+
+const ProblemChild = () => {
+  throw new Error('Test error');
+};
+
+describe('ErrorBoundary', () => {
+  it('renders fallback UI when child throws', () => {
+    render(
+      <ErrorBoundary>
+        <ProblemChild />
+      </ErrorBoundary>
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('Something went wrong');
+  });
+});


### PR DESCRIPTION
## Summary
- add `ErrorBoundary` component to handle uncaught React errors
- wrap root layout with the error boundary
- test that the boundary renders fallback UI

## Testing
- `npx vitest --config vitest.boundary.config.mjs run src/components/__tests__/ErrorBoundary.test.tsx`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840d29e5ba0832c872c5157148a25a1