### PR TITLE
Update FastAPI MCP docs

### DIFF
--- a/backend/docs/fastapi_mcp/README.md
+++ b/backend/docs/fastapi_mcp/README.md
@@ -80,6 +80,20 @@ FastAPI-MCP is designed as a native extension of FastAPI, not just a converter t
 
 This design philosophy ensures minimum friction when adding MCP capabilities to your existing FastAPI services.
 
+## Tool Routes
+
+FastAPI-MCP automatically exposes selected API endpoints as tools under the `/mcp-tools` prefix. The current routes are:
+
+- `/mcp-tools/project/create` (POST)
+- `/mcp-tools/task/create` (POST)
+- `/mcp-tools/projects/list` (GET)
+- `/mcp-tools/tasks/list` (GET)
+- `/mcp-tools/memory/add-entity` (POST)
+- `/mcp-tools/memory/update-entity` (POST)
+- `/mcp-tools/memory/add-observation` (POST)
+- `/mcp-tools/memory/add-relation` (POST)
+- `/mcp-tools/memory/search` (GET)
+
 ## Development and Contributing
 
 Thank you for considering contributing to FastAPI-MCP! We encourage the community to post Issues and create Pull Requests.
@@ -105,3 +119,4 @@ MIT License. Copyright (c) 2024 Tadata Inc.
 - `docs.json`
 
 <!-- File List End -->
+

