### PR TITLE
Fix flake8 style issues in memory router

### DIFF
--- a/backend/routers/memory/core/core.py
+++ b/backend/routers/memory/core/core.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, status, Query, Path, Body
+from fastapi import APIRouter, Depends, HTTPException, status, Query, Path
 from sqlalchemy.orm import Session
 from typing import List, Optional, Dict, Any
 from pydantic import BaseModel, Field
@@ -20,12 +20,14 @@ router = APIRouter(
     tags=["Memory Entities"],
 )
 
+
 def get_memory_service(db: Session = Depends(get_db)) -> MemoryService:
     return MemoryService(db)
 
 # =============================
 # CRUD Endpoints
 # =============================
+
 
 @router.post("/", response_model=MemoryEntity, status_code=status.HTTP_201_CREATED)
 def create_memory_entity_endpoint(
@@ -40,6 +42,7 @@ def create_memory_entity_endpoint(
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+
 
 @router.get("/{entity_id}", response_model=MemoryEntity)
 def read_memory_entity_endpoint(
@@ -56,6 +59,7 @@ def read_memory_entity_endpoint(
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
 
+
 @router.get("/", response_model=List[MemoryEntity])
 def list_memory_entities_endpoint(
     type: Optional[str] = Query(None),
@@ -69,6 +73,7 @@ def list_memory_entities_endpoint(
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
 
+
 @router.get("/by-type/{entity_type}", response_model=List[MemoryEntity])
 def read_entities_by_type(
     entity_type: str = Path(...),
@@ -77,9 +82,14 @@ def read_entities_by_type(
     limit: int = Query(100),
 ):
     try:
-        return memory_service.get_entities_by_type(entity_type=entity_type, skip=skip, limit=limit)
+        return memory_service.get_entities_by_type(
+            entity_type=entity_type,
+            skip=skip,
+            limit=limit,
+        )
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+
 
 @router.put("/{entity_id}", response_model=MemoryEntity)
 def update_memory_entity_endpoint(
@@ -96,6 +106,7 @@ def update_memory_entity_endpoint(
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+
 
 @router.delete("/{entity_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_memory_entity_endpoint(
@@ -116,8 +127,10 @@ def delete_memory_entity_endpoint(
 # Ingestion Inputs
 # =============================
 
+
 class UrlIngestInput(BaseModel):
     url: str = Field(..., description="URL to ingest")
+
 
 class TextIngestInput(BaseModel):
     text: str = Field(..., description="Text snippet to ingest")
@@ -127,14 +140,22 @@ class TextIngestInput(BaseModel):
 # Ingestion Endpoints
 # =============================
 
-@router.post("/ingest/file", response_model=MemoryEntity, status_code=status.HTTP_201_CREATED)
+
+@router.post(
+    "/ingest/file",
+    response_model=MemoryEntity,
+    status_code=status.HTTP_201_CREATED,
+)
 def ingest_file_endpoint(
     ingest_input: FileIngestInput,
     memory_service: MemoryService = Depends(get_memory_service),
     current_user: UserModel = Depends(get_current_active_user),
 ):
     try:
-        return memory_service.ingest_file(ingest_input=ingest_input, user_id=current_user.id)
+        return memory_service.ingest_file(
+            ingest_input=ingest_input,
+            user_id=current_user.id,
+        )
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except HTTPException:
@@ -142,18 +163,31 @@ def ingest_file_endpoint(
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to ingest file: {e}")
 
-@router.post("/ingest/url", response_model=MemoryEntity, status_code=status.HTTP_201_CREATED)
+
+@router.post(
+    "/ingest/url",
+    response_model=MemoryEntity,
+    status_code=status.HTTP_201_CREATED,
+)
 def ingest_url_endpoint(
     ingest_input: UrlIngestInput,
     memory_service: MemoryService = Depends(get_memory_service),
     current_user: UserModel = Depends(get_current_active_user),
 ):
     try:
-        return memory_service.ingest_url(url=ingest_input.url, user_id=current_user.id)
+        return memory_service.ingest_url(
+            url=ingest_input.url,
+            user_id=current_user.id,
+        )
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to ingest url: {e}")
 
-@router.post("/ingest/text", response_model=MemoryEntity, status_code=status.HTTP_201_CREATED)
+
+@router.post(
+    "/ingest/text",
+    response_model=MemoryEntity,
+    status_code=status.HTTP_201_CREATED,
+)
 def ingest_text_endpoint(
     ingest_input: TextIngestInput,
     memory_service: MemoryService = Depends(get_memory_service),
@@ -172,6 +206,7 @@ def ingest_text_endpoint(
 # File Content & Metadata
 # =============================
 
+
 @router.get("/{entity_id}/content")
 def get_file_content_endpoint(
     entity_id: int = Path(...),
@@ -184,6 +219,7 @@ def get_file_content_endpoint(
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+
 
 @router.get("/{entity_id}/metadata")
 def get_file_metadata_endpoint(


### PR DESCRIPTION
## Summary
- fix blank lines flagged by E302 in `core.py`
- wrap long lines to comply with 88 char limit
- drop unused Body import

## Testing
- `flake8 routers/memory/core/core.py`

------
https://chatgpt.com/codex/tasks/task_e_6840e2c3f09c832c8f38f247a6a0f3e5