### PR TITLE
Add memory ingestion endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ project-manager/
     *   Provides a centralized, database-backed store for structured information.
     *   Enables agents and potentially human users to store, retrieve, and relate entities, observations, and facts.
     *   Powers enhanced contextual understanding and persistent memory for agents.
+    *   Offers `/api/memory/ingest-url` and `/api/memory/ingest-text` endpoints
+        to capture web pages and raw text snippets directly into the memory graph.
 *   **Unified Interface:** Modern WebGUI (Next.js/Chakra UI) for human interaction, monitoring, and guidance.
 *   **Comprehensive Task Management:** Create, view, update, delete, assign, archive, and unarchive tasks and subtasks.
 *   **Project Organization:** Group tasks into projects with descriptions and statuses.

--- a/backend/routers/memory/__init__.py
+++ b/backend/routers/memory/__init__.py
@@ -1,5 +1,50 @@
-from fastapi import APIRouter
-from .core.core import router as core_router
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from ...database import get_sync_db as get_db
+from ...services.memory_service import MemoryService
+from ...schemas.memory import MemoryEntity
+from ...auth import get_current_active_user
+from ...models import User as UserModel
+from .core.core import (
+    router as core_router,
+    UrlIngestInput,
+    TextIngestInput,
+)
 
 router = APIRouter()
 router.include_router(core_router)
+
+
+def get_memory_service(db: Session = Depends(get_db)) -> MemoryService:
+    return MemoryService(db)
+
+
+@router.post("/ingest-url", response_model=MemoryEntity, status_code=status.HTTP_201_CREATED)
+def ingest_url_root(
+    ingest_input: UrlIngestInput,
+    memory_service: MemoryService = Depends(get_memory_service),
+    current_user: UserModel = Depends(get_current_active_user),
+):
+    """Ingest content directly from a URL."""
+    try:
+        return memory_service.ingest_url(url=ingest_input.url, user_id=current_user.id)
+    except Exception as e:  # pragma: no cover - pass through any service errors
+        raise HTTPException(status_code=500, detail=f"Failed to ingest url: {e}")
+
+
+@router.post("/ingest-text", response_model=MemoryEntity, status_code=status.HTTP_201_CREATED)
+def ingest_text_root(
+    ingest_input: TextIngestInput,
+    memory_service: MemoryService = Depends(get_memory_service),
+    current_user: UserModel = Depends(get_current_active_user),
+):
+    """Store a raw text snippet as a MemoryEntity."""
+    try:
+        return memory_service.ingest_text(
+            text=ingest_input.text,
+            user_id=current_user.id,
+            metadata=ingest_input.metadata,
+        )
+    except Exception as e:  # pragma: no cover - pass through any service errors
+        raise HTTPException(status_code=500, detail=f"Failed to ingest text: {e}")


### PR DESCRIPTION
## Summary
- extend Memory router with `/ingest-url` and `/ingest-text` endpoints
- allow ingesting URLs and text in MemoryService
- document new ingestion endpoints in README
- test new endpoints

## Testing
- `pytest tests/test_memory_endpoints.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6840d27eb514832caf4a420129a162b3