### PR TITLE
Refactor to enforce token usage

### DIFF
--- a/frontend/src/components/modals/AgentAssignmentModal.tsx
+++ b/frontend/src/components/modals/AgentAssignmentModal.tsx
@@ -12,6 +12,7 @@ import {
   ListItem,
   Spinner,
   Box,
+  Text,
 } from "@chakra-ui/react";
 import { Agent, Task } from "@/types";
 import { sizing } from "@/tokens";
@@ -61,7 +62,9 @@ const AgentAssignmentModal: React.FC<AgentAssignmentModalProps> = ({
                 justifyContent="space-between"
               >
                 <span>{agent.name}</span>
-                <span style={{ fontSize: '0.85em', color: '#888' }}>{agent.status || 'offline'}</span>
+                <Text fontSize="sm" color="textSecondary">
+                  {agent.status || 'offline'}
+                </Text>
               </ListItem>
             ))}
           </List>


### PR DESCRIPTION
## Summary
- replace a hardcoded hex color with a semantic token in `AgentAssignmentModal`

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6840d29d7718832cbb1e3b4df7326f89