### PR TITLE
Add memory retrieval MCP tools

### DIFF
--- a/backend/mcp_tools/memory_tools.py
+++ b/backend/mcp_tools/memory_tools.py
@@ -12,8 +12,9 @@ from backend.crud.memory import (
     create_memory_relation,
     add_observation_to_entity,
     search_entities,
-    get_memory_entity_by_name
+    get_memory_entity_by_name,
 )
+from backend.services.memory_service import MemoryService
 from backend.schemas.memory import MemoryEntityCreate, MemoryObservationCreate
 
 logger = logging.getLogger(__name__)
@@ -121,5 +122,43 @@ async def search_memory_tool(
     ]
     }
     except Exception as e:
-    logger.error(f"MCP search memory failed: {e}")
-    raise HTTPException(status_code=500, detail=str(e))
+        logger.error(f"MCP search memory failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+async def get_memory_content_tool(
+    entity_id: int,
+    db: Session,
+) -> dict:
+    """MCP Tool: Get memory entity content."""
+    try:
+        service = MemoryService(db)
+        content = service.get_file_content(entity_id)
+        return {"success": True, "content": content}
+    except HTTPException as e:
+        logger.error(
+            f"MCP get memory content failed with HTTP exception: {e.detail}"
+        )
+        raise e
+    except Exception as e:
+        logger.error(f"MCP get memory content failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+async def get_memory_metadata_tool(
+    entity_id: int,
+    db: Session,
+) -> dict:
+    """MCP Tool: Get memory entity metadata."""
+    try:
+        service = MemoryService(db)
+        metadata = service.get_file_metadata(entity_id)
+        return {"success": True, "metadata": metadata}
+    except HTTPException as e:
+        logger.error(
+            f"MCP get memory metadata failed with HTTP exception: {e.detail}"
+        )
+        raise e
+    except Exception as e:
+        logger.error(f"MCP get memory metadata failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/routers/mcp/core.py
+++ b/backend/routers/mcp/core.py
@@ -378,3 +378,49 @@ async def mcp_search_memory(
     except Exception as e:
         logger.error(f"MCP search memory failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get(
+    "/mcp-tools/memory/get-content",
+    tags=["mcp-tools"],
+    operation_id="get_memory_content_tool",
+)
+async def mcp_get_memory_content(
+    entity_id: int,
+    memory_service: MemoryService = Depends(get_memory_service),
+):
+    """MCP Tool: Retrieve memory entity content."""
+    try:
+        content = memory_service.get_file_content(entity_id)
+        return {"success": True, "content": content}
+    except HTTPException as e:
+        logger.error(
+            f"MCP get memory content failed with HTTP exception: {e.detail}"
+        )
+        raise e
+    except Exception as e:
+        logger.error(f"MCP get memory content failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get(
+    "/mcp-tools/memory/get-metadata",
+    tags=["mcp-tools"],
+    operation_id="get_memory_metadata_tool",
+)
+async def mcp_get_memory_metadata(
+    entity_id: int,
+    memory_service: MemoryService = Depends(get_memory_service),
+):
+    """MCP Tool: Retrieve memory entity metadata."""
+    try:
+        metadata = memory_service.get_file_metadata(entity_id)
+        return {"success": True, "metadata": metadata}
+    except HTTPException as e:
+        logger.error(
+            f"MCP get memory metadata failed with HTTP exception: {e.detail}"
+        )
+        raise e
+    except Exception as e:
+        logger.error(f"MCP get memory metadata failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
## Summary
- implement retrieval helpers in `memory_tools`
- expose `/mcp-tools/memory/get-content` and `/mcp-tools/memory/get-metadata` routes

## Testing
- `flake8 mcp_tools/memory_tools.py routers/mcp/core.py | head -n 5` *(fails: IndentationError)*
- `pytest -q` *(fails to import backend app)*
- `npm test --silent` *(fails: vitest not found)*
- `npm run lint --silent` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840edc27dd4832c9dd5bc84b0e5da0d