### PR TITLE
docs: clarify type-check script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ pre-commit install
 ### What gets checked:
 
 * **Backend**: `flake8` runs on Python files
-* **Frontend**: `npm run lint` runs on JS/TS files
+* **Frontend**: `npm run lint` and `npm run type-check` run on JS/TS files (the type check can also be triggered from the repo root with `npm run type-check`)
 
 These checks will automatically run on every commit.
 
@@ -64,7 +64,7 @@ This ensures all `README.md` files reflect up-to-date directory contents.
 * Keep code self-explanatory and remove unused code.
 * **Frontend**:
 
-  * Run: `npm run lint`, `npm run fix`, and `npm run format` before committing.
+  * Run: `npm run lint`, `npm run type-check`, `npm run fix`, and `npm run format` before committing.
 * **Backend**:
 
   * Run: `flake8` and ensure no style violations or unused imports remain.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -32,6 +32,12 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+### Type Checking
+
+Run `npm run type-check` to ensure the TypeScript codebase compiles without errors. This command runs `tsc --noEmit` using the configuration in `tsconfig.json`.
+
+At the repository root there is a matching `type-check` script that simply invokes the frontend command, allowing you to execute the check from either location.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:


### PR DESCRIPTION
## Summary
- explain type-check script in frontend README
- note npm run type-check in pre-commit checks

## Testing
- `npm run lint` *(fails: next not found until deps installed)*
- `npm run type-check` *(fails: several TS errors)*
- `npm test` *(fails: 6 failing tests)*
- `pytest` *(fails: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6840e919bec8832c9f535ab4082a30f2