### PR TITLE
Add MCP task update/delete tools

### DIFF
--- a/backend/app_factory.py
+++ b/backend/app_factory.py
@@ -276,7 +276,7 @@ def create_app() -> FastAPI:
     """Application factory for the Task Manager backend."""
     app = FastAPI(
         title="Task Manager API",
-        version="2.0.0",
+        version="2.0.1",
         description="Task Manager with MCP integration",
         openapi_url="/openapi.json",
         docs_url=None,


### PR DESCRIPTION
## Summary
- expose `task/update` and `task/delete` MCP tools
- implement helper functions for updating and deleting tasks
- bump API version to 2.0.1

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm run test:all` *(fails: Missing script "test:all")*

------
https://chatgpt.com/codex/tasks/task_e_6840edc26e54832c88f59187a137b0b1