### PR TITLE
feat(frontend): add 404 page

### DIFF
--- a/frontend/src/__tests__/integration/not-found.test.tsx
+++ b/frontend/src/__tests__/integration/not-found.test.tsx
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@/__tests__/utils/test-utils';
+import NotFound from '@/app/not-found';
+
+describe('NotFound page', () => {
+  it('renders message and home link', () => {
+    render(<NotFound />);
+    expect(screen.getByText(/page not found/i)).toBeInTheDocument();
+    const link = screen.getByRole('button', { name: /go home/i });
+    expect(link).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/README.md
+++ b/frontend/src/app/README.md
@@ -48,7 +48,9 @@ This directory is the core of the Next.js application, utilizing the App Router.
 
 - **Purpose**: The icon file used by browsers for bookmarks, tabs, etc. This is the standard ICO format.
 
-_Note: Attempts to read `loading.tsx`, `not-found.tsx`, and `global.error.tsx` (which were present in a previous directory listing) were unsuccessful. Standard Next.js conventions would apply if these files were present and functional, but they are not in the current directory structure observed._
+### `not-found.tsx`
+
+- **Purpose**: Handles 404 errors by showing a friendly message and link back to the home page.
 
 ## 🎨 Theming Architecture & Best Practices
 
@@ -134,5 +136,6 @@ graph TD
 - `globals.css`
 - `layout.tsx`
 - `page.tsx`
+- `not-found.tsx`
 
 <!-- File List End -->

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { Button, Flex, Heading, Text } from "@chakra-ui/react";
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <Flex direction="column" align="center" justify="center" minH="100vh" gap={6}>
+      <Heading as="h1" size="lg">
+        404 - Page Not Found
+      </Heading>
+      <Text>Sorry, the page you are looking for does not exist.</Text>
+      <Button as={Link} href="/" colorScheme="blue">
+        Go Home
+      </Button>
+    </Flex>
+  );
+}


### PR DESCRIPTION
## Summary
- add `not-found.tsx` for 404 handling
- document the new 404 page in the app README
- test that the 404 page renders

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d28d6ce4832c88450ed4e4d264d0