### PR TITLE
Add backend linting section

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -47,6 +47,19 @@ backend\.venv\Scripts\pytest.exe backend\tests\test_audit_logs_crud.py -v
 # From the project root
 backend\.venv\Scripts\pytest.exe backend\tests\test_async_example.py backend\tests\test_projects_crud.py backend\tests\test_tasks_crud.py backend\tests\test_agents_crud.py backend\tests\test_comments_crud.py backend\tests\test_audit_logs_crud.py -v
 ```
+
+## 🧺 Linting
+
+Run `flake8` before committing to ensure Python code meets the project style.
+
+```bash
+cd backend
+flake8 .
+```
+
+Fix any issues reported. The helper script `comprehensive_flake8_fixer.py` can
+automatically clean common violations.
+
 ## 📁 Project Structure
 
 ```


### PR DESCRIPTION
## Summary
- document flake8 usage in backend README

## Testing
- `flake8`
- `pytest -q` *(fails: ImportError: cannot import name 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6840e2cb811c832ca5a70b9361c49358