### PR TITLE
Fix flake8 issues in memory service

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,12 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203,W503
+exclude = 
+    .venv,
+    __pycache__,
+    .pytest_cache,
+    alembic/versions.bak-*,
+    .git,
+    build,
+    dist,
+    *.egg-info

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -21,7 +21,6 @@ from ..crud.memory import (
     get_memory_entities,
     update_memory_entity,
     delete_memory_entity,
-    get_memory_entities_by_source_type
 )
 from ..services.exceptions import EntityNotFoundError
 
@@ -41,21 +40,32 @@ class MemoryService:
     def get_memory_entity_by_id(self, entity_id: int) -> Optional[models.MemoryEntity]:
         return self.get_entity(entity_id)
 
-    def get_entities(self, skip: int = 0, limit: int = 100) -> List[models.MemoryEntity]:
+    def get_entities(
+        self, skip: int = 0, limit: int = 100
+    ) -> List[models.MemoryEntity]:
         return get_memory_entities(self.db, skip, limit)
 
-    def update_entity(self, entity_id: int, entity_update: MemoryEntityUpdate) -> Optional[models.MemoryEntity]:
+    def update_entity(
+        self, entity_id: int, entity_update: MemoryEntityUpdate
+    ) -> Optional[models.MemoryEntity]:
         return update_memory_entity(self.db, entity_id, entity_update)
 
     def delete_entity(self, entity_id: int) -> bool:
         return delete_memory_entity(self.db, entity_id)
 
-    def ingest_file(self, ingest_input: FileIngestInput, user_id: Optional[str] = None) -> models.MemoryEntity:
+    def ingest_file(
+        self, ingest_input: FileIngestInput, user_id: Optional[str] = None
+    ) -> models.MemoryEntity:
         file_path = ingest_input.file_path
         try:
             if not os.path.exists(file_path):
-                logger.error(f"File not found during ingestion: {file_path}")
-                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"File not found: {file_path}")
+                logger.error(
+                    f"File not found during ingestion: {file_path}"
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"File not found: {file_path}",
+                )
 
             file_stat = os.stat(file_path)
             file_info = {
@@ -67,7 +77,17 @@ class MemoryService:
             }
 
             file_content = ""
-            if file_info["extension"] in [".txt", ".md", ".py", ".js", ".json", ".yml", ".yaml", ".xml", ".csv"]:
+            if file_info["extension"] in [
+                ".txt",
+                ".md",
+                ".py",
+                ".js",
+                ".json",
+                ".yml",
+                ".yaml",
+                ".xml",
+                ".csv",
+            ]:
                 try:
                     with open(file_path, 'r', encoding='utf-8') as f:
                         file_content = f.read()
@@ -88,9 +108,14 @@ class MemoryService:
             return self.create_entity(entity_create)
         except Exception as e:
             logger.error(f"Error ingesting file {file_path}: {e}")
-            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Error ingesting file: {str(e)}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Error ingesting file: {str(e)}",
+            )
 
-    def ingest_url(self, url: str, user_id: Optional[str] = None) -> models.MemoryEntity:
+    def ingest_url(
+        self, url: str, user_id: Optional[str] = None
+    ) -> models.MemoryEntity:
         try:
             response = httpx.get(url)
             response.raise_for_status()
@@ -105,9 +130,17 @@ class MemoryService:
             return self.create_entity(entity_create)
         except Exception as e:
             logger.error(f"Error ingesting url {url}: {e}")
-            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Error ingesting url: {str(e)}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Error ingesting url: {str(e)}",
+            )
 
-    def ingest_text(self, text: str, user_id: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> models.MemoryEntity:
+    def ingest_text(
+        self,
+        text: str,
+        user_id: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> models.MemoryEntity:
         try:
             entity_create = MemoryEntityCreate(
                 entity_type="text",
@@ -120,7 +153,10 @@ class MemoryService:
             return self.create_entity(entity_create)
         except Exception as e:
             logger.error(f"Error ingesting text: {e}")
-            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Error ingesting text: {str(e)}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Error ingesting text: {str(e)}",
+            )
 
     def get_file_content(self, entity_id: int) -> str:
         entity = self.get_entity(entity_id)
@@ -131,7 +167,10 @@ class MemoryService:
     def get_file_metadata(self, entity_id: int) -> Dict[str, Any]:
         entity = self.get_entity(entity_id)
         if not entity:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Entity not found")
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Entity not found",
+            )
         return entity.entity_metadata or {}
 
     def create_memory_entity(self, entity: MemoryEntityCreate) -> models.MemoryEntity:
@@ -149,16 +188,32 @@ class MemoryService:
             return db_entity
         except IntegrityError:
             self.db.rollback()
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Entity with name '{entity.name}' already exists")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Entity with name '{entity.name}' already exists",
+            )
         except Exception as e:
             self.db.rollback()
             logger.error(f"Error creating memory entity: {e}")
