### PR TITLE
Add deleteTemplate api helper

### DIFF
--- a/frontend/src/services/api/project_templates.ts
+++ b/frontend/src/services/api/project_templates.ts
@@ -1,10 +1,10 @@
-import { request } from "./request";
-import { buildApiUrl } from "./config";
+import { request } from './request';
+import { buildApiUrl } from './config';
 import {
   ProjectTemplate,
   ProjectTemplateCreateData,
   ProjectTemplateUpdateData,
-} from "@/types/project_template";
+} from '@/types/project_template';
 
 /**
  * Thin REST wrapper for /project-templates endpoints.
@@ -13,38 +13,60 @@ import {
 export const projectTemplatesApi = {
   /** Create a new project template */
   async create(data: ProjectTemplateCreateData): Promise<ProjectTemplate> {
-    return request<ProjectTemplate>(buildApiUrl("/project-templates/"), {
-      method: "POST",
+    return request<ProjectTemplate>(buildApiUrl('/project-templates/'), {
+      method: 'POST',
       body: JSON.stringify(data),
     });
   },
 
   /** List project templates with basic pagination */
   async list(skip = 0, limit = 100): Promise<ProjectTemplate[]> {
-    const params = new URLSearchParams({ skip: String(skip), limit: String(limit) });
-    return request<ProjectTemplate[]>(buildApiUrl("/project-templates/", `?${params}`));
+    const params = new URLSearchParams({
+      skip: String(skip),
+      limit: String(limit),
+    });
+    return request<ProjectTemplate[]>(
+      buildApiUrl('/project-templates/', `?${params}`)
+    );
   },
 
   /** Retrieve a single project template */
   async get(templateId: string): Promise<ProjectTemplate> {
-    return request<ProjectTemplate>(buildApiUrl("/project-templates/", `/${templateId}`));
+    return request<ProjectTemplate>(
+      buildApiUrl('/project-templates/', `/${templateId}`)
+    );
   },
 
   /** Update a project template */
   async update(
     templateId: string,
-    data: ProjectTemplateUpdateData,
+    data: ProjectTemplateUpdateData
   ): Promise<ProjectTemplate> {
-    return request<ProjectTemplate>(buildApiUrl("/project-templates/", `/${templateId}`), {
-      method: "PUT",
-      body: JSON.stringify(data),
-    });
+    return request<ProjectTemplate>(
+      buildApiUrl('/project-templates/', `/${templateId}`),
+      {
+        method: 'PUT',
+        body: JSON.stringify(data),
+      }
+    );
   },
 
   /** Delete a project template */
   async delete(templateId: string): Promise<{ message: string }> {
-    return request<{ message: string }>(buildApiUrl("/project-templates/", `/${templateId}`), {
-      method: "DELETE",
-    });
+    return request<{ message: string }>(
+      buildApiUrl('/project-templates/', `/${templateId}`),
+      {
+        method: 'DELETE',
+      }
+    );
   },
+};
+
+/**
+ * Convenience wrapper for deleting a project template by ID.
+ */
+export const deleteTemplate = async (
+  templateId: string
+): Promise<{ message: string }> => {
+  return projectTemplatesApi.delete(templateId);
 };


### PR DESCRIPTION
## Summary
- add `deleteTemplate` wrapper to `project_templates` API

## Testing
- `npm run lint`
- `npm run test` *(fails: observer.observe is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6840f3bc4544832cb4d2ca1975171eb4