### PR TITLE
refactor(db): respect DATABASE_URL

### DIFF
--- a/SYSTEM_GUIDE.md
+++ b/SYSTEM_GUIDE.md
@@ -67,7 +67,7 @@ cd backend
 
 ### 🗄️ Database Management
 ```bash
-# Initialize database
+# Initialize database (uses `DATABASE_URL` from backend/.env)
 cd backend
 python init_db.py
 
@@ -156,7 +156,7 @@ python -m venv .venv
 .venv\Scripts\pip install -r requirements.txt
 
 # If database issues:
-python init_db.py
+python init_db.py  # reads DATABASE_URL from backend/.env
 ```
 
 ### Frontend Issues

--- a/backend/README.md
+++ b/backend/README.md
@@ -91,6 +91,9 @@ ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 DEBUG=True
 ```
+`DATABASE_URL` is read by `database.py` and `init_db.py`. Set it to a
+SQLAlchemy-compatible URL (e.g., a custom SQLite file path or PostgreSQL URI)
+to override the default `sql_app.db`.
 
 ### Database
 

--- a/backend/database.py
+++ b/backend/database.py
@@ -6,12 +6,25 @@ It also provides a dependency to get a database session.
 """
 
 import os
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
-from sqlalchemy.orm import declarative_base, sessionmaker, Session
+from pathlib import Path
+from dotenv import load_dotenv
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.orm import declarative_base, sessionmaker
 from sqlalchemy import create_engine
 
+# Load environment variables from backend/.env if present
+backend_dir = Path(__file__).resolve().parent
+env_path = backend_dir / ".env"
+load_dotenv(env_path)
+
 # Database URL
-DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite+aiosqlite:///./sql_app.db")
+DATABASE_URL = os.environ.get(
+    "DATABASE_URL", f"sqlite+aiosqlite:///{backend_dir / 'sql_app.db'}"
+)
 
 # For sync operations, convert the async URL to sync
 SYNC_DATABASE_URL = DATABASE_URL.replace("sqlite+aiosqlite://", "sqlite:///")
@@ -33,6 +46,8 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=sync_engine)
 Base = declarative_base()
 
 # Async dependency to get DB session
+
+
 async def get_db():
     async with AsyncSessionLocal() as db:
         try:
@@ -45,6 +60,8 @@ async def get_db():
             await db.close()
 
 # Sync dependency to get DB session
+
+
 def get_sync_db():
     db = SessionLocal()
     try:

--- a/backend/init_db.py
+++ b/backend/init_db.py
@@ -6,9 +6,14 @@ This script initializes the database with all required tables and basic data.
 
 import asyncio
 import sys
-from pathlib import Path  # Add the backend directory to the Python path
+from pathlib import Path
+from dotenv import load_dotenv
+
 backend_dir = Path(__file__).parent
 sys.path.insert(0, str(backend_dir))
+load_dotenv(backend_dir / ".env")
+
+from database import Base, engine
 
 from sqlalchemy.orm import Session
 from sqlalchemy import text


### PR DESCRIPTION
## Summary
- load `.env` automatically in `database.py`
- load `.env` and import database engine in `init_db.py`
- document DATABASE_URL handling

## Testing
- `flake8 database.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6840d294f96c832c8215f41bff63a1f1