-            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Error creating memory entity")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Error creating memory entity",
+            )
 
     def get_memory_entity_by_name(self, name: str) -> Optional[models.MemoryEntity]:
-        return self.db.query(models.MemoryEntity).filter(models.MemoryEntity.name == name).first()
+        return (
+            self.db.query(models.MemoryEntity)
+            .filter(models.MemoryEntity.name == name)
+            .first()
+        )
 
-    def get_memory_entities(self, type: Optional[str] = None, name: Optional[str] = None, skip: int = 0, limit: int = 100) -> List[models.MemoryEntity]:
+    def get_memory_entities(
+        self,
+        type: Optional[str] = None,
+        name: Optional[str] = None,
+        skip: int = 0,
+        limit: int = 100,
+    ) -> List[models.MemoryEntity]:
         query = self.db.query(models.MemoryEntity)
         if type:
             query = query.filter(models.MemoryEntity.type == type)
@@ -166,8 +221,16 @@ class MemoryService:
             query = query.filter(models.MemoryEntity.name.ilike(f"%{name}%"))
         return query.offset(skip).limit(limit).all()
 
-    def get_memory_entities_by_type(self, entity_type: str, skip: int = 0, limit: int = 100) -> List[models.MemoryEntity]:
-        return self.db.query(models.MemoryEntity).filter(models.MemoryEntity.type == entity_type).offset(skip).limit(limit).all()
+    def get_memory_entities_by_type(
+        self, entity_type: str, skip: int = 0, limit: int = 100
+    ) -> List[models.MemoryEntity]:
+        return (
+            self.db.query(models.MemoryEntity)
+            .filter(models.MemoryEntity.type == entity_type)
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
 
     def delete_memory_entity(self, entity_id: int) -> Optional[models.MemoryEntity]:
         db_entity = self.get_entity(entity_id)
@@ -177,10 +240,15 @@ class MemoryService:
             logger.info(f"Deleted memory entity: {entity_id}")
             return db_entity
 
-    def add_observation_to_entity(self, entity_id: int, observation: MemoryObservationCreate) -> models.MemoryObservation:
+    def add_observation_to_entity(
+        self, entity_id: int, observation: MemoryObservationCreate
+    ) -> models.MemoryObservation:
         db_entity = self.get_memory_entity_by_id(entity_id)
         if db_entity is None:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Entity not found")
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Entity not found",
+            )
 
         db_observation = models.MemoryObservation(
             entity_id=entity_id,
@@ -195,21 +263,41 @@ class MemoryService:
         logger.info(f"Added observation to entity {entity_id}: {db_observation.id}")
         return db_observation
 
-    def get_observations(self, entity_id: Optional[int] = None, search_query: Optional[str] = None, skip: int = 0, limit: int = 100) -> List[models.MemoryObservation]:
+    def get_observations(
+        self,
+        entity_id: Optional[int] = None,
+        search_query: Optional[str] = None,
+        skip: int = 0,
+        limit: int = 100,
+    ) -> List[models.MemoryObservation]:
         query = self.db.query(models.MemoryObservation)
         if entity_id is not None:
             query = query.filter(models.MemoryObservation.entity_id == entity_id)
         if search_query:
-            query = query.filter(models.MemoryObservation.content.ilike(f"%{search_query}%"))
+            query = query.filter(
+                models.MemoryObservation.content.ilike(f"%{search_query}%")
+            )
         return query.offset(skip).limit(limit).all()
 
-    def create_memory_relation(self, relation: MemoryRelationCreate) -> models.MemoryRelation:
+    def create_memory_relation(
+        self, relation: MemoryRelationCreate
+    ) -> models.MemoryRelation:
         from_entity = self.get_memory_entity_by_id(relation.from_entity_id)
         to_entity = self.get_memory_entity_by_id(relation.to_entity_id)
         if not from_entity:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Source entity with ID {relation.from_entity_id} not found")
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=(
+                    f"Source entity with ID {relation.from_entity_id} not found"
+                ),
+            )
         if not to_entity:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Target entity with ID {relation.to_entity_id} not found")
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=(
+                    f"Target entity with ID {relation.to_entity_id} not found"
+                ),
+            )
 
         try:
             db_relation = models.MemoryRelation(
@@ -225,16 +313,34 @@ class MemoryService:
             return db_relation
         except IntegrityError:
             self.db.rollback()
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Relation of type '{relation.relation_type}' already exists between entity {relation.from_entity_id} and entity {relation.to_entity_id}")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Relation of type '{relation.relation_type}' already exists "
+                    f"between entity {relation.from_entity_id} "
+                    f"and entity {relation.to_entity_id}"
+                ),
+            )
         except Exception as e:
             self.db.rollback()
             logger.error(f"Error creating memory relation: {e}")
