### PR TITLE
Add React import in not-found page

### DIFF
--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import React from "react";
 import { Button, Flex, Heading, Text } from "@chakra-ui/react";
 import Link from "next/link";
 


### PR DESCRIPTION
## Summary
- add missing React import in `not-found` page
- run type checker, lint, and tests

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test` *(fails: observer.observe is not a function)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6840e9280f78832cb806c17cd1b99838