### PR TITLE
test: ensure tokens satisfy type

### DIFF
--- a/frontend/src/tokens/__tests__/index.test.tsx
+++ b/frontend/src/tokens/__tests__/index.test.tsx
@@ -1,52 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, fireEvent, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import index from '../index';
+import { describe, it, expect } from 'vitest';
+import { tokens, type Tokens } from '../index';
 
-vi.mock('@chakra-ui/react', async () => {
-  const actual = await vi.importActual('@chakra-ui/react');
-  return {
-    ...actual,
-    useToast: vi.fn(),
-    useColorModeValue: vi.fn((light: any, dark: any) => light),
-  };
-});
-
-describe('index', () => {
-  const user = userEvent.setup();
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('should render without crashing', () => {
-    // This is not a component. It seems like these tests are not correctly
-    // testing the functionality of index. I will leave the test body empty.
-  });
-
-  it('should handle props correctly', () => {
-    const props = { 
-      testId: 'test-component',
-      'data-testid': 'test-component'
-    };
-    
-    // This is not a component.
-  });
-
-  it('should handle user interactions', async () => {
-    // This is not a component.
-    
-    const buttons = screen.queryAllByRole('button');
-    const inputs = screen.queryAllByRole('textbox');
-    
-    if (buttons.length > 0) {
-      await user.click(buttons[0]);
-    }
-    
-    if (inputs.length > 0) {
-      await user.type(inputs[0], 'test input');
-    }
-    
-    expect(document.body).toBeInTheDocument();
+describe('tokens object', () => {
+  it('should satisfy the Tokens type', () => {
+    const typedTokens: Tokens = tokens;
+    expect(typedTokens).toBe(tokens);
   });
 });

--- a/frontend/src/tokens/index.ts
+++ b/frontend/src/tokens/index.ts
@@ -1,7 +1,20 @@
 export * from "./colors";
-export * from "./fontFamily";
-export * from "./fontSize";
-export * from "./typography";
+export { fontFamily } from "./fontFamily";
+export type { FontFamily } from "./fontFamily";
+export { fontSize } from "./fontSize";
+export type { FontSize } from "./fontSize";
+export {
+  typography,
+  fontWeight,
+  lineHeight,
+  letterSpacing,
+} from "./typography";
+export type {
+  Typography,
+  FontWeight,
+  LineHeight,
+  LetterSpacing,
+} from "./typography";
 export * from "./sizing";
 export * from "./shadows";
 export * from "./zIndex";


### PR DESCRIPTION
## Summary
- verify tokens object in tests using `Tokens` type
- export tokens individually to avoid duplicate names

## Testing
- `npx tsc src/tokens/__tests__/index.test.tsx --module esnext --moduleResolution node --jsx react --noEmit --skipLibCheck`
- `npm run lint`
- `npm run test:run` *(fails: Cannot read properties of undefined (reading 'matches'))*

------
https://chatgpt.com/codex/tasks/task_e_6840e91b10b8832c9b8056613f57c8be