-            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Error creating memory relation")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Error creating memory relation",
+            )
 
-    def get_memory_relation(self, relation_id: int) -> Optional[models.MemoryRelation]:
-        return self.db.query(models.MemoryRelation).filter(models.MemoryRelation.id == relation_id).first()
+    def get_memory_relation(
+        self, relation_id: int
+    ) -> Optional[models.MemoryRelation]:
+        return (
+            self.db.query(models.MemoryRelation)
+            .filter(models.MemoryRelation.id == relation_id)
+            .first()
+        )
 
-    def get_relations_for_entity(self, entity_id: int, relation_type: Optional[str] = None) -> List[models.MemoryRelation]:
+    def get_relations_for_entity(
+        self, entity_id: int, relation_type: Optional[str] = None
+    ) -> List[models.MemoryRelation]:
         query = self.db.query(models.MemoryRelation).filter(
             (models.MemoryRelation.from_entity_id == entity_id) |
             (models.MemoryRelation.to_entity_id == entity_id)
@@ -243,7 +349,9 @@ class MemoryService:
             query = query.filter(models.MemoryRelation.relation_type == relation_type)
         return query.all()
 
-    def delete_memory_relation(self, relation_id: int) -> Optional[models.MemoryRelation]:
+    def delete_memory_relation(
+        self, relation_id: int
+    ) -> Optional[models.MemoryRelation]:
         db_relation = self.get_memory_relation(relation_id)
         if db_relation:
             self.db.delete(db_relation)
@@ -251,10 +359,25 @@ class MemoryService:
             logger.info(f"Deleted memory relation: {relation_id}")
         return db_relation
 
-    def get_memory_relations_by_type(self, relation_type: str, skip: int = 0, limit: int = 100) -> List[models.MemoryRelation]:
-        return self.db.query(models.MemoryRelation).filter(models.MemoryRelation.relation_type == relation_type).offset(skip).limit(limit).all()
+    def get_memory_relations_by_type(
+        self, relation_type: str, skip: int = 0, limit: int = 100
+    ) -> List[models.MemoryRelation]:
+        return (
+            self.db.query(models.MemoryRelation)
+            .filter(models.MemoryRelation.relation_type == relation_type)
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
 
-    def get_memory_relations_between_entities(self, from_entity_id: int, to_entity_id: int, relation_type: Optional[str] = None, skip: int = 0, limit: int = 100) -> List[models.MemoryRelation]:
+    def get_memory_relations_between_entities(
+        self,
+        from_entity_id: int,
+        to_entity_id: int,
+        relation_type: Optional[str] = None,
+        skip: int = 0,
+        limit: int = 100,
+    ) -> List[models.MemoryRelation]:
         query = self.db.query(models.MemoryRelation).filter(
             models.MemoryRelation.from_entity_id == from_entity_id,
             models.MemoryRelation.to_entity_id == to_entity_id
@@ -263,5 +386,7 @@ class MemoryService:
             query = query.filter(models.MemoryRelation.relation_type == relation_type)
         return query.offset(skip).limit(limit).all()
 
-    def search_memory_entities(self, query: str, limit: int = 10) -> List[models.MemoryEntity]:
+    def search_memory_entities(
+        self, query: str, limit: int = 10
+    ) -> List[models.MemoryEntity]:
         return self.get_memory_entities(name=query, limit=limit)


### PR DESCRIPTION
## Summary
- remove unused import from MemoryService
- wrap long FileService and DB query lines
- add repo flake8 config to use 88 char lines

## Testing
- `python3 -m flake8 backend/services/memory_service.py`
- `pytest backend/tests` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_6840e2c0bbf8832c8246df3e2ce395e7