### PR TITLE
Fix trailing whitespace in check_routes

### DIFF
--- a/backend/check_routes.py
+++ b/backend/check_routes.py
@@ -8,14 +8,14 @@ sys.path.insert(0, os.path.abspath('.'))
 try:
     from backend.main import app
     print("App imported successfully")
-    
+
     # Print all routes
     print("\nRegistered routes:")
     for route in app.routes:
         if hasattr(route, 'path'):
             methods = getattr(route, 'methods', ['GET'])
             print(f"{methods} {route.path}")
-    
+
     print("\nDone")
 except Exception as e:
     print(f"Error: {e}")


### PR DESCRIPTION
## Summary
- remove spaces on blank lines in `check_routes.py`

## Testing
- `flake8 backend/check_routes.py`
- `pytest -q` *(fails: ImportError: cannot import name 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6840e2cab474832cb6401b2451ff25a7