### PR TITLE
Add TypeScript type-check test

### DIFF
--- a/frontend/tests/typecheck.test.ts
+++ b/frontend/tests/typecheck.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { spawnSync } from 'child_process'
+import path from 'path'
+
+const repoRoot = path.resolve(__dirname, '..', '..')
+const frontendDir = path.join(repoRoot, 'frontend')
+
+describe('TypeScript type checking', () => {
+  it('runs tsc --noEmit without errors', () => {
+    const result = spawnSync('npx', ['tsc', '--noEmit'], {
+      cwd: frontendDir,
+      encoding: 'utf8',
+      shell: true,
+    })
+    expect(result.status).toBe(0)
+  })
+})

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -23,7 +23,8 @@ export default defineConfig({
       'src/lib/__tests__/utils.test.tsx',
       'src/store/__tests__/*.test.ts',
       'src/__tests__/integration/**/*.{ts,tsx}',
-      'src/services/api/__tests__/*.test.ts'
+      'src/services/api/__tests__/*.test.ts',
+      'tests/**/*.test.ts'
     ],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary
- add a Vitest test to ensure `tsc --noEmit` succeeds
- include new `tests` directory in Vitest config

## Testing
- `npm run lint` in `frontend`
- `npm run test:run tests/typecheck.test.ts` *(fails: tsc exited with code 1)*
- `flake8 .` *(fails: E305, E501, F401, W293 errors)*
- `pytest` *(fails to import backend app)*

------
https://chatgpt.com/codex/tasks/task_e_6840e919e114832c94e6832025f90515