### PR TITLE
test(providers): validate context behavior

### DIFF
--- a/frontend/src/providers/__tests__/ChakraProviderWrapper.test.tsx
+++ b/frontend/src/providers/__tests__/ChakraProviderWrapper.test.tsx
@@ -1,68 +1,53 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
 import ChakraProviderWrapper from '../ChakraProviderWrapper';
+import { useTheme } from '../../contexts/ThemeContext';
+import { useColorMode } from '@chakra-ui/react';
 
-vi.mock('@chakra-ui/react', async () => {
-  const actual = await vi.importActual('@chakra-ui/react');
-  return {
-    ...actual,
-    useToast: () => vi.fn(),
-    useColorModeValue: (light: any, dark: any) => light,
-  };
-});
+const Consumer = () => {
+  const { theme, toggleTheme } = useTheme();
+  const { colorMode } = useColorMode();
+  return (
+    <div>
+      <span data-testid="theme">{theme}</span>
+      <span data-testid="colorMode">{colorMode}</span>
+      <button onClick={toggleTheme}>toggle</button>
+    </div>
+  );
+};
 
 describe('ChakraProviderWrapper', () => {
-  const user = userEvent.setup();
+  it('applies stored theme on mount and syncs color mode', () => {
+    localStorage.setItem('theme', 'dark');
 
-  beforeEach(() => {
-    vi.clearAllMocks();
+    render(
+      <ChakraProviderWrapper>
+        <Consumer />
+      </ChakraProviderWrapper>
+    );
+
+    expect(screen.getByTestId('theme').textContent).toBe('dark');
+    expect(screen.getByTestId('colorMode').textContent).toBe('dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
   });
 
-  it('should render without crashing', () => {
-    render(
-      <TestWrapper>
-        <ChakraProviderWrapper />
-      </TestWrapper>
-    );
-    expect(document.body).toBeInTheDocument();
-  });
+  it('toggleTheme updates context and chakra color mode', async () => {
+    localStorage.setItem('theme', 'light');
+    const user = userEvent.setup();
 
-  it('should handle props correctly', () => {
-    const props = { 
-      testId: 'test-component',
-      'data-testid': 'test-component'
-    };
-    
     render(
-      <TestWrapper>
-        <ChakraProviderWrapper {...props} />
-      </TestWrapper>
+      <ChakraProviderWrapper>
+        <Consumer />
+      </ChakraProviderWrapper>
     );
-    
-    const component = screen.queryByTestId('test-component');
-    expect(component || document.body).toBeInTheDocument();
-  });
 
-  it('should handle user interactions', async () => {
-    render(
-      <TestWrapper>
-        <ChakraProviderWrapper />
-      </TestWrapper>
-    );
-    
-    const buttons = screen.queryAllByRole('button');
-    const inputs = screen.queryAllByRole('textbox');
-    
-    if (buttons.length > 0) {
-      await user.click(buttons[0]);
-    }
-    
-    if (inputs.length > 0) {
-      await user.type(inputs[0], 'test input');
-    }
-    
-    expect(document.body).toBeInTheDocument();
+    expect(screen.getByTestId('theme').textContent).toBe('light');
+
+    await user.click(screen.getByRole('button'));
+
+    expect(screen.getByTestId('theme').textContent).toBe('dark');
+    expect(screen.getByTestId('colorMode').textContent).toBe('dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
   });
 });

--- a/frontend/src/providers/__tests__/ModalProvider.test.tsx
+++ b/frontend/src/providers/__tests__/ModalProvider.test.tsx
@@ -1,68 +1,28 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
 import ModalProvider from '../ModalProvider';
+import Modal from 'react-modal';
 
-vi.mock('@chakra-ui/react', async () => {
-  const actual = await vi.importActual('@chakra-ui/react');
-  return {
-    ...actual,
-    useToast: () => vi.fn(),
-    useColorModeValue: (light: any, dark: any) => light,
-  };
-});
+vi.mock('react-modal', () => ({ default: { setAppElement: vi.fn() } }));
 
 describe('ModalProvider', () => {
-  const user = userEvent.setup();
+  it('sets react-modal app element on mount', () => {
+    render(
+      <ModalProvider>
+        <div />
+      </ModalProvider>
+    );
 
-  beforeEach(() => {
-    vi.clearAllMocks();
+    expect(Modal.setAppElement).toHaveBeenCalledWith(document.body);
   });
 
-  it('should render without crashing', () => {
+  it('renders children', () => {
     render(
-      <TestWrapper>
-        <ModalProvider />
-      </TestWrapper>
+      <ModalProvider>
+        <span data-testid="child">Child</span>
+      </ModalProvider>
     );
-    expect(document.body).toBeInTheDocument();
-  });
 
-  it('should handle props correctly', () => {
-    const props = { 
-      testId: 'test-component',
-      'data-testid': 'test-component'
-    };
-    
-    render(
-      <TestWrapper>
-        <ModalProvider {...props} />
-      </TestWrapper>
-    );
-    
-    const component = screen.queryByTestId('test-component');
-    expect(component || document.body).toBeInTheDocument();
-  });
-
-  it('should handle user interactions', async () => {
-    render(
-      <TestWrapper>
-        <ModalProvider />
-      </TestWrapper>
-    );
-    
-    const buttons = screen.queryAllByRole('button');
-    const inputs = screen.queryAllByRole('textbox');
-    
-    if (buttons.length > 0) {
-      await user.click(buttons[0]);
-    }
-    
-    if (inputs.length > 0) {
-      await user.type(inputs[0], 'test input');
-    }
-    
-    expect(document.body).toBeInTheDocument();
+    expect(screen.getByTestId('child')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- strengthen provider unit tests by checking context values and theme synchronization
- verify ModalProvider sets `react-modal` app element

## Testing
- `npm test src/providers/__tests__` *(fails: No test files found)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840d273dde0832cb2060b092b45c5bf