### PR TITLE
Add type check to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,14 @@ repos:
         language: system
         pass_filenames: false
 
+      - id: frontend-type-check
+        name: Type-check frontend
+        entry: npm run type-check --prefix frontend
+        language: system
+        pass_filenames: false
+        files: ^frontend/
+        types: [javascript, jsx, ts, tsx]
+
       - id: frontend-format
         name: Format frontend with Prettier
         entry: npm run format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ pre-commit install
 ### What gets checked:
 
 * **Backend**: `flake8` runs on Python files
-* **Frontend**: `npm run lint` runs on JS/TS files
+* **Frontend**: `npm run lint` and `npm run type-check` run on JS/TS files
 
 These checks will automatically run on every commit.
 


### PR DESCRIPTION
## Summary
- run `npm run type-check` during pre-commit when frontend files change
- mention type checking in contributing guide

## Testing
- `npm run lint --prefix frontend` *(fails: next not found)*
- `npm run type-check --prefix frontend` *(fails: cannot find module 'next' etc.)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6840e91960c4832cb47c442ab74cc3f2