### PR TITLE
Add project-wide type check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ cd frontend
 npm test
 ```
 
+### Type Checking
+
+```bash
+npm run type-check
+```
+
 ---
 
 ## 🔍 System Validation & Tests

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:frontend": "cd frontend && npx eslint . --ext .js,.jsx,.ts,.tsx --config ./eslint.config.cjs --format json --output-file ../eslint_report.json",
     "watch:pack": "nodemon --watch cli.js --watch package.json --watch .npmignore --watch .cursor/rules --ext js,json,mdc --exec \"npm pack\"",
     "build:all": "cd frontend && npm run build && cd .. && backend\\.venv\\Scripts\\python.exe -m pip install -r backend\\requirements.txt",
-    "type-check": "npx tsc --noEmit",
+    "type-check": "npm --prefix frontend run type-check",
     "fix": "cd frontend && npm run fix",
     "format": "cd frontend && npm run format",
     "update-readmes": "python scripts/update_readmes.py",


### PR DESCRIPTION
## Summary
- provide `type-check` script at repo root
- document how to run it in the README

## Testing
- `npm --prefix frontend run type-check` *(fails: Cannot find module 'zod', etc.)*
- `npm --prefix frontend test` *(fails: vitest not found)*
- `npm --prefix frontend run lint` *(fails: next not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6840e924503c832c83fbaf7885852779