### PR TITLE
Add pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+- repo: https://github.com/pycqa/flake8
+  rev: 7.0.0
+  hooks:
+    - id: flake8
+      additional_dependencies: []
+      # run only on backend python files
+      files: ^backend/
+- repo: local
+  hooks:
+    - id: npm-lint
+      name: npm lint
+      entry: npm run lint --prefix frontend
+      language: system
+      pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+
+Thank you for taking the time to contribute to MCP Project Manager! Follow these steps to get your environment ready.
+
+## Install Dependencies
+
+1. **Python**
+   ```bash
+   cd backend
+   python3 -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+2. **Node.js**
+   ```bash
+   cd frontend
+   npm install
+   ```
+
+## Set Up Pre-commit Hooks
+
+This project uses [pre-commit](https://pre-commit.com/) to run linting checks automatically.
+
+1. Install `pre-commit`:
+   ```bash
+   pip install pre-commit
+   ```
+2. Install the hooks:
+   ```bash
+   pre-commit install
+   ```
+
+The hooks will run `flake8` on Python files and `npm run lint` for the frontend whenever you commit.


### PR DESCRIPTION
## Summary
- add pre-commit config running flake8 and `npm run lint`
- create CONTRIBUTING guide with setup steps

## Testing
- `flake8 .` *(fails: E501 and other errors)*
- `npm run lint` *(passes)*
- `npm test` *(fails: 6 failing tests)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6840d2965950832caaf97aad7a61dc5b