### PR TITLE
chore: clean utils example code

### DIFF
--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -19,16 +19,6 @@ export const formatDisplayName = (name?: string | null): string => {
   return capitalizedWords.join(" ").trim();
 };
 
-// Example usage (can be removed or kept for testing)
-/*
-console.log(formatDisplayName("my_project_name")); // My Project Name
-console.log(formatDisplayName("another-agent-name")); // Another Agent Name
-console.log(formatDisplayName("SingleWord"));      // Singleword (Note: Could be improved to handle camelCase better if needed)
-console.log(formatDisplayName("  leading space  ")); // Leading Space
-console.log(formatDisplayName(null));                 // Unnamed
-console.log(formatDisplayName(""));                   // Unnamed
-*/
-
 export const mapStatusToStatusID = (
   status: string | null | undefined,
 ): CanonicalStatusID => {


### PR DESCRIPTION
## Summary
- remove dead commented example block from utils

## Testing
- `npm run lint`
- `npx prettier src/lib/utils.ts --write`
- `npm test` *(fails: Cannot read properties of undefined)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_6840d2819d68832cac598917f1c7f8bb