### PR TITLE
refactor: remove pass-only schema classes

### DIFF
--- a/backend/schemas/task.py
+++ b/backend/schemas/task.py
@@ -120,4 +120,4 @@ class Task(TaskInDBBase):
     model_config = ConfigDict(from_attributes=True)
 
 class TaskInDB(TaskInDBBase):
-    pass
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/schemas/task_status.py
+++ b/backend/schemas/task_status.py
@@ -17,7 +17,7 @@ class TaskStatusBase(BaseModel):
 
 class TaskStatusCreate(TaskStatusBase):
     """Schema for creating a new task status."""
-    pass
+    model_config = ConfigDict(from_attributes=True)
 
 class TaskStatusUpdate(BaseModel):
     """Schema for updating an existing task status. All fields are optional."""

--- a/backend/schemas/workflow_step.py
+++ b/backend/schemas/workflow_step.py
@@ -20,7 +20,7 @@ class WorkflowStepBase(BaseModel):
 
 class WorkflowStepCreate(WorkflowStepBase):
     """Schema for creating a new workflow step."""
-    pass
+    model_config = ConfigDict(from_attributes=True)
 
 class WorkflowStepUpdate(BaseModel):
     """Schema for updating an existing workflow step."""


### PR DESCRIPTION
## Summary
- convert placeholder classes to real configs
- keep TaskInDB but add ConfigDict

## Testing
- `flake8 schemas`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d26f7950832cbde45395f6e7d73f