### PR TITLE
feat(hooks): implement useProjectData

### DIFF
--- a/frontend/src/hooks/__tests__/useProjectData.test.tsx
+++ b/frontend/src/hooks/__tests__/useProjectData.test.tsx
@@ -1,40 +1,52 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import userEvent from '@testing-library/user-event';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { useProjectData } from '../useProjectData';
+import * as api from '@/services/api';
+import { TaskStatus } from '@/types/task';
 
-vi.mock('@chakra-ui/react', async () => {
-  const actual = await vi.importActual('@chakra-ui/react');
-  return {
-    ...actual,
-    useToast: vi.fn(),
-    useColorModeValue: vi.fn((light: any, dark: any) => light),
-  };
-});
+vi.mock('@/services/api', () => ({
+  getProjectById: vi.fn(),
+  getAllTasksForProject: vi.fn(),
+  updateProject: vi.fn(),
+}));
+
+const mockedApi = vi.mocked(api as any);
 
 describe('useProjectData', () => {
-  const user = userEvent.setup();
-
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('should render without crashing', () => {
-    // This is a hook, not a component. Update test to use renderHook.
-    // renderHook(() => useProjectData());
+  it('loads project and tasks on mount', async () => {
+    const project = { id: 'p1', name: 'Project 1', created_at: '2024' } as any;
+    const tasks = [
+      { project_id: 'p1', task_number: 1, title: 'T1', status: TaskStatus.TO_DO, created_at: '2024' } as any,
+    ];
+    mockedApi.getProjectById.mockResolvedValueOnce(project);
+    mockedApi.getAllTasksForProject.mockResolvedValueOnce(tasks);
+
+    const { result } = renderHook(() => useProjectData('p1'));
+
+    await waitFor(() => expect(result.current.project).toEqual(project));
+    expect(result.current.tasks).toEqual(tasks);
+    expect(result.current.error).toBeNull();
   });
 
-  it('should handle props correctly', () => {
-    const props = { 
-      testId: 'test-component',
-      'data-testid': 'test-component'
-    };
-    
-    // This is a hook, not a component. Update test to use renderHook.
-    // renderHook(() => useProjectData(props));
-  });
+  it('updates project details', async () => {
+    const project = { id: 'p1', name: 'Project 1', created_at: '2024' } as any;
+    const updated = { ...project, name: 'Updated' };
+    mockedApi.getProjectById.mockResolvedValue(project);
+    mockedApi.getAllTasksForProject.mockResolvedValue([]);
+    mockedApi.updateProject.mockResolvedValue(updated);
 
-  it('should handle user interactions', async () => {
-    // This is a hook, not a component. Update test to use renderHook.
-    // renderHook(() => useProjectData());
+    const { result } = renderHook(() => useProjectData('p1'));
+    await waitFor(() => expect(result.current.project).toEqual(project));
+
+    await act(async () => {
+      await result.current.updateProjectDetails({ name: 'Updated' } as any);
+    });
+
+    expect(mockedApi.updateProject).toHaveBeenCalledWith('p1', { name: 'Updated' });
+    expect(result.current.project).toEqual(updated);
   });
 });

--- a/frontend/src/hooks/useProjectData.ts
+++ b/frontend/src/hooks/useProjectData.ts
@@ -1,3 +1,69 @@
-import { getProjectById, updateProject, getProjectTasks } from '../services/api';
-import { Project } from '../types';
-import { Task } from '../types'; 
+import { useState, useEffect, useCallback } from "react";
+import { getProjectById, updateProject, getAllTasksForProject } from "@/services/api";
+import { Project, ProjectUpdateData, Task } from "@/types";
+
+interface UseProjectDataResult {
+  project: Project | null;
+  tasks: Task[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+  updateProjectDetails: (data: ProjectUpdateData) => Promise<void>;
+}
+
+/**
+ * Fetch project details and its tasks.
+ * Provides helpers for refreshing data and updating the project.
+ */
+export const useProjectData = (projectId: string): UseProjectDataResult => {
+  const [project, setProject] = useState<Project | null>(null);
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    if (!projectId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const [proj, projTasks] = await Promise.all([
+        getProjectById(projectId),
+        getAllTasksForProject(projectId),
+      ]);
+      setProject(proj);
+      setTasks(projTasks);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to load project";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const updateProjectDetails = useCallback(
+    async (data: ProjectUpdateData) => {
+      if (!projectId) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const updated = await updateProject(projectId, data);
+        setProject(updated);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to update project";
+        setError(message);
+        throw err;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [projectId],
+  );
+
+  return { project, tasks, loading, error, refresh: fetchData, updateProjectDetails };
+};
+
+export default useProjectData;


### PR DESCRIPTION
## Summary
- add hook to fetch project details and tasks
- expose refresh and update methods
- test hook via `renderHook`

## Testing
- `npm run lint`
- `npm test` *(fails: Task Management Integration tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_6840d271b154832cb0e049d6aeaf77c0