### PR TITLE
Fix TaskControls status enum usage

### DIFF
--- a/frontend/src/components/TaskControls.tsx
+++ b/frontend/src/components/TaskControls.tsx
@@ -40,12 +40,14 @@ interface TaskControlsProps {
   setSearchTerm: (value: string) => void;
 }
 
+// List of statuses a user can apply to multiple tasks at once.
+// Using enum values ensures type safety across the codebase.
 const availableStatusesForBulkUpdate: TaskStatus[] = [
-  "pending",
-  "in_progress",
-  "done",
-  "blocked",
-  "archived",
+  TaskStatus.TO_DO,
+  TaskStatus.IN_PROGRESS,
+  TaskStatus.COMPLETED,
+  TaskStatus.BLOCKED,
+  TaskStatus.CANCELLED,
 ];
 
 const TaskControls: React.FC<TaskControlsProps> = ({


### PR DESCRIPTION
## Summary
- use enum constants for bulk status update

## Testing
- `npm run type-check` *(fails: TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6840e93049a4832cb1d0d628b2c4626e