### PR TITLE
Audit API services for strong typing

### DIFF
--- a/frontend/src/services/api/memory.ts
+++ b/frontend/src/services/api/memory.ts
@@ -12,6 +12,7 @@ import type {
   MemoryRelation,
   MemoryRelationCreateData,
   MemoryRelationFilters,
+  KnowledgeGraph,
 } from "@/types/memory";
 
 // --- Memory Entity APIs ---
@@ -148,8 +149,8 @@ export const memoryApi = {
 
   // --- Knowledge Graph APIs ---
   // Get the full knowledge graph
-  getKnowledgeGraph: async (): Promise<any> => {
-    const response = await request<{ data: any }>(
+  getKnowledgeGraph: async (): Promise<KnowledgeGraph> => {
+    const response = await request<{ data: KnowledgeGraph }>(
       buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/graph")
     );
     return response.data;

--- a/frontend/src/services/api/rules.ts
+++ b/frontend/src/services/api/rules.ts
@@ -12,6 +12,7 @@ import type {
   UniversalMandateFilters,
   AgentRuleFilters,
 } from "@/types/rules";
+import type { AgentPromptTemplate } from "@/types/agent_prompt_template";
 
 export const rulesApi = {
   // --- Universal Mandate APIs ---
@@ -158,8 +159,8 @@ export const rulesApi = {
   // --- Rule Template APIs ---
   templates: {
     // Get all rule templates
-    list: async (): Promise<any[]> => {
-      const response = await request<{ data: any[] }>(
+    list: async (): Promise<AgentPromptTemplate[]> => {
+      const response = await request<{ data: AgentPromptTemplate[] }>(
         buildApiUrl(API_CONFIG.ENDPOINTS.RULES, "/templates")
       );
       return response.data;

--- a/frontend/src/services/api/tasks.ts
+++ b/frontend/src/services/api/tasks.ts
@@ -1,4 +1,17 @@
-import { TaskFilters, Task, TaskCreateData, TaskUpdateData, TaskFileAssociation, TaskFileAssociationCreateData, TaskDependency, TaskDependencyCreateData, TaskSortOptions, TaskStatus } from "@/types";
+import {
+  TaskFilters,
+  Task,
+  TaskCreateData,
+  TaskUpdateData,
+  TaskFileAssociation,
+  TaskFileAssociationCreateData,
+  TaskDependency,
+  TaskDependencyCreateData,
+  TaskSortOptions,
+  TaskStatus,
+  Comment,
+  CommentCreateData,
+} from "@/types";
 import { request, normalizeToStatusID } from "./request";
 import { buildApiUrl, API_CONFIG } from "./config";
 import { StatusID } from "@/lib/statusUtils";
@@ -370,19 +383,25 @@ export const deleteTask = async (
 export const getTaskComments = async (
   project_id: string,
   task_number: number
-): Promise<any[]> => {
-  return request<any[]>(
-    buildApiUrl(API_CONFIG.ENDPOINTS.PROJECTS, `/${project_id}/tasks/${task_number}/comments/`)
+): Promise<Comment[]> => {
+  return request<Comment[]>(
+    buildApiUrl(
+      API_CONFIG.ENDPOINTS.PROJECTS,
+      `/${project_id}/tasks/${task_number}/comments/`
+    )
   );
 };
 
 export const addTaskComment = async (
   project_id: string,
   task_number: number,
-  commentData: { content: string; user_id?: string }
-): Promise<any> => {
-  return request<any>(
-    buildApiUrl(API_CONFIG.ENDPOINTS.PROJECTS, `/${project_id}/tasks/${task_number}/comments/`),
+  commentData: CommentCreateData
+): Promise<Comment> => {
+  return request<Comment>(
+    buildApiUrl(
+      API_CONFIG.ENDPOINTS.PROJECTS,
+      `/${project_id}/tasks/${task_number}/comments/`
+    ),
     { method: "POST", body: JSON.stringify(commentData) }
   );
 };

--- a/frontend/src/types/README.md
+++ b/frontend/src/types/README.md
@@ -87,6 +87,7 @@ graph TD
 - `memory.ts`
 - `project.ts`
 - `project_template.ts`
+- `agent_prompt_template.ts`
 - `rules.ts`
 - `task.ts`
 - `user.ts`

--- a/frontend/src/types/agent_prompt_template.ts
+++ b/frontend/src/types/agent_prompt_template.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+export const agentPromptTemplateBaseSchema = z.object({
+  template_name: z.string(),
+  template_content: z.string(),
+  context_requirements: z.string().nullable().optional(),
+  is_active: z.boolean().default(true),
+});
+
+export const agentPromptTemplateCreateSchema = agentPromptTemplateBaseSchema.extend({
+  agent_role_id: z.string(),
+});
+export type AgentPromptTemplateCreateData = z.infer<typeof agentPromptTemplateCreateSchema>;
+
+export const agentPromptTemplateUpdateSchema = agentPromptTemplateBaseSchema.partial();
+export type AgentPromptTemplateUpdateData = z.infer<typeof agentPromptTemplateUpdateSchema>;
+
+export const agentPromptTemplateSchema = agentPromptTemplateBaseSchema.extend({
+  id: z.string(),
+  agent_role_id: z.string(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+export type AgentPromptTemplate = z.infer<typeof agentPromptTemplateSchema>;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -8,6 +8,7 @@ export * from "./comment";
 export * from "./rules";
 export * from "./mcp";
 export * from "./project_template";
+export * from "./agent_prompt_template";
 
 // Common types used across the application
 // Canonical shared sort direction type for all entities

--- a/frontend/src/types/memory.ts
+++ b/frontend/src/types/memory.ts
@@ -86,3 +86,8 @@ export interface MemoryRelationFilters {
   to_entity_id?: number;
   relation_type?: string;
 }
+
+export interface KnowledgeGraph {
+  entities: MemoryEntity[];
+  relations: MemoryRelation[];
+}


### PR DESCRIPTION
## Summary
- ensure API services return typed data
- add `AgentPromptTemplate` schema and exports
- type task comment APIs
- type memory knowledge graph response

## Testing
- `npm run type-check` *(fails: Cannot find modules)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e91e7bcc832c92d23059a107cdd8