### PR TITLE
Add Prettier configuration

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "tabWidth": 2,
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "es5",
+  "printWidth": 80
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "build:all": "cd frontend && npm run build && cd .. && backend\\.venv\\Scripts\\python.exe -m pip install -r backend\\requirements.txt",
     "type-check": "npx tsc --noEmit",
     "fix": "cd frontend && npm run fix",
-    "format": "cd frontend && npm run format"
+    "format": "cd frontend && npm run format",
+    "prettier:check": "prettier --check .",
+    "prettier:write": "prettier --write ."
   },
   "keywords": [
     "project-management",


### PR DESCRIPTION
## Summary
- add `.prettierrc.json` with 2 space indentation and single quotes
- add `prettier:check` and `prettier:write` scripts in `package.json`

## Testing
- `npm run lint:frontend` *(fails: Cannot find module '@eslint/eslintrc')*
- `npm run test:backend` *(fails: .venvScripts pytest.exe not found)*
- `npm run prettier:check` *(fails with code style issues)*

------
https://chatgpt.com/codex/tasks/task_e_6840d2770b7c832c990c2a56111dcbcb