### PR TITLE
Fix TaskRow project name default

### DIFF
--- a/frontend/src/components/task/TaskRow.tsx
+++ b/frontend/src/components/task/TaskRow.tsx
@@ -42,7 +42,7 @@ const TaskRow: React.FC<TaskRowProps> = ({
     <Box flex={1}>
       <TaskItem
         task={task}
-        projectName={task.project_name}
+        projectName={task.project_name ?? ''}
         onAssignAgent={onAssignAgent}
         onDeleteInitiate={onDelete}
         onClick={onClick}


### PR DESCRIPTION
## Summary
- default to empty string when TaskRow passes project name

## Testing
- `npm run lint`
- `npm run type-check` *(fails: missing types in unrelated files)*
- `npm run test` *(fails: observer.observe is not a function)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_6840e92cad24832c9338f00b048b4565