### PR TITLE
chore: add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: setup-backend setup-frontend test lint dev
+
+setup-backend:
+	python -m venv backend/.venv
+	backend/.venv/bin/pip install -r backend/requirements.txt
+
+setup-frontend:
+	cd frontend && npm install
+
+# Run backend and frontend tests
+# Requires backend/.venv to be created first
+
+test:
+	cd backend && ../backend/.venv/bin/pytest -v
+	cd frontend && npm test
+
+# Lint Python and TypeScript code
+lint:
+	cd backend && ../backend/.venv/bin/flake8 .
+	cd frontend && npm run lint
+
+dev:
+	python start_system.py

--- a/README.md
+++ b/README.md
@@ -187,6 +187,17 @@ The frontend application will be available at `http://localhost:3000`.
 
 A `dev_launcher.bat` script is available in the project root. This batch file attempts to clear ports **8000** (for the backend) and **3000** (for the frontend), then starts the backend server with `uvicorn` and the frontend with `npm run dev` in separate command windows. Run it by double-clicking the file or executing `dev_launcher.bat` from the project root.
 
+### Makefile Shortcuts
+A `Makefile` in the project root provides handy commands:
+
+```bash
+make setup-backend   # create backend virtualenv and install deps
+make setup-frontend  # install frontend npm packages
+make test            # run backend and frontend tests
+make lint            # run flake8 and frontend eslint
+make dev             # launch backend and frontend together
+```
+
 
 ## How It Works
 


### PR DESCRIPTION
## Summary
- add Makefile for backend and frontend helpers
- document Makefile commands in README

## Testing
- `make setup-backend`
- `make setup-frontend`
- `make test` *(fails: Task Management Integration Tests)*
- `make lint` *(fails: flake8 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6840d299a1f0832cbab1d7872d6c4664