### PR TITLE
Add toast-based API error handler

### DIFF
--- a/frontend/src/lib/__tests__/apiErrorHandler.test.ts
+++ b/frontend/src/lib/__tests__/apiErrorHandler.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockToast = vi.fn();
+vi.mock('@chakra-ui/react', async () => {
+  const actual =
+    await vi.importActual<typeof import('@chakra-ui/react')>(
+      '@chakra-ui/react'
+    );
+  return {
+    ...actual,
+    createStandaloneToast: () => ({ toast: mockToast }),
+  };
+});
+
+import { handleApiError } from '../apiErrorHandler';
+import { ApiError } from '@/services/api/request';
+
+describe('handleApiError', () => {
+  beforeEach(() => {
+    mockToast.mockClear();
+  });
+
+  it('handles ApiError instances', () => {
+    handleApiError(new ApiError('Boom', 500), 'Oops');
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Oops',
+        description: 'Boom',
+        status: 'error',
+      })
+    );
+  });
+
+  it('handles Error objects', () => {
+    handleApiError(new Error('Fail'));
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ description: 'Fail' })
+    );
+  });
+
+  it('handles string messages', () => {
+    handleApiError('Nope');
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ description: 'Nope' })
+    );
+  });
+});

--- a/frontend/src/lib/apiErrorHandler.ts
+++ b/frontend/src/lib/apiErrorHandler.ts
@@ -1,35 +1,26 @@
-import { createStandaloneToast, UseToastOptions } from "@chakra-ui/react";
-
-export class ApiError extends Error {
-  status?: number;
-  code?: string | number;
-  constructor(message: string, status?: number, code?: string | number) {
-    super(message);
-    this.status = status;
-    this.code = code;
-  }
-}
+import { createStandaloneToast, UseToastOptions } from '@chakra-ui/react';
+import { ApiError } from '@/services/api/request';
 
 const { toast } = createStandaloneToast();
 
 export function handleApiError(
   error: unknown,
-  title = "API Error",
-  options?: Partial<UseToastOptions>,
+  title = 'API Error',
+  options?: Partial<UseToastOptions>
 ): void {
-  let description = "An unexpected error occurred.";
+  let description = 'An unexpected error occurred.';
   if (error instanceof ApiError) {
     description = error.message;
   } else if (error instanceof Error) {
     description = error.message;
-  } else if (typeof error === "string") {
+  } else if (typeof error === 'string') {
     description = error;
   }
 
   toast({
     title,
     description,
-    status: "error",
+    status: 'error',
     duration: 5000,
     isClosable: true,
     ...options,

--- a/frontend/src/store/README.md
+++ b/frontend/src/store/README.md
@@ -13,7 +13,7 @@ These stores centralize application state and logic for handling data related to
   - Defines a `BaseState` interface including `loading` (boolean), `error` (string | null), and a `clearError` function.
   - The `createBaseStore` factory function initializes new stores with this base state, user-defined initial data, and an actions creator function.
   - Supports optional state persistence via `zustand/middleware/persist`, configured with a store name and version.
-  - Includes a `handleApiError` utility to standardize error message extraction.
+  - Includes an `extractErrorMessage` utility to standardize error message extraction.
   - Provides a `withLoading` higher-order function that wraps asynchronous operations (like API calls) to automatically manage the `loading` and `error` states within the store.
 
 ### `projectStore.ts`
@@ -64,6 +64,7 @@ These stores centralize application state and logic for handling data related to
 These stores are fundamental to the application's reactivity and data flow, providing a structured way to manage and interact with backend data on the client side.
 
 ## Architecture Diagram
+
 ```mermaid
 graph TD
     user((User)) -->|interacts with| frontend(Frontend)
@@ -73,6 +74,7 @@ graph TD
 ```
 
 <!-- File List Start -->
+
 ## File List
 
 - `agentStore.ts`
@@ -83,4 +85,3 @@ graph TD
 - `taskStore.ts`
 
 <!-- File List End -->
-


### PR DESCRIPTION
## Summary
- use ApiError from `request.ts` in `handleApiError`
- surface API failures with Chakra toasts in stores
- adjust store helpers to expose `extractErrorMessage`
- document new helper
- add unit tests for `handleApiError`

## Testing
- `npm --prefix frontend run format`
- `npx eslint frontend/src/lib/apiErrorHandler.ts frontend/src/store/baseStore.ts frontend/src/store/agentStore.ts frontend/src/store/README.md frontend/src/lib/__tests__/apiErrorHandler.test.ts --fix` *(fails: ESLint config issues)*
- `npm --prefix frontend run test:coverage` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6840edcda92c832ca4a28b2e095fef46