### PR TITLE
Add DisplayableStatus type

### DIFF
--- a/frontend/src/lib/statusUtils.ts
+++ b/frontend/src/lib/statusUtils.ts
@@ -65,6 +65,16 @@ export interface StatusAttributeObject {
   dynamicDisplayNamePattern?: string;          // pattern with {value} placeholder
 }
 
+/**
+ * Shape for objects returned by display helper functions.
+ */
+export interface DisplayableStatus {
+  displayName: string;
+  colorScheme: string;
+  icon?: ElementType | string;
+  dynamicValue?: string;
+}
+
 /* ────────────────────────────────────────────────────────────── */
 /* Canonical Status Map                                          */
 /* ────────────────────────────────────────────────────────────── */
@@ -384,9 +394,7 @@ export function getStatusAttributes(statusId: StatusID): StatusAttributeObject |
 export function getDisplayableStatus(
   statusId: string,
   fallback?: string,
-):
-  | { displayName: string; colorScheme: string; icon?: ElementType | string; dynamicValue?: string }
-  | undefined {
+): DisplayableStatus | undefined {
   let base: StatusAttributeObject | undefined;
   let extracted = fallback;
 
@@ -421,7 +429,7 @@ export function getDisplayableStatus(
 export function getFallbackDisplayableStatus(
   original: string,
   fallback?: string,
-): { displayName: string; colorScheme: string; icon?: ElementType | string; dynamicValue?: string } {
+): DisplayableStatus {
   const title =
     fallback ||
     original


### PR DESCRIPTION
## Summary
- add `DisplayableStatus` interface for clarity
- use `DisplayableStatus` as the return type of helpers in `statusUtils`

## Testing
- `npm run type-check` *(fails: Cannot find module 'zod' or other deps)*
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e91d6370832ca8554896067ee79b