--- a/backend/docs/fastapi_mcp/docs.json
+++ b/backend/docs/fastapi_mcp/docs.json
@@ -1,80 +1,80 @@
 {
-    "$schema": "https://mintlify.com/docs.json",
-    "name": "FastAPI MCP",
-    "background": {
-        "color": {
-            "dark": "#222831",
-            "light": "#EEEEEE"
-        },
-        "decoration": "windows"
+  "$schema": "https://mintlify.com/docs.json",
+  "name": "FastAPI MCP",
+  "background": {
+    "color": {
+      "dark": "#222831",
+      "light": "#EEEEEE"
     },
-    "colors": {
-      "primary": "#6d45dc",
-      "light": "#9f8ded",
-      "dark": "#6a42d7"
-    },
-    "description": "Convert your FastAPI app into a MCP server with zero configuration",
-    "navigation": {
-      "groups": [
-        {
-            "group": "Getting Started",
-            "pages": [
-              "getting-started/welcome",
-              "getting-started/installation",
-              "getting-started/quickstart",
-              "getting-started/FAQ",
-              "getting-started/best-practices"
-            ]
-        },
-        {
-            "group": "Configurations",
-            "pages": [
-              "configurations/tool-naming",
-              "configurations/customization"
-            ]
-        },
-        {
-            "group": "Advanced Usage",
-            "pages": [
-              "advanced/auth",
-              "advanced/deploy",
-              "advanced/refresh",
-              "advanced/transport"
-            ]
-        }
-      ],
-      "global": {
-        "anchors": [
-          {
-            "anchor": "Documentation",
-            "href": "https://fastapi-mcp.tadata.com/",
-            "icon": "book-open-cover"
-          },
-          {
-            "anchor": "Community",
-            "href": "https://join.slack.com/t/themcparty/shared_invite/zt-30yxr1zdi-2FG~XjBA0xIgYSYuKe7~Xg",
-            "icon": "slack"
-          },
-          {
-            "anchor": "Blog",
-            "href": "https://medium.com/@miki_45906",
-            "icon": "newspaper"
-          }
+    "decoration": "windows"
+  },
+  "colors": {
+    "primary": "#6d45dc",
+    "light": "#9f8ded",
+    "dark": "#6a42d7"
+  },
+  "description": "Convert your FastAPI app into a MCP server with zero configuration",
+  "navigation": {
+    "groups": [
+      {
+        "group": "Getting Started",
+        "pages": [
+          "getting-started/welcome",
+          "getting-started/installation",
+          "getting-started/quickstart",
+          "getting-started/FAQ",
+          "getting-started/best-practices"
+        ]
+      },
+      {
+        "group": "Configurations",
+        "pages": [
+          "configurations/tool-naming",
+          "configurations/customization"
+        ]
+      },
+      {
+        "group": "Advanced Usage",
+        "pages": [
+          "advanced/auth",
+          "advanced/deploy",
+          "advanced/refresh",
+          "advanced/transport"
         ]
       }
-    },
-    "navbar": {
-        "primary": {
-            "href": "https://github.com/tadata-org/fastapi_mcp",
-            "type": "github"
+    ],
+    "global": {
+      "anchors": [
+        {
+          "anchor": "Documentation",
+          "href": "https://fastapi-mcp.tadata.com/",
+          "icon": "book-open-cover"
+        },
+        {
+          "anchor": "Community",
+          "href": "https://join.slack.com/t/themcparty/shared_invite/zt-30yxr1zdi-2FG~XjBA0xIgYSYuKe7~Xg",
+          "icon": "slack"
+        },
+        {
+          "anchor": "Blog",
+          "href": "https://medium.com/@miki_45906",
+          "icon": "newspaper"
         }
-    },
-    "footer": {
-      "socials": {
-        "x": "https://x.com/makhlevich",
-        "github": "https://github.com/tadata-org/fastapi_mcp",
-        "website": "https://tadata.com/"
-      }
-    },
-    "theme": "mint"
-  }
+      ]
+    }
+  },
+  "navbar": {
+    "primary": {
+      "href": "https://github.com/tadata-org/fastapi_mcp",
+      "type": "github"
+    }
+  },
+  "footer": {
+    "socials": {
+      "x": "https://x.com/makhlevich",
+      "github": "https://github.com/tadata-org/fastapi_mcp",
+      "website": "https://tadata.com/"
+    }
+  },
+  "theme": "mint"
+}

--- a/scripts/regenerate_docs_json.py
+++ b/scripts/regenerate_docs_json.py
@@ -1,0 +1,96 @@
+import json
+from pathlib import Path
+
+ROOT = Path('backend/docs/fastapi_mcp')
+TEMPLATE = {
+    "$schema": "https://mintlify.com/docs.json",
+    "name": "FastAPI MCP",
+    "background": {
+        "color": {"dark": "#222831", "light": "#EEEEEE"},
+        "decoration": "windows"
+    },
+    "colors": {"primary": "#6d45dc", "light": "#9f8ded", "dark": "#6a42d7"},
+    "description": "Convert your FastAPI app into a MCP server with zero configuration",
+}
+
+GROUPS = {
+    "getting-started": [
+        "welcome",
+        "installation",
+        "quickstart",
+        "FAQ",
+        "best-practices",
+    ],
+    "configurations": [
+        "tool-naming",
+        "customization",
+    ],
+    "advanced": [
+        "auth",
+        "deploy",
+        "refresh",
+        "transport",
+    ],
+}
+TITLE_MAP = {
+    "getting-started": "Getting Started",
+    "configurations": "Configurations",
+    "advanced": "Advanced Usage",
+}
+
+navigation_groups = []
+for folder, files in GROUPS.items():
+    pages = [
+        f"{folder}/{name}"
+        for name in files
+        if (ROOT / folder / f"{name}.md").exists()
+    ]
+    navigation_groups.append({"group": TITLE_MAP[folder], "pages": pages})
+
+docs_json = TEMPLATE | {
+    "navigation": {
+        "groups": navigation_groups,
+        "global": {
+            "anchors": [
+                {
+                    "anchor": "Documentation",
+                    "href": "https://fastapi-mcp.tadata.com/",
+                    "icon": "book-open-cover",
+                },
+                {
+                    "anchor": "Community",
+                    "href": (
+                        "https://join.slack.com/t/themcparty/"
+                        "shared_invite/zt-30yxr1zdi-2FG~XjBA0xIgYSYuKe7~Xg"
+                    ),
+                    "icon": "slack",
+                },
+                {
+                    "anchor": "Blog",
+                    "href": "https://medium.com/@miki_45906",
+                    "icon": "newspaper",
+                },
+            ]
+        }
+    },
+    "navbar": {
+        "primary": {
+            "href": "https://github.com/tadata-org/fastapi_mcp",
+            "type": "github",
+        }
+    },
+    "footer": {
+        "socials": {
+            "x": "https://x.com/makhlevich",
+            "github": "https://github.com/tadata-org/fastapi_mcp",
+            "website": "https://tadata.com/",
+        }
+    },
+    "theme": "mint",
+}
+
+with open(ROOT / 'docs.json', 'w', encoding='utf-8') as f:
+    json.dump(docs_json, f, indent=2)
+    f.write('\n')
+
+print('docs.json regenerated')


### PR DESCRIPTION
## Summary
- regenerate `docs.json` for FastAPI MCP docs
- document all available MCP tool routes in the README
- add helper script for docs.json generation

## Testing
- `python3 -m flake8 scripts/regenerate_docs_json.py`
- `pytest -k "dummy"` *(fails: ImportError: cannot import name 'app')*
- `npm --prefix frontend run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840edcc9910832c971c244700784431