### PR TITLE
Add skip/limit support for listing

### DIFF
--- a/backend/routers/mcp/core.py
+++ b/backend/routers/mcp/core.py
@@ -5,7 +5,7 @@ MCP Core Tools Router - Functionality for Project and Task MCP integration.
 Provides MCP tool definitions.
 """
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 from typing import List, Dict, Any, Optional
 import logging
@@ -139,8 +139,8 @@ async def mcp_create_task(
     operation_id="list_projects_tool",
 )
 async def mcp_list_projects(
-    skip: int = 0,
-    limit: int = 100,
+    skip: int = Query(0, ge=0, description="Number of records to skip."),
+    limit: int = Query(100, gt=0, description="Maximum records to return."),
     is_archived: Optional[bool] = None,
     db: Session = Depends(get_db_session)
 ):
@@ -181,8 +181,8 @@ async def mcp_list_tasks(
     project_id: Optional[str] = None,
     status: Optional[str] = None,
     agent_id: Optional[str] = None,
-    skip: int = 0,
-    limit: int = 100,
+    skip: int = Query(0, ge=0, description="Number of records to skip."),
+    limit: int = Query(100, gt=0, description="Maximum records to return."),
     db: Session = Depends(get_db_session)
 ):
     """MCP Tool: List tasks with filtering."""

--- a/backend/services/project_service.py
+++ b/backend/services/project_service.py
@@ -81,12 +81,20 @@ class ProjectService:
     async def get_projects(
         self,
         skip: int = 0,
-        limit: int = 100,
+        limit: Optional[int] = 100,
         search: Optional[str] = None,
         status: Optional[str] = None,
-        is_archived: Optional[bool] = False
-        ) -> List[models.Project]:  # Delegate to CRUD and await
-        return await get_projects(self.db, skip, search, status, is_archived)  # Convert to async method and use await
+        is_archived: Optional[bool] = False,
+    ) -> List[models.Project]:
+        """Retrieve projects with optional pagination and filters."""
+        return await get_projects(
+            self.db,
+            skip=skip,
+            limit=limit,
+            search=search,
+            status=status,
+            is_archived=is_archived,
+        )
     async def create_project(
         self, project: ProjectCreate, created_by_user_id: Optional[str] = None
         ) -> models.Project:

--- a/frontend/src/services/api/projects.ts
+++ b/frontend/src/services/api/projects.ts
@@ -22,6 +22,8 @@ interface RawProject {
 // Fetch all projects
 export const getProjects = async (
   filters?: ProjectFilters,
+  skip = 0,
+  limit = 100,
 ): Promise<Project[]> => {
   const queryParams = new URLSearchParams();
   if (filters?.search) queryParams.append("search", filters.search);
@@ -29,6 +31,8 @@ export const getProjects = async (
   if (filters?.is_archived !== undefined && filters?.is_archived !== null) {
     queryParams.append("is_archived", String(filters.is_archived));
   }
+  queryParams.append("skip", String(skip));
+  queryParams.append("limit", String(limit));
   const queryString = queryParams.toString();
   const url = buildApiUrl(API_CONFIG.ENDPOINTS.PROJECTS, queryString ? `?${queryString}` : "");
   const rawProjects = await request<RawProject[]>(url);

--- a/frontend/src/services/api/tasks.ts
+++ b/frontend/src/services/api/tasks.ts
@@ -171,7 +171,13 @@ export const removeTaskDependency = async (
 };
 
 // Fetch all tasks
-export const getTasks = async (projectId: string, filters?: TaskFilters, sortOptions?: TaskSortOptions): Promise<Task[]> => {
+export const getTasks = async (
+  projectId: string,
+  filters?: TaskFilters,
+  sortOptions?: TaskSortOptions,
+  skip = 0,
+  limit = 100,
+): Promise<Task[]> => {
   const queryParams = new URLSearchParams();
   if (filters?.agentId) queryParams.append("agent_id", filters.agentId);
   if (filters?.status && filters.status !== "all")
@@ -180,6 +186,9 @@ export const getTasks = async (projectId: string, filters?: TaskFilters, sortOpt
   if (filters?.is_archived !== undefined && filters.is_archived !== null) {
     queryParams.append("is_archived", String(filters.is_archived));
   }
+  // Add pagination and sorting parameters if provided
+  queryParams.append("skip", String(skip));
+  queryParams.append("limit", String(limit));
   // Add sorting parameters if provided
   if (sortOptions) {
     if (sortOptions.field) queryParams.append("sort_by", sortOptions.field);
@@ -211,7 +220,12 @@ export const getTasks = async (projectId: string, filters?: TaskFilters, sortOpt
 };
 
 // Fetch all tasks across all projects
-export const getAllTasks = async (filters?: TaskFilters, sortOptions?: TaskSortOptions): Promise<Task[]> => {
+export const getAllTasks = async (
+  filters?: TaskFilters,
+  sortOptions?: TaskSortOptions,
+  skip = 0,
+  limit = 100,
+): Promise<Task[]> => {
   const queryParams = new URLSearchParams();
   if (filters?.agentId) queryParams.append("agent_id", filters.agentId);
   if (filters?.status && filters.status !== "all")
@@ -220,6 +234,8 @@ export const getAllTasks = async (filters?: TaskFilters, sortOptions?: TaskSortO
   if (filters?.is_archived !== undefined && filters.is_archived !== null) {
     queryParams.append("is_archived", String(filters.is_archived));
   }
+  queryParams.append("skip", String(skip));
+  queryParams.append("limit", String(limit));
   // Add sorting parameters if provided
   if (sortOptions) {
     if (sortOptions.field) queryParams.append("sort_by", sortOptions.field);


### PR DESCRIPTION
## Summary
- add pagination to project query in CRUD and service layers
- support skip/limit in project list routes
- expose skip/limit query params in MCP list tools
- send skip/limit when fetching projects and tasks in the frontend

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f0dd7c20832c978224885bbe6640