### PR TITLE
Add audit log viewer page

### DIFF
--- a/frontend/src/app/audit-logs/page.tsx
+++ b/frontend/src/app/audit-logs/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+import React from 'react';
+import AuditLogViewer from '@/components/audit/AuditLogViewer';
+
+const AuditLogsPage: React.FC = () => {
+  return <AuditLogViewer />;
+};
+
+export default AuditLogsPage;

--- a/frontend/src/components/audit/AuditLogViewer.tsx
+++ b/frontend/src/components/audit/AuditLogViewer.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Input,
+  Button,
+  Flex,
+} from '@chakra-ui/react';
+import { AuditLog } from '@/types/audit_log';
+import { getAuditLogs } from '@/services/api/audit_logs';
+
+const AuditLogViewer: React.FC = () => {
+  const [logs, setLogs] = useState<AuditLog[]>([]);
+  const [projectId, setProjectId] = useState('');
+  const [userId, setUserId] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const fetchLogs = async () => {
+    setLoading(true);
+    try {
+      const data = await getAuditLogs({
+        project_id: projectId || undefined,
+        user_id: userId || undefined,
+      });
+      setLogs(data);
+    } catch (err) {
+      console.error('Failed to fetch audit logs', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchLogs();
+  }, []);
+
+  return (
+    <Box p={4}>
+      <Flex mb={4} gap={2} flexWrap="wrap">
+        <Input
+          placeholder="Project ID"
+          value={projectId}
+          onChange={(e) => setProjectId(e.target.value)}
+          maxW="200px"
+        />
+        <Input
+          placeholder="User ID"
+          value={userId}
+          onChange={(e) => setUserId(e.target.value)}
+          maxW="200px"
+        />
+        <Button onClick={fetchLogs} isLoading={loading} minW="100px">
+          Apply
+        </Button>
+      </Flex>
+      <Table variant="simple" size="sm">
+        <Thead>
+          <Tr>
+            <Th>ID</Th>
+            <Th>Action</Th>
+            <Th>User</Th>
+            <Th>Timestamp</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {logs.map((log) => (
+            <Tr key={log.id}>
+              <Td>{log.id}</Td>
+              <Td>{log.action}</Td>
+              <Td>{log.user_id || '-'}</Td>
+              <Td>{new Date(log.timestamp).toLocaleString()}</Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </Box>
+  );
+};
+
+export default AuditLogViewer;

--- a/frontend/src/services/api/audit_logs.ts
+++ b/frontend/src/services/api/audit_logs.ts
@@ -2,6 +2,23 @@ import { request } from "./request";
 import { AuditLog, AuditLogFilters } from "@/types/audit_log";
 import { buildApiUrl, API_CONFIG } from "./config";
 
+// Fetch audit logs with optional filters
+export const getAuditLogs = async (
+  filters?: AuditLogFilters & { project_id?: string }
+): Promise<AuditLog[]> => {
+  const queryParams = new URLSearchParams();
+  if (filters?.user_id) queryParams.append("user_id", filters.user_id);
+  if (filters?.project_id) queryParams.append("project_id", filters.project_id);
+  if (filters?.skip !== undefined) queryParams.append("skip", String(filters.skip));
+  if (filters?.limit !== undefined) queryParams.append("limit", String(filters.limit));
+  const queryString = queryParams.toString();
+  const url = buildApiUrl(
+    API_CONFIG.ENDPOINTS.AUDIT_LOGS,
+    queryString ? `?${queryString}` : ""
+  );
+  return request<AuditLog[]>(url);
+};
+
 // Fetch a single audit log entry by ID
 export const getAuditLogById = async (logId: string): Promise<AuditLog> => {
   return request<AuditLog>(buildApiUrl(API_CONFIG.ENDPOINTS.AUDIT_LOGS, `/${logId}`));


### PR DESCRIPTION
## Summary
- implement `getAuditLogs` API call
- add `AuditLogViewer` component with project/user filtering
- expose a new `/audit-logs` route

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test:run` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f0dfb9d8832c9638666ad84dd999