### PR TITLE
feat(auth): finalize login workflow

### DIFF
--- a/frontend/src/components/user/LoginForm.tsx
+++ b/frontend/src/components/user/LoginForm.tsx
@@ -8,7 +8,9 @@ import {
   Button,
   Heading,
   Text,
+  useToast,
 } from "@chakra-ui/react";
+import { useRouter } from "next/navigation";
 import { login } from "@/services/api/users";
 import { LoginRequest, TokenResponse } from "@/types/user";
 import { useAuthStore } from "@/store/authStore";
@@ -19,6 +21,8 @@ const LoginForm: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const setToken = useAuthStore((state) => state.setToken);
+  const toast = useToast();
+  const router = useRouter();
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -30,10 +34,19 @@ const LoginForm: React.FC = () => {
     try {
       const response: TokenResponse = await login(loginData);
       setToken(response.access_token);
-      alert("Login successful!");
+      localStorage.setItem("token", response.access_token);
+      router.push("/");
     } catch (err: any) {
       console.error("Login failed:", err);
-      setError(err.message || "An error occurred during login.");
+      const message = err.message || "An error occurred during login.";
+      setError(message);
+      toast({
+        title: "Login failed",
+        description: message,
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
     } finally {
       setIsLoading(false);
     }
@@ -42,7 +55,9 @@ const LoginForm: React.FC = () => {
   return (
     <Box p={8} maxWidth="500px" borderWidth={1} borderRadius={8} boxShadow="lg">
       <VStack spacing={4} as="form" onSubmit={handleSubmit}>
-        <Heading as="h2" size="xl">Login</Heading>
+        <Heading as="h2" size="xl">
+          Login
+        </Heading>
         <FormControl id="username">
           <FormLabel>Username</FormLabel>
           <Input
@@ -61,7 +76,13 @@ const LoginForm: React.FC = () => {
             required
           />
         </FormControl>
-        <Button type="submit" colorScheme="blue" size="lg" width="full" isLoading={isLoading}>
+        <Button
+          type="submit"
+          colorScheme="blue"
+          size="lg"
+          width="full"
+          isLoading={isLoading}
+        >
           Login
         </Button>
         {error && <Text color="red.500">{error}</Text>}
@@ -70,4 +91,4 @@ const LoginForm: React.FC = () => {
   );
 };
 
-export default LoginForm; 
+export default LoginForm;

--- a/frontend/src/components/user/__tests__/LoginForm.test.tsx
+++ b/frontend/src/components/user/__tests__/LoginForm.test.tsx
@@ -1,68 +1,123 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { TestWrapper } from '@/__tests__/utils/test-utils';
-import LoginForm from '../LoginForm';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TestWrapper } from "@/__tests__/utils/test-utils";
+import { useAuthStore } from "@/store/authStore";
+import LoginForm from "../LoginForm";
 
-vi.mock('@chakra-ui/react', async () => {
-  const actual = await vi.importActual('@chakra-ui/react');
+const toastMock = vi.fn();
+const pushMock = vi.fn();
+const loginMock = vi.fn();
+
+vi.mock("@chakra-ui/react", async () => {
+  const actual = await vi.importActual("@chakra-ui/react");
   return {
     ...actual,
-    useToast: () => vi.fn(),
+    useToast: () => toastMock,
     useColorModeValue: (light: any, dark: any) => light,
   };
 });
 
-describe('LoginForm', () => {
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+vi.mock("@/services/api/users", () => ({
+  login: loginMock,
+}));
+
+describe("LoginForm", () => {
   const user = userEvent.setup();
 
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('should render without crashing', () => {
+  it("should render without crashing", () => {
     render(
       <TestWrapper>
         <LoginForm />
-      </TestWrapper>
+      </TestWrapper>,
     );
     expect(document.body).toBeInTheDocument();
   });
 
-  it('should handle props correctly', () => {
-    const props = { 
-      testId: 'test-component',
-      'data-testid': 'test-component'
+  it("should handle props correctly", () => {
+    const props = {
+      testId: "test-component",
+      "data-testid": "test-component",
     };
-    
+
     render(
       <TestWrapper>
         <LoginForm {...props} />
-      </TestWrapper>
+      </TestWrapper>,
     );
-    
-    const component = screen.queryByTestId('test-component');
+
+    const component = screen.queryByTestId("test-component");
     expect(component || document.body).toBeInTheDocument();
   });
 
-  it('should handle user interactions', async () => {
+  it("should handle user interactions", async () => {
     render(
       <TestWrapper>
         <LoginForm />
-      </TestWrapper>
+      </TestWrapper>,
     );
-    
-    const buttons = screen.queryAllByRole('button');
-    const inputs = screen.queryAllByRole('textbox');
-    
+
+    const buttons = screen.queryAllByRole("button");
+    const inputs = screen.queryAllByRole("textbox");
+
     if (buttons.length > 0) {
       await user.click(buttons[0]);
     }
-    
+
     if (inputs.length > 0) {
-      await user.type(inputs[0], 'test input');
+      await user.type(inputs[0], "test input");
     }
-    
+
     expect(document.body).toBeInTheDocument();
+  });
+
+  it("submits credentials and redirects on success", async () => {
+    loginMock.mockResolvedValueOnce({
+      access_token: "abc",
+      token_type: "bearer",
+    });
+    const setTokenMock = vi.fn();
+    useAuthStore.setState({ token: null, setToken: setTokenMock } as any);
+
+    render(
+      <TestWrapper>
+        <LoginForm />
+      </TestWrapper>,
+    );
+
+    await user.type(screen.getByLabelText(/username/i), "john");
+    await user.type(screen.getByLabelText(/password/i), "secret");
+    await user.click(screen.getByRole("button", { name: /login/i }));
+
+    await waitFor(() => expect(loginMock).toHaveBeenCalled());
+
+    expect(setTokenMock).toHaveBeenCalledWith("abc");
+    expect(localStorage.getItem("token")).toBe("abc");
+    expect(pushMock).toHaveBeenCalledWith("/");
+  });
+
+  it("shows toast on login failure", async () => {
+    loginMock.mockRejectedValueOnce(new Error("invalid"));
+
+    render(
+      <TestWrapper>
+        <LoginForm />
+      </TestWrapper>,
+    );
+
+    await user.type(screen.getByLabelText(/username/i), "john");
+    await user.type(screen.getByLabelText(/password/i), "bad");
+    await user.click(screen.getByRole("button", { name: /login/i }));
+
+    await waitFor(() => expect(toastMock).toHaveBeenCalled());
+    expect(pushMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- store token and redirect to dashboard after login
- display toast on authentication failure
- add unit tests for LoginForm submit handler

## Testing
- `npx prettier frontend/src/components/user/LoginForm.tsx --write`
- `npx prettier frontend/src/components/user/__tests__/LoginForm.test.tsx --write`
- `npx eslint src/components/user/LoginForm.tsx --fix` *(fails: File ignored)*
- `npm test -- -t LoginForm` *(tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6840d27b8f68832ca7d894df6a045478