### PR TITLE
Extend MCP API tools

### DIFF
--- a/frontend/src/services/api/mcp.ts
+++ b/frontend/src/services/api/mcp.ts
@@ -4,11 +4,19 @@ import type {
   MCPToolResponse,
   MCPProjectCreateRequest,
   MCPProjectDeleteRequest,
+  MCPProjectUpdateRequest,
   MCPTaskCreateRequest,
   MCPTaskUpdateRequest,
+  MCPTaskDeleteRequest,
   MCPMemoryCreateEntityRequest,
   MCPMemoryCreateObservationRequest,
   MCPMemoryCreateRelationRequest,
+  MCPMemoryGetContentRequest,
+  MCPMemoryGetMetadataRequest,
+  MCPProjectMemberAddRequest,
+  MCPProjectMemberRemoveRequest,
+  MCPProjectFileAddRequest,
+  MCPProjectFileRemoveRequest,
   MCPToolInfo,
 } from "@/types/mcp";
 
@@ -18,6 +26,16 @@ export const mcpApi = {
     create: async (data: MCPProjectCreateRequest): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
         buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/project/create"),
+        {
+          method: "POST",
+          body: JSON.stringify(data),
+        }
+      );
+    },
+
+    update: async (data: MCPProjectUpdateRequest): Promise<MCPToolResponse> => {
+      return await request<MCPToolResponse>(
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/project/update"),
         {
           method: "POST",
           body: JSON.stringify(data),
@@ -51,6 +69,16 @@ export const mcpApi = {
     update: async (data: MCPTaskUpdateRequest): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
         buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/task/update"),
+        {
+          method: "POST",
+          body: JSON.stringify(data),
+        }
+      );
+    },
+
+    delete: async (data: MCPTaskDeleteRequest): Promise<MCPToolResponse> => {
+      return await request<MCPToolResponse>(
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/task/delete"),
         {
           method: "POST",
           body: JSON.stringify(data),
@@ -124,9 +152,85 @@ export const mcpApi = {
       );
     },
 
+    getContent: async (
+      data: MCPMemoryGetContentRequest
+    ): Promise<MCPToolResponse> => {
+      return await request<MCPToolResponse>(
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/memory/get-content"),
+        {
+          method: "POST",
+          body: JSON.stringify(data),
+        }
+      );
+    },
+
+    getMetadata: async (
+      data: MCPMemoryGetMetadataRequest
+    ): Promise<MCPToolResponse> => {
+      return await request<MCPToolResponse>(
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/memory/get-metadata"),
+        {
+          method: "POST",
+          body: JSON.stringify(data),
+        }
+      );
+    },
+
     search: async (query: string): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
         buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, `/memory/search?q=${encodeURIComponent(query)}`)
+      );
+    },
+  },
+
+  // --- Project Member MCP Tools ---
+  projectMember: {
+    add: async (
+      data: MCPProjectMemberAddRequest
+    ): Promise<MCPToolResponse> => {
+      return await request<MCPToolResponse>(
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/project/member/add"),
+        {
+          method: "POST",
+          body: JSON.stringify(data),
+        }
+      );
+    },
+
+    remove: async (
+      data: MCPProjectMemberRemoveRequest
+    ): Promise<MCPToolResponse> => {
+      return await request<MCPToolResponse>(
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/project/member/remove"),
+        {
+          method: "POST",
+          body: JSON.stringify(data),
+        }
+      );
+    },
+  },
+
+  // --- Project File MCP Tools ---
+  projectFile: {
+    add: async (data: MCPProjectFileAddRequest): Promise<MCPToolResponse> => {
+      return await request<MCPToolResponse>(
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/project/file/add"),
+        {
+          method: "POST",
+          body: JSON.stringify(data),
+        }
+      );
+    },
+
+    remove: async (
+      data: MCPProjectFileRemoveRequest
+    ): Promise<MCPToolResponse> => {
+      return await request<MCPToolResponse>(
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/project/file/remove"),
+        {
+          method: "POST",
+          body: JSON.stringify(data),
+        }
       );
     },
   },

