### PR TITLE
refactor(task): tidy icon map prop

### DIFF
--- a/frontend/src/components/common/README.md
+++ b/frontend/src/components/common/README.md
@@ -102,6 +102,7 @@ Key files:
 *   `TaskActionsMenu.tsx`: Menu for task-specific actions.
 *   `TaskTitleEditor.tsx`: Inline editor for task titles.
 *   `TaskStatusTag.tsx`: Component to display task status.
+*   `iconMap.ts`: Provides `defaultIconMap` and `IconMap` used for status icons.
 *   `TaskProjectTag.tsx`: Component to display associated project.
 *   `TaskDescriptionEditor.tsx`: Inline editor for task descriptions.
 *   `FilterPanel.tsx`: Panel containing filter controls (likely used within `FilterSidebar`).
@@ -132,5 +133,6 @@ graph TD
 - `TaskProjectTag.tsx`
 - `TaskStatusTag.tsx`
 - `TaskTitleEditor.tsx`
+- `iconMap.ts`
 
 <!-- File List End -->

--- a/frontend/src/components/common/TaskStatusTag.tsx
+++ b/frontend/src/components/common/TaskStatusTag.tsx
@@ -1,12 +1,21 @@
 import React from "react";
 import { Tag, TagLabel, TagLeftIcon } from "@chakra-ui/react";
 import { getDisplayableStatus, StatusID } from "@/lib/statusUtils";
+import { IconMap, defaultIconMap } from "./iconMap";
 
