### PR TITLE
Add integration test for framework validator

### DIFF
--- a/frontend/src/__tests__/integration/README.md
+++ b/frontend/src/__tests__/integration/README.md
@@ -20,5 +20,6 @@ graph TD
 
 - `task-management.test.tsx`
 - `validate-frontend.test.ts`
+- `validate-testing-framework.test.ts`
 
 <!-- File List End -->

--- a/frontend/src/__tests__/integration/validate-testing-framework.test.ts
+++ b/frontend/src/__tests__/integration/validate-testing-framework.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+const repoRoot = path.resolve(__dirname, "../../../..");
+const script = path.join(repoRoot, "frontend", "validate-testing-framework.js");
+
+describe("validate-testing-framework.js", () => {
+  it("should fail in an empty workspace", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-test-"));
+    const result = spawnSync("node", [script], {
+      cwd: tmpDir,
+      encoding: "utf8",
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).toContain("TESTING FRAMEWORK VALIDATION SUMMARY");
+    expect(result.stdout).toContain("Validation error");
+  });
+});


### PR DESCRIPTION
## Summary
- add integration test for `validate-testing-framework.js`
- update README file list

## Testing
- `npm run fix` *(fails: Cannot find module '@eslint/eslintrc')*
- `npm run format`
- `npm --prefix frontend run test:integration` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d2756bf8832c9fa95c34d212e0f0