### PR TITLE
Add memory ingestion form

### DIFF
--- a/frontend/src/components/memory/MemoryIngestForm.tsx
+++ b/frontend/src/components/memory/MemoryIngestForm.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  HStack,
+  Input,
+  Radio,
+  RadioGroup,
+  Textarea,
+  VStack,
+  useToast,
+} from "@chakra-ui/react";
+import { memoryApi } from "@/services/api";
+
+const MemoryIngestForm: React.FC = () => {
+  const toast = useToast();
+  const [mode, setMode] = useState<"file" | "url" | "text">("file");
+  const [filePath, setFilePath] = useState("");
+  const [url, setUrl] = useState("");
+  const [text, setText] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    try {
+      if (mode === "file") {
+        await memoryApi.ingestFile(filePath);
+      } else if (mode === "url") {
+        await memoryApi.ingestUrl(url);
+      } else {
+        await memoryApi.ingestText(text);
+      }
+      toast({
+        title: "Ingestion successful",
+        status: "success",
+        duration: 3000,
+        isClosable: true,
+      });
+      setFilePath("");
+      setUrl("");
+      setText("");
+    } catch (err) {
+      toast({
+        title: "Ingestion failed",
+        description: err instanceof Error ? err.message : "Failed to ingest",
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Box
+      as="form"
+      onSubmit={handleSubmit}
+      p={4}
+      borderWidth="1px"
+      borderRadius="md"
+      bg="bg.surface"
+    >
+      <VStack spacing={4} align="stretch">
+        <RadioGroup value={mode} onChange={(v) => setMode(v as "file" | "url" | "text")}>
+          <HStack spacing={4}>
+            <Radio value="file">File</Radio>
+            <Radio value="url">URL</Radio>
+            <Radio value="text">Text</Radio>
+          </HStack>
+        </RadioGroup>
+
+        {mode === "file" && (
+          <FormControl>
+            <FormLabel>File Path</FormLabel>
+            <Input
+              value={filePath}
+              onChange={(e) => setFilePath(e.target.value)}
+              placeholder="/path/to/file.txt"
+            />
+          </FormControl>
+        )}
+
+        {mode === "url" && (
+          <FormControl>
+            <FormLabel>URL</FormLabel>
+            <Input
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="https://example.com"
+            />
+          </FormControl>
+        )}
+
+        {mode === "text" && (
+          <FormControl>
+            <FormLabel>Text</FormLabel>
+            <Textarea
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              placeholder="Enter text"
+            />
+          </FormControl>
+        )}
+
+        <Button type="submit" colorScheme="blue" isLoading={isLoading}>
+          Ingest
+        </Button>
+      </VStack>
+    </Box>
+  );
+};
+
+export default MemoryIngestForm;

--- a/frontend/src/components/memory/__tests__/MemoryIngestForm.test.tsx
+++ b/frontend/src/components/memory/__tests__/MemoryIngestForm.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen, TestWrapper } from '@/__tests__/utils/test-utils';
+import MemoryIngestForm from '../MemoryIngestForm';
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual('@chakra-ui/react');
+  return {
+    ...actual,
+    useToast: () => vi.fn(),
+    useColorModeValue: (l: any, d: any) => l,
+  };
+});
+
+vi.mock('@/services/api', () => ({
+  memoryApi: {
+    ingestFile: vi.fn(),
+    ingestUrl: vi.fn(),
+    ingestText: vi.fn(),
+  },
+}));
+
+describe('MemoryIngestForm', () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders without crashing', () => {
+    render(
+      <TestWrapper>
+        <MemoryIngestForm />
+      </TestWrapper>
+    );
+    expect(document.body).toBeInTheDocument();
+  });
+
+  it('handles basic interactions', async () => {
+    render(
+      <TestWrapper>
+        <MemoryIngestForm />
+      </TestWrapper>
+    );
+
+    const radios = screen.getAllByRole('radio');
+    const inputs = screen.queryAllByRole('textbox');
+    const buttons = screen.getAllByRole('button');
+
+    if (radios.length > 0) {
+      await user.click(radios[0]);
+    }
+    if (inputs.length > 0) {
+      await user.type(inputs[0], 'test');
+    }
+    if (buttons.length > 0) {
+      await user.click(buttons[0]);
+    }
+
+    expect(document.body).toBeInTheDocument();
+  });
+});

--- a/frontend/src/services/api/memory.ts
+++ b/frontend/src/services/api/memory.ts
@@ -78,6 +78,42 @@ export const memoryApi = {
     );
   },
 
+  // Ingest a file from the server filesystem
+  ingestFile: async (filePath: string): Promise<MemoryEntity> => {
+    const response = await request<MemoryEntityResponse>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/entities/ingest/file"),
+      {
+        method: "POST",
+        body: JSON.stringify({ file_path: filePath }),
+      }
+    );
+    return response.data;
+  },
+
+  // Ingest content directly from a URL
+  ingestUrl: async (url: string): Promise<MemoryEntity> => {
+    const response = await request<MemoryEntityResponse>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/ingest-url"),
+      {
+        method: "POST",
+        body: JSON.stringify({ url }),
+      }
+    );
+    return response.data;
+  },
+
+  // Ingest a raw text snippet
+  ingestText: async (text: string): Promise<MemoryEntity> => {
+    const response = await request<MemoryEntityResponse>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/ingest-text"),
+      {
+        method: "POST",
+        body: JSON.stringify({ text }),
+      }
+    );
+    return response.data;
+  },
+
   // --- Memory Observation APIs ---
   // Add an observation to an entity
   addObservation: async (data: MemoryObservationCreateData): Promise<MemoryObservation> => {


### PR DESCRIPTION
## Summary
- support ingestion endpoints in memory API
- create `MemoryIngestForm` for file, URL, or text
- add unit tests for the new form

## Testing
- `npm run lint`
- `npm test` *(fails: Task Management integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_6840edc512f4832caed0ab50a5b8c389