### PR TITLE
Add observation update API

### DIFF
--- a/frontend/src/services/api/memory.ts
+++ b/frontend/src/services/api/memory.ts
@@ -9,6 +9,7 @@ import type {
   MemoryEntityFilters,
   MemoryObservation,
   MemoryObservationCreateData,
+  MemoryObservationUpdateData,
   MemoryRelation,
   MemoryRelationCreateData,
   MemoryRelationFilters,
@@ -131,6 +132,21 @@ export const memoryApi = {
   getObservations: async (entityId: number): Promise<MemoryObservation[]> => {
     const response = await request<{ data: MemoryObservation[] }>(
       buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/entities/${entityId}/observations`)
+    );
+    return response.data;
+  },
+
+  // Update an observation
+  updateObservation: async (
+    observationId: number,
+    data: MemoryObservationUpdateData
+  ): Promise<MemoryObservation> => {
+    const response = await request<{ data: MemoryObservation }>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/observations/${observationId}`),
+      {
+        method: "PUT",
+        body: JSON.stringify(data),
+      }
     );
     return response.data;
   },

--- a/frontend/src/types/memory.ts
+++ b/frontend/src/types/memory.ts
@@ -33,6 +33,10 @@ export const memoryObservationCreateSchema = memoryObservationBaseSchema;
 
 export type MemoryObservationCreateData = z.infer<typeof memoryObservationCreateSchema>;
 
+export const memoryObservationUpdateSchema = memoryObservationBaseSchema.partial();
+
+export type MemoryObservationUpdateData = z.infer<typeof memoryObservationUpdateSchema>;
+
 export const memoryObservationSchema = memoryObservationBaseSchema.extend({
   id: z.number(),
   created_at: z.string(),


### PR DESCRIPTION
## Summary
- expose MemoryObservationUpdateData type
- support updating memory observations via `memoryApi.updateObservation`

## Testing
- `npm run lint`
- `npm run test:run` *(fails: observer.observe is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6840f3b7b594832ca34e7a8ce77fcf99