### PR TITLE
Fix ProjectCard boolean expression

### DIFF
--- a/frontend/src/components/project/ProjectCard.tsx
+++ b/frontend/src/components/project/ProjectCard.tsx
@@ -143,7 +143,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
             onDelete={onDelete}
             onCopyGet={onCopyGet}
             onOpenCliPrompt={onOpenCliPrompt}
-            disableActions={project.is_archived && projectToDeleteId === project.id}
+            disableActions={!!(project.is_archived && projectToDeleteId === project.id)}
           />
         </Flex>
         <Text fontSize="sm" color={project.description ? 'textSecondary' : 'textPlaceholder'} fontWeight="normal" lineHeight="condensed" noOfLines={2} title={displayDescription} fontStyle={project.description ? undefined : 'italic'}>


### PR DESCRIPTION
## Summary
- coerce `project.is_archived` expression to boolean in `ProjectCard`

## Testing
- `npm run lint`
- `npm run type-check` *(fails: TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6840e92d4458832c80e401f91d9920b2