### PR TITLE
Update cursor ignore list

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,1 +1,6 @@
 # Add directories or file patterns to ignore during indexing (e.g. foo/ or *.csv)
+
+backend/.venv/
+frontend/node_modules/
+coverage/
+*.db


### PR DESCRIPTION
## Summary
- ignore backend venv, node modules, coverage reports and *.db in `.cursorignore`

## Testing
- `npm run lint` in `frontend`
- `npm test` *(fails: 6 failed, 23 passed)*
- `pytest backend/tests/test_simple.py::test_addition -q` *(fails: ModuleNotFoundError)*


------
https://chatgpt.com/codex/tasks/task_e_6840d2789b20832cb545aff8f71a00f2