--- a/frontend/src/types/mcp.ts
+++ b/frontend/src/types/mcp.ts
@@ -24,6 +24,15 @@ export const mcpProjectDeleteRequestSchema = z.object({
 
 export type MCPProjectDeleteRequest = z.infer<typeof mcpProjectDeleteRequestSchema>;
 
+export const mcpProjectUpdateRequestSchema = z.object({
+  project_id: z.string(),
+  name: z.string().optional(),
+  description: z.string().nullable().optional(),
+  is_archived: z.boolean().optional(),
+});
+
+export type MCPProjectUpdateRequest = z.infer<typeof mcpProjectUpdateRequestSchema>;
+
 // --- MCP Task Tool Schemas ---
 export const mcpTaskCreateRequestSchema = z.object({
   project_id: z.string(),
@@ -44,6 +53,13 @@ export const mcpTaskUpdateRequestSchema = z.object({
 });
 
 export type MCPTaskUpdateRequest = z.infer<typeof mcpTaskUpdateRequestSchema>;
+
+export const mcpTaskDeleteRequestSchema = z.object({
+  project_id: z.string(),
+  task_number: z.number(),
+});
+
+export type MCPTaskDeleteRequest = z.infer<typeof mcpTaskDeleteRequestSchema>;
 
 // --- MCP Memory Tool Schemas ---
 export const mcpMemoryCreateEntityRequestSchema = z.object({
@@ -69,6 +85,49 @@ export const mcpMemoryCreateRelationRequestSchema = z.object({
 });
 
 export type MCPMemoryCreateRelationRequest = z.infer<typeof mcpMemoryCreateRelationRequestSchema>;
+
+export const mcpMemoryGetContentRequestSchema = z.object({
+  entity_id: z.number(),
+});
+
+export type MCPMemoryGetContentRequest = z.infer<typeof mcpMemoryGetContentRequestSchema>;
+
+export const mcpMemoryGetMetadataRequestSchema = z.object({
+  entity_id: z.number(),
+});
+
+export type MCPMemoryGetMetadataRequest = z.infer<typeof mcpMemoryGetMetadataRequestSchema>;
+
+// --- MCP Project Member Tool Schemas ---
+export const mcpProjectMemberAddRequestSchema = z.object({
+  project_id: z.string(),
+  user_id: z.string(),
+  role: z.string(),
+});
+
+export type MCPProjectMemberAddRequest = z.infer<typeof mcpProjectMemberAddRequestSchema>;
+
+export const mcpProjectMemberRemoveRequestSchema = z.object({
+  project_id: z.string(),
+  user_id: z.string(),
+});
+
+export type MCPProjectMemberRemoveRequest = z.infer<typeof mcpProjectMemberRemoveRequestSchema>;
+
+// --- MCP Project File Tool Schemas ---
+export const mcpProjectFileAddRequestSchema = z.object({
+  project_id: z.string(),
+  file_id: z.string(),
+});
+
+export type MCPProjectFileAddRequest = z.infer<typeof mcpProjectFileAddRequestSchema>;
+
+export const mcpProjectFileRemoveRequestSchema = z.object({
+  project_id: z.string(),
+  file_id: z.string(),
+});
+
+export type MCPProjectFileRemoveRequest = z.infer<typeof mcpProjectFileRemoveRequestSchema>;
 
 // --- MCP Tool Categories ---
 export enum MCPToolCategory {


### PR DESCRIPTION
## Summary
- add missing MCP tool request types
- support additional MCP endpoints in the API service

## Testing
- `npm run lint`
- `npm test` *(fails: observer.observe is not a function)*
- `flake8 .` *(fails: E501 line too long etc.)*
- `pytest -q` *(fails: ImportError while loading conftest)*

------
https://chatgpt.com/codex/tasks/task_e_6840edc42b28832cab26c53d41e557d4