### PR TITLE
Implement token storage and auth headers

### DIFF
--- a/frontend/src/services/api/request.ts
+++ b/frontend/src/services/api/request.ts
@@ -1,4 +1,4 @@
-import { StatusID } from "@/lib/statusUtils";
+import { StatusID } from '@/lib/statusUtils';
 
 /** Error type thrown when API requests fail */
 export class ApiError extends Error {
@@ -7,7 +7,7 @@ export class ApiError extends Error {
 
   constructor(message: string, status: number, url: string) {
     super(message);
-    this.name = "ApiError";
+    this.name = 'ApiError';
     this.status = status;
     this.url = url;
   }
@@ -16,44 +16,52 @@ export class ApiError extends Error {
 // Helper to normalize status string to a known StatusID
 export const normalizeToStatusID = (
   backendStatus: string | null | undefined,
-  completedFlag: boolean,
+  completedFlag: boolean
 ): StatusID => {
   if (completedFlag) {
-    return "Completed";
+    return 'Completed';
   }
   if (backendStatus) {
     const validStatuses: StatusID[] = [
-      "To Do",
-      "In Progress",
-      "In Review",
-      "Completed",
-      "Blocked",
-      "Cancelled",
+      'To Do',
+      'In Progress',
+      'In Review',
+      'Completed',
+      'Blocked',
+      'Cancelled',
     ];
     if (validStatuses.includes(backendStatus as StatusID)) {
       return backendStatus as StatusID;
     }
 
     console.warn(
-      `Unknown backend status string: "${backendStatus}". Defaulting to "To Do".`,
+      `Unknown backend status string: "${backendStatus}". Defaulting to "To Do".`
     );
-    return "To Do";
+    return 'To Do';
   }
-  return "To Do";
+  return 'To Do';
 };
 
 // Helper function to handle API requests
 export async function request<T>(
   url: string,
-  options: RequestInit = {},
+  options: RequestInit = {}
 ): Promise<T> {
   const headers: HeadersInit = {
     ...(options.headers || {}),
   };
 
+  if (!('Authorization' in headers)) {
+    const token =
+      typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+    if (token) {
+      (headers as Record<string, string>).Authorization = `Bearer ${token}`;
+    }
+  }
+
   const method = options.method?.toUpperCase();
-  if (method === "POST" || method === "PUT" || method === "PATCH") {
-    (headers as Record<string, string>)["Content-Type"] = "application/json";
+  if (method === 'POST' || method === 'PUT' || method === 'PATCH') {
+    (headers as Record<string, string>)['Content-Type'] = 'application/json';
   }
 
   let response: Response;
@@ -63,7 +71,7 @@ export async function request<T>(
       headers,
     });
   } catch (err) {
-    throw new ApiError((err as Error).message || "Network Error", 0, url);
+    throw new ApiError((err as Error).message || 'Network Error', 0, url);
   }
 
   if (!response.ok) {
@@ -96,8 +104,8 @@ export async function request<T>(
 
   if (
     responseData &&
-    typeof responseData === "object" &&
-    "data" in responseData
+    typeof responseData === 'object' &&
+    'data' in responseData
   ) {
     return responseData.data as T;
   }

--- a/frontend/src/services/api/users.ts
+++ b/frontend/src/services/api/users.ts
@@ -43,7 +43,7 @@ export const getUsers = async (skip = 0, limit = 100): Promise<User[]> => {
  */
 export const updateUser = async (
   userId: string,
-  userData: UserUpdateData,
+  userData: UserUpdateData
 ): Promise<User> => {
   return request<User>(buildApiUrl(API_CONFIG.ENDPOINTS.USERS, `/${userId}`), {
     method: 'PUT',
@@ -65,9 +65,18 @@ export const deleteUser = async (userId: string): Promise<User> => {
  */
 export const login = async (formData: LoginRequest): Promise<TokenResponse> => {
   // Use the OAuth2-compatible token endpoint which expects URL encoded form data
-  return request<TokenResponse>(buildApiUrl(API_CONFIG.ENDPOINTS.AUTH, '/token'), {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams(formData as Record<string, string>).toString(),
-  });
+  return request<TokenResponse>(
+    buildApiUrl(API_CONFIG.ENDPOINTS.AUTH, '/token'),
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams(formData as Record<string, string>).toString(),
+    }
+  );
+};
+
+export const logout = (): void => {
+  if (typeof window !== 'undefined') {
+    localStorage.removeItem('token');
+  }
 };

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -1,19 +1,36 @@
-import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 interface AuthState {
   token: string | null;
   setToken: (token: string) => void;
   clearToken: () => void;
+  logout: () => void;
 }
 
 export const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({
       token: null,
-      setToken: (token: string) => set({ token }),
-      clearToken: () => set({ token: null }),
+      setToken: (token: string) => {
+        if (typeof window !== 'undefined') {
+          localStorage.setItem('token', token);
+        }
+        set({ token });
+      },
+      clearToken: () => {
+        if (typeof window !== 'undefined') {
+          localStorage.removeItem('token');
+        }
+        set({ token: null });
+      },
+      logout: () => {
+        if (typeof window !== 'undefined') {
+          localStorage.removeItem('token');
+        }
+        set({ token: null });
+      },
     }),
-    { name: "auth" },
-  ),
+    { name: 'auth' }
+  )
 );


### PR DESCRIPTION
## Summary
- store JWT token when setting auth state
- clear stored token on logout
- attach token as bearer auth header in request helper

## Testing
- `npm run lint`
- `npm test` *(fails: observer.observe is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6840edc9a278832c94447c92ab99cca2