### PR TITLE
Add ingestion retrieval tests

### DIFF
--- a/backend/tests/test_memory_ingestion.py
+++ b/backend/tests/test_memory_ingestion.py
@@ -1,0 +1,65 @@
+from unittest.mock import MagicMock, patch
+from datetime import datetime, timezone
+
+import pytest
+
+from backend.services.memory_service import MemoryService
+from backend.schemas.memory import MemoryEntity
+
+
+@pytest.fixture
+def memory_service():
+    session = MagicMock()
+    service = MemoryService(session)
+    storage = {}
+
+    def fake_create_entity(entity_data):
+        entity = MemoryEntity(
+            id=len(storage) + 1,
+            entity_type=entity_data.entity_type,
+            content=entity_data.content,
+            entity_metadata=entity_data.entity_metadata,
+            source=entity_data.source,
+            source_metadata=entity_data.source_metadata,
+            created_by_user_id=entity_data.created_by_user_id,
+            created_at=datetime.now(timezone.utc),
+            updated_at=None,
+        )
+        storage[entity.id] = entity
+        return entity
+
+    def fake_get_entity(entity_id):
+        return storage.get(entity_id)
+
+    service.create_entity = MagicMock(side_effect=fake_create_entity)
+    service.get_entity = MagicMock(side_effect=fake_get_entity)
+    return service
+
+
+def test_ingest_text_and_retrieve(memory_service):
+    entity = memory_service.ingest_text("hello world", user_id="u1")
+
+    assert entity.content == "hello world"
+    assert memory_service.get_entity(entity.id) == entity
+
+
+@patch("backend.services.memory_service.httpx.get")
+def test_ingest_url_and_retrieve(mock_get, memory_service):
+    mock_get.return_value.text = "from web"
+    mock_get.return_value.status_code = 200
+
+    entity = memory_service.ingest_url("http://example.com", user_id="u2")
+
+    mock_get.assert_called_once_with("http://example.com")
+    assert entity.content == "from web"
+    assert memory_service.get_entity(entity.id) == entity
+
+
+def test_ingest_file_and_retrieve(tmp_path, memory_service):
+    f = tmp_path / "sample.txt"
+    f.write_text("file content", encoding="utf-8")
+
+    entity = memory_service.ingest_file(str(f), user_id="u3")
+
+    assert entity.content == "file content"
+    assert memory_service.get_entity(entity.id) == entity


### PR DESCRIPTION
## Summary
- add `test_memory_ingestion.py` for file, URL and text ingestion
- verify retrieval by ID after ingest

## Testing
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6840d27f4a0c832cbb4829375e95ba07