+/**
+ * Props for {@link TaskStatusTag}. The optional {@link IconMap iconMap}
+ * allows consumers to supply custom icon components keyed by the string
+ * identifiers used in {@link getDisplayableStatus}.
+ */
 interface TaskStatusTagProps {
   statusId: StatusID;
   fontWeight?: string | number;
   fontSize?: string | number;
-  iconMap: Record<string, React.ElementType>;
+  /**
+   * Mapping from icon name to component. Defaults to {@link defaultIconMap}.
+   */
+  iconMap?: IconMap;
   style?: React.CSSProperties;
   bg: string;
   color: string;
@@ -16,7 +25,7 @@ const TaskStatusTag: React.FC<TaskStatusTagProps> = ({
   statusId,
   fontWeight,
   fontSize,
-  iconMap,
+  iconMap = defaultIconMap,
   style,
   bg,
   color,

--- a/frontend/src/components/common/iconMap.ts
+++ b/frontend/src/components/common/iconMap.ts
@@ -1,0 +1,48 @@
+import React from "react";
+import {
+  EditIcon,
+  TimeIcon,
+  ViewIcon,
+  WarningTwoIcon,
+  CheckCircleIcon,
+  CloseIcon,
+  InfoIcon,
+  InfoOutlineIcon,
+  CalendarIcon,
+  RepeatIcon,
+  RepeatClockIcon,
+  ArrowForwardIcon,
+  QuestionIcon,
+  QuestionOutlineIcon,
+  CheckIcon,
+  NotAllowedIcon,
+  SettingsIcon,
+} from "@chakra-ui/icons";
+
+/**
+ * Map of icon identifier strings (as returned by `getDisplayableStatus`)
+ * to Chakra UI icon components. Components rendering task status tags
+ * can use this mapping to translate icon names into actual components.
+ */
+export type IconMap = Record<string, React.ElementType>;
+
+/** Default mapping of known status icon names to Chakra icons. */
+export const defaultIconMap: IconMap = {
+  EditIcon,
+  TimeIcon,
+  ViewIcon,
+  WarningTwoIcon,
+  CheckCircleIcon,
+  CloseIcon,
+  InfoIcon,
+  InfoOutlineIcon,
+  CalendarIcon,
+  RepeatIcon,
+  RepeatClockIcon,
+  ArrowForwardIcon,
+  QuestionIcon,
+  QuestionOutlineIcon,
+  CheckIcon,
+  NotAllowedIcon,
+  SettingsIcon,
+};

--- a/frontend/src/components/task/TaskItem.tsx
+++ b/frontend/src/components/task/TaskItem.tsx
@@ -10,17 +10,7 @@ import {
   useToast,
   Button,
 } from "@chakra-ui/react";
-import {
-  EditIcon,
-  TimeIcon,
-  WarningTwoIcon,
-  CheckCircleIcon,
-  InfoOutlineIcon,
-  QuestionOutlineIcon,
-  CheckIcon,
-  NotAllowedIcon,
-  SettingsIcon, // Assuming ListOrderedIcon and RepeatClockIcon map to something like SettingsIcon or need specific imports
-} from "@chakra-ui/icons";
+import { defaultIconMap } from "../common/iconMap";
 import { useProjectStore } from "@/store/projectStore";
 import { useTaskStore } from "@/store/taskStore";
 import { getDisplayableStatus, StatusID, StatusAttributeObject } from "@/lib/statusUtils";
@@ -31,19 +21,8 @@ import TaskItemMainSection from "./TaskItemMainSection";
 import TaskItemModals from "../TaskItemModals";
 import { TaskStatus } from "@/types/task";
 
-// Define the iconMap
-const iconMap: Record<string, React.ElementType> = {
-  EditIcon: EditIcon,
-  TimeIcon: TimeIcon,
-  WarningTwoIcon: WarningTwoIcon,
-  CheckCircleIcon: CheckCircleIcon,
-  InfoOutlineIcon: InfoOutlineIcon,
-  ListOrderedIcon: SettingsIcon, // Placeholder, replace with actual icon if available
-  RepeatClockIcon: SettingsIcon, // Placeholder, replace with actual icon if available
-  QuestionOutlineIcon: QuestionOutlineIcon,
-  CheckIcon: CheckIcon,
-  NotAllowedIcon: NotAllowedIcon,
-};
+// Default mapping from status icon names to actual icon components.
+const iconMap = defaultIconMap;
 
 /**
  * @module TaskItem

--- a/frontend/src/components/task/TaskItemDetailsSection.tsx
+++ b/frontend/src/components/task/TaskItemDetailsSection.tsx
@@ -34,6 +34,7 @@ import TaskStatusTag from "../common/TaskStatusTag";
 import TaskProjectTag from "../common/TaskProjectTag";
 import TaskAgentTag from "../common/TaskAgentTag";
 import TaskDependencyTag from "../common/TaskDependencyTag";
+import { IconMap } from "../common/iconMap";
 import {
   Task,
   TaskFileAssociation,
@@ -67,8 +68,8 @@ interface TaskItemDetailsSectionProps {
   projectName?: string;
   /** Style object, typically from a custom hook like useTaskItemStyles. */
   styles: Record<string, unknown>; // Consider a more specific type
-  /** Optional: A map of status IDs to React ElementType for rendering status icons in TaskStatusTag. */
-  iconMap?: Record<string, React.ElementType>;
+  /** Optional: Icon mapping used by `TaskStatusTag` for status icons. */
+  iconMap?: IconMap;
   /** The current status ID of the task, used by TaskStatusTag. */
   currentStatusId: StatusID;
   /** If true, applies specific styling adjustments, like reduced margin-top. */

--- a/frontend/src/components/task/TaskItemMainSection.tsx
+++ b/frontend/src/components/task/TaskItemMainSection.tsx
@@ -6,6 +6,7 @@ import { inputStyle, textareaStyle } from "./TaskItem.styles";
 import { Task, TaskUpdateData } from "@/types/task"; // Assuming Task is ITask or similar
 import TaskItemDetailsSection from "./TaskItemDetailsSection";
 import { StatusID, StatusAttributeObject } from "@/lib/statusUtils";
+import { IconMap } from "../common/iconMap";
 
 
 /**
@@ -25,8 +26,8 @@ interface TaskItemMainSectionProps {
   styles: Record<string, unknown>; // Consider a more specific type if possible
   /** The color to use for text elements, determined by archiving status or other factors. */
   textColor: string;
-  /** A map of status IDs to React ElementType, for rendering status icons. */
-  iconMap: Record<string, React.ElementType>;
+  /** A map of icon names to components used by TaskStatusTag. */
+  iconMap: IconMap;
   /** The current status ID of the task. */
   currentStatusId: StatusID;
   /** If true, renders a more compact version of this section. */


### PR DESCRIPTION
## Summary
- centralize default icons and icon map type
- document icon map usage and defaults in `TaskStatusTag`
- update task components to use the shared map
- mention new file in README

## Testing
- `npm run lint`
- `npm run test` *(fails: Task Management Integration tests)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6840d27da088832c8142074326626371