### PR TITLE
docs: add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing Guide
+
+Thank you for taking the time to contribute to **MCP Project Manager**! This project follows a few conventions to keep the codebase consistent and reliable.
+
+## Coding Standards
+
+- Use the existing patterns in the repository. For the frontend run `npm run fix` and `npm run format` before committing.
+- For backend changes run `flake8` and fix issues using the provided scripts. Keep code self-explanatory and avoid unused imports.
+
+## Commit Style
+
+- Use [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`) with short imperative messages.
+- Reference related issues or tickets when applicable.
+
+## Test Requirements
+
+Before opening a pull request:
+
+1. Run the frontend linter and tests:
+   ```bash
+   cd frontend
+   npm run lint
+   npm test
+   ```
+2. Run backend tests:
+   ```bash
+   cd backend
+   pytest
+   ```
+
+All tests and linters should pass locally prior to submitting a PR.

--- a/README.md
+++ b/README.md
@@ -287,6 +287,10 @@ python final_integration.py --mode all
 
 ISC
 
+## Contributing
+
+Please read our [CONTRIBUTING.md](CONTRIBUTING.md) for coding standards, commit guidelines, and test requirements.
+
 ## Directory Contents Overview
 
 This is the root directory of the MCP Project Manager Suite. It contains top-level configuration files, build scripts, documentation, and the main entry points for the backend and frontend applications.


### PR DESCRIPTION
## Summary
- add a CONTRIBUTING guide
- link it from the README

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot read properties of undefined)*
- `pytest tests/test_simple.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6840d28412c8832cbe8fe0586f2ffe3b