### PR TITLE
Add MCP tool metrics

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,3 +16,4 @@ flake8
 pytest
 pytest-asyncio
 pytest-cov
+redis

--- a/backend/routers/mcp/core.py
+++ b/backend/routers/mcp/core.py
@@ -16,7 +16,10 @@ from ....services.project_service import ProjectService
 from ....services.task_service import TaskService
 from ....services.audit_log_service import AuditLogService
 from ....services.memory_service import MemoryService
-from ....services.project_file_association_service import ProjectFileAssociationService
+from ....services.project_file_association_service import (
+    ProjectFileAssociationService,
+)
+from ....services.tool_metrics_service import ToolMetricsService
 from ....schemas.project import ProjectCreate
 from ....schemas.task import TaskCreate
 from ....schemas.memory import (
@@ -59,6 +62,7 @@ async def mcp_create_project(
     db: Session = Depends(get_db_session)
 ):
     """MCP Tool: Create a new project."""
+    ToolMetricsService.increment("create_project_tool")
     try:
         project_service = ProjectService(db)
         existing = project_service.get_project_by_name(project_data.name)
@@ -98,6 +102,7 @@ async def mcp_create_task(
     db: Session = Depends(get_db_session)
 ):
     """MCP Tool: Create a new task."""
+    ToolMetricsService.increment("create_task_tool")
     try:
         task_service = TaskService(db)
         project_service = ProjectService(db)
@@ -145,6 +150,7 @@ async def mcp_list_projects(
     db: Session = Depends(get_db_session)
 ):
     """MCP Tool: List all projects."""
+    ToolMetricsService.increment("list_projects_tool")
     try:
         project_service = ProjectService(db)
         projects = project_service.get_projects(
@@ -186,6 +192,7 @@ async def mcp_list_tasks(
     db: Session = Depends(get_db_session)
 ):
     """MCP Tool: List tasks with filtering."""
+    ToolMetricsService.increment("list_tasks_tool")
     try:
         task_service = TaskService(db)
         tasks = task_service.get_tasks(
@@ -227,6 +234,7 @@ async def mcp_update_task(
     db: Session = Depends(get_db_session)
 ):
     """MCP Tool: Update an existing task."""
+    ToolMetricsService.increment("update_task_tool")
     try:
         task_service = TaskService(db)
         task = task_service.update_task(
@@ -270,6 +278,7 @@ async def mcp_delete_task(
     db: Session = Depends(get_db_session)
 ):
     """MCP Tool: Delete an existing task."""
+    ToolMetricsService.increment("delete_task_tool")
     try:
         task_service = TaskService(db)
         task_service.delete_task(
@@ -304,6 +313,7 @@ async def mcp_add_project_file(
     service: ProjectFileAssociationService = Depends(get_project_file_service),
 ):
     """MCP Tool: Associate a file (memory entity) with a project."""
+    ToolMetricsService.increment("add_project_file_tool")
     try:
         project_file = service.add_project_file_association(
             project_id=project_id,
@@ -337,6 +347,7 @@ async def mcp_list_project_files(
     service: ProjectFileAssociationService = Depends(get_project_file_service),
 ):
     """MCP Tool: List files associated with a project."""
+    ToolMetricsService.increment("list_project_files_tool")
     try:
         project_files = service.get_project_file_associations(
             project_id=project_id,
@@ -371,6 +382,7 @@ async def mcp_remove_project_file(
     service: ProjectFileAssociationService = Depends(get_project_file_service),
 ):
     """MCP Tool: Remove a file (memory entity) association from a project."""
+    ToolMetricsService.increment("remove_project_file_tool")
     try:
         service.remove_project_file_association(
             project_id=project_id,
@@ -402,6 +414,7 @@ async def mcp_add_memory_entity(
     memory_service: MemoryService = Depends(get_memory_service)
 ):
     """MCP Tool: Add a new memory entity."""
+    ToolMetricsService.increment("add_memory_entity_tool")
     try:
         entity = memory_service.create_memory_entity(entity_data)
         audit_service = AuditLogService(memory_service.db)
@@ -428,6 +441,7 @@ async def mcp_update_memory_entity(
     memory_service: MemoryService = Depends(get_memory_service)
 ):
     """MCP Tool: Update an existing memory entity."""
+    ToolMetricsService.increment("update_memory_entity_tool")
     try:
         entity = memory_service.update_memory_entity(entity_id, entity_update)
         audit_service = AuditLogService(memory_service.db)
@@ -454,6 +468,7 @@ async def mcp_add_memory_observation(
     memory_service: MemoryService = Depends(get_memory_service)
 ):
     """MCP Tool: Add an observation to a memory entity."""
+    ToolMetricsService.increment("add_memory_observation_tool")
     try:
         observation = memory_service.create_memory_observation(entity_id, observation_data)
         audit_service = AuditLogService(memory_service.db)
@@ -479,6 +494,7 @@ async def mcp_add_memory_relation(
     memory_service: MemoryService = Depends(get_memory_service)
 ):
     """MCP Tool: Add a relation between memory entities."""
+    ToolMetricsService.increment("add_memory_relation_tool")
     try:
         relation = memory_service.create_memory_relation(relation_data)
         audit_service = AuditLogService(memory_service.db)
@@ -505,6 +521,7 @@ async def mcp_search_memory(
     memory_service: MemoryService = Depends(get_memory_service)
 ):
     """MCP Tool: Search memory entities by content."""
+    ToolMetricsService.increment("search_memory_tool")
     try:
         results = memory_service.search_memory_entities(query, limit)
         return {"success": True, "results": results}
@@ -523,6 +540,7 @@ async def mcp_get_memory_content(
     memory_service: MemoryService = Depends(get_memory_service),
 ):
     """MCP Tool: Retrieve content of a memory entity by ID."""
+    ToolMetricsService.increment("get_memory_content_tool")
     try:
         content = memory_service.get_memory_entity_content(entity_id)
         if content is None:
@@ -543,6 +561,7 @@ async def mcp_get_memory_metadata(
     memory_service: MemoryService = Depends(get_memory_service),
 ):
     """MCP Tool: Retrieve metadata of a memory entity by ID."""
+    ToolMetricsService.increment("get_memory_metadata_tool")
     try:
         metadata = memory_service.get_memory_entity_metadata(entity_id)
         if metadata is None:
@@ -560,6 +579,7 @@ async def mcp_get_memory_metadata(
 )
 async def mcp_list_tools():
     """MCP Tool: List all available MCP tools."""
+    ToolMetricsService.increment("list_mcp_tools_tool")
     try:
         tool_list = []
         for route in router.routes:
@@ -575,3 +595,13 @@ async def mcp_list_tools():
     except Exception as e:
         logger.error(f"MCP list tools failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get(
+    "/mcp-tools/metrics",
+    tags=["mcp-tools"],
+    operation_id="tool_metrics",
+)
+async def mcp_tool_metrics() -> Dict[str, int]:
+    """Retrieve invocation counts for MCP tools."""
+    return ToolMetricsService.get_counts()

--- a/backend/services/tool_metrics_service.py
+++ b/backend/services/tool_metrics_service.py
@@ -1,0 +1,52 @@
+import os
+import logging
+from typing import Dict
+
+try:
+    import redis  # type: ignore
+except Exception:  # pragma: no cover - redis optional
+    redis = None
+
+logger = logging.getLogger(__name__)
+
+
+class ToolMetricsService:
+    """Service for tracking MCP tool invocation counts."""
+
+    _counts: Dict[str, int] = {}
+    _redis_client = None
+
+    @classmethod
+    def _get_redis_client(cls):
+        if cls._redis_client is not None:
+            return cls._redis_client
+        redis_url = os.getenv("REDIS_URL")
+        if redis_url and redis is not None:
+            try:
+                cls._redis_client = redis.from_url(redis_url, decode_responses=True)
+            except Exception as e:  # pragma: no cover - redis connection failure
+                logger.error(f"Failed to connect to Redis: {e}")
+                cls._redis_client = None
+        return cls._redis_client
+
+    @classmethod
+    def increment(cls, tool_name: str) -> None:
+        client = cls._get_redis_client()
+        if client:
+            try:
+                client.hincrby("mcp_tool_metrics", tool_name, 1)
+            except Exception as e:  # pragma: no cover - redis failure
+                logger.error(f"Redis error updating metrics: {e}")
+        else:
+            cls._counts[tool_name] = cls._counts.get(tool_name, 0) + 1
+
+    @classmethod
+    def get_counts(cls) -> Dict[str, int]:
+        client = cls._get_redis_client()
+        if client:
+            try:
+                metrics = client.hgetall("mcp_tool_metrics")
+                return {k: int(v) for k, v in metrics.items()}
+            except Exception as e:  # pragma: no cover - redis failure
+                logger.error(f"Redis error fetching metrics: {e}")
+        return dict(cls._counts)

--- a/frontend/src/app/mcp-tools/metrics/README.md
+++ b/frontend/src/app/mcp-tools/metrics/README.md
@@ -1,0 +1,4 @@
+# MCP Tool Metrics Page (`frontend/src/app/mcp-tools/metrics/`)
+
+This route exposes the `/mcp-tools/metrics` page which displays invocation counts for each MCP tool.
+It renders the `MCPToolMetrics` component that fetches data from the backend metrics endpoint and shows it in a table.

--- a/frontend/src/app/mcp-tools/metrics/page.tsx
+++ b/frontend/src/app/mcp-tools/metrics/page.tsx
@@ -1,0 +1,5 @@
+import MCPToolMetrics from "@/components/MCPToolMetrics";
+
+export default function MCPToolMetricsPage() {
+  return <MCPToolMetrics />;
+}

--- a/frontend/src/components/MCPToolMetrics.tsx
+++ b/frontend/src/components/MCPToolMetrics.tsx
@@ -1,0 +1,81 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import {
+  Box,
+  Heading,
+  Spinner,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  TableContainer,
+  Text,
+} from "@chakra-ui/react";
+import { mcpApi } from "@/services/api/mcp";
+
+const MCPToolMetrics: React.FC = () => {
+  const [metrics, setMetrics] = useState<Record<string, number>>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchMetrics = async () => {
+      try {
+        const data = await mcpApi.tools.metrics();
+        setMetrics(data);
+      } catch (err) {
+        setError((err as Error).message);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchMetrics();
+  }, []);
+
+  if (loading) {
+    return (
+      <Box p={4} textAlign="center">
+        <Spinner />
+        <Text mt={2}>Loading Metrics...</Text>
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box p={4} borderWidth={1} borderRadius="md">
+        <Text color="red.500">Error: {error}</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box p={4}>
+      <Heading as="h1" size="lg" mb={4}>
+        MCP Tool Metrics
+      </Heading>
+      <TableContainer>
+        <Table variant="simple" size="sm">
+          <Thead>
+            <Tr>
+              <Th>Tool</Th>
+              <Th isNumeric>Invocations</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {Object.entries(metrics).map(([tool, count]) => (
+              <Tr key={tool}>
+                <Td>{tool}</Td>
+                <Td isNumeric>{count}</Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+};
+
+export default MCPToolMetrics;

--- a/frontend/src/services/api/__tests__/mcp.metrics.test.ts
+++ b/frontend/src/services/api/__tests__/mcp.metrics.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mcpApi } from '../mcp';
+
+vi.mock('../request', () => ({
+  request: vi.fn(async () => ({ foo: 1 }))
+}));
+
+describe('mcpApi.tools.metrics', () => {
+  it('calls metrics endpoint', async () => {
+    const data = await mcpApi.tools.metrics();
+    expect(data).toEqual({ foo: 1 });
+  });
+});

--- a/frontend/src/services/api/mcp.ts
+++ b/frontend/src/services/api/mcp.ts
@@ -282,5 +282,12 @@ export const mcpApi = {
       );
       return response;
     },
+
+    metrics: async (): Promise<Record<string, number>> => {
+      const response = await request<Record<string, number>>(
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/metrics")
+      );
+      return response;
+    },
   },
 };


### PR DESCRIPTION
## Summary
- track invocation counts for MCP tools with optional Redis backend
- expose `/mcp-tools/metrics` endpoint
- surface metrics in `mcpApi`
- display tool metrics in new page `/mcp-tools/metrics`
- add tests for the new API call

## Testing
- `flake8` *(fails: command not found)*
- `npm run lint` *(fails: next not found)*
- `npm run test:components` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f1136298832cb6cfa3e03d25f2d8