### PR TITLE
Add frontend type-check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,11 @@ jobs:
           cd frontend
           npm install
 
+      - name: Type check
+        run: |
+          cd frontend
+          npm run type-check
+
       - name: Test with coverage
         run: |
           cd frontend


### PR DESCRIPTION
## Summary
- run `npm run type-check` during frontend CI

## Testing
- `flake8 .` *(fails: ModuleNotFoundError: 'sqlalchemy')*
- `pytest -q` *(fails to import app)*
- `npm run lint`
- `npm run type-check` *(fails with TS2322 et al.)*
- `npm run test:coverage` *(fails: observer.observe is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6840e9224e94832c91a855afb74d34b7