### PR TITLE
Add Node version check to CLI

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+const [major] = process.versions.node.split('.').map(Number);
+if (major < 18) {
+  console.error(`Node.js 18 or higher is required. Current version: ${process.version}`);
+  process.exit(1);
+}
+
+require('./dev_launcher.js');
+


### PR DESCRIPTION
## Summary
- add missing `cli.js`
- enforce Node 18+ requirement before running dev launcher

## Testing
- `npm run lint:frontend` *(fails: Cannot find module '@eslint/eslintrc')*
- `pytest backend/tests/test_simple.py -q` *(fails: cannot import name 'field_validator' from 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6840d29134e4832cb9ef9de75a6fb1f0