### PR TITLE
Refactor tokens index exports

### DIFF
--- a/frontend/src/tokens/index.ts
+++ b/frontend/src/tokens/index.ts
@@ -1,26 +1,60 @@
-export * from "./colors";
-export * from "./fontFamily";
-export * from "./fontSize";
-export * from "./typography";
-export * from "./sizing";
-export * from "./shadows";
-export * from "./zIndex";
-export * from "./breakpoints";
-export * from "./transitions";
-export * from "./opacity";
-export * from "./blur";
+export {
+  colorPrimitives,
+  type ColorPrimitives,
+  semanticColors,
+  type SemanticColors,
+} from './colors';
+export { fontFamily, type FontFamily } from './fontFamily';
+export { fontSize, type FontSize } from './fontSize';
+export {
+  typography,
+  type Typography,
+  fontWeight,
+  type FontWeight,
+  lineHeight,
+  type LineHeight,
+  letterSpacing,
+  type LetterSpacing,
+} from './typography';
+export {
+  sizing,
+  type Sizing,
+  spacing,
+  type Spacing,
+  width,
+  type Width,
+  height,
+  type Height,
+  borderRadius,
+  type BorderRadius,
+  borderWidth,
+  type BorderWidth,
+} from './sizing';
+export { shadows, type Shadows } from './shadows';
+export { zIndex, type ZIndex } from './zIndex';
+export { breakpoints, type Breakpoints } from './breakpoints';
+export {
+  transitions,
+  type Transitions,
+  transitionDuration,
+  type TransitionDuration,
+  transitionEasing,
+  type TransitionEasing,
+} from './transitions';
+export { opacity, type Opacity } from './opacity';
+export { blur, type Blur } from './blur';
 
-import { colorPrimitives, semanticColors } from "./colors";
-import { fontFamily } from "./fontFamily";
-import { fontSize } from "./fontSize";
-import { typography } from "./typography";
-import { sizing } from "./sizing";
-import { shadows } from "./shadows";
-import { zIndex } from "./zIndex";
-import { breakpoints } from "./breakpoints";
-import { transitions } from "./transitions";
-import { opacity } from "./opacity";
-import { blur } from "./blur";
+import { colorPrimitives, semanticColors } from './colors';
+import { fontFamily } from './fontFamily';
+import { fontSize } from './fontSize';
+import { typography } from './typography';
+import { sizing } from './sizing';
+import { shadows } from './shadows';
+import { zIndex } from './zIndex';
+import { breakpoints } from './breakpoints';
+import { transitions } from './transitions';
+import { opacity } from './opacity';
+import { blur } from './blur';
 
 export const tokens = {
   colors: { ...colorPrimitives, ...semanticColors },


### PR DESCRIPTION
## Summary
- use explicit named exports in `src/tokens/index.ts`

## Testing
- `npm run type-check` *(fails: TypeScript errors)*
- `npm run test` *(fails: observer.observe is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6840e92a39a4832cba43a87246fa67f9