### PR TITLE
Add mandate API client

### DIFF
--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -7,6 +7,7 @@ export * from "./config";
 export * from "./memory";
 export * from "./comments";
 export * from "./rules";
+export * from "./mandates";
 export * from "./mcp";
 export * from "./users";
 export * from "./audit_logs";

--- a/frontend/src/services/api/mandates.ts
+++ b/frontend/src/services/api/mandates.ts
@@ -1,0 +1,62 @@
+import { request } from "./request";
+import { buildApiUrl, API_CONFIG } from "./config";
+import type {
+  Mandate,
+  MandateCreateData,
+  MandateUpdateData,
+  MandateFilters,
+  RuleListResponse,
+  RuleResponse,
+} from "@/types/rules";
+
+export const listMandates = async (
+  filters?: MandateFilters & { skip?: number; limit?: number }
+): Promise<RuleListResponse<Mandate>> => {
+  const params = new URLSearchParams();
+  if (filters) {
+    Object.entries(filters).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        params.append(key, String(value));
+      }
+    });
+  }
+  return await request<RuleListResponse<Mandate>>(
+    buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/mandates?${params.toString()}`)
+  );
+};
+
+export const createMandate = async (
+  data: MandateCreateData
+): Promise<Mandate> => {
+  const response = await request<RuleResponse<Mandate>>(
+    buildApiUrl(API_CONFIG.ENDPOINTS.RULES, "/mandates"),
+    {
+      method: "POST",
+      body: JSON.stringify(data),
+    }
+  );
+  return response.data;
+};
+
+export const updateMandate = async (
+  mandateId: string,
+  data: MandateUpdateData
+): Promise<Mandate> => {
+  const response = await request<RuleResponse<Mandate>>(
+    buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/mandates/${mandateId}`),
+    {
+      method: "PUT",
+      body: JSON.stringify(data),
+    }
+  );
+  return response.data;
+};
+
+export const deleteMandate = async (mandateId: string): Promise<void> => {
+  await request(
+    buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/mandates/${mandateId}`),
+    {
+      method: "DELETE",
+    }
+  );
+};

--- a/frontend/src/types/rules.ts
+++ b/frontend/src/types/rules.ts
@@ -25,6 +25,28 @@ export const universalMandateSchema = universalMandateBaseSchema.extend({
 
 export type UniversalMandate = z.infer<typeof universalMandateSchema>;
 
+// --- Mandate Schemas (for universal mandate endpoints) ---
+export const mandateBaseSchema = z.object({
+  title: z.string().min(1, "Title is required"),
+  description: z.string().min(1, "Description is required"),
+  priority: z.number().min(1).max(10).default(5),
+  is_active: z.boolean().default(true),
+});
+
+export const mandateCreateSchema = mandateBaseSchema;
+export type MandateCreateData = z.infer<typeof mandateCreateSchema>;
+
+export const mandateUpdateSchema = mandateBaseSchema.partial();
+export type MandateUpdateData = z.infer<typeof mandateUpdateSchema>;
+
+export const mandateSchema = mandateBaseSchema.extend({
+  id: z.string(),
+  created_at: z.string(),
+  updated_at: z.string().optional(),
+});
+
+export type Mandate = z.infer<typeof mandateSchema>;
+
 // --- Agent Rule Schemas ---
 export const ruleAgentRuleBaseSchema = z.object({
   agent_id: z.string(),
@@ -67,6 +89,13 @@ export interface RuleListResponse<T> {
 export interface UniversalMandateFilters {
   is_active?: boolean;
   category?: string;
+  priority_min?: number;
+  priority_max?: number;
+  search?: string;
+}
+
+export interface MandateFilters {
+  is_active?: boolean;
   priority_min?: number;
   priority_max?: number;
   search?: string;


### PR DESCRIPTION
## Summary
- add mandate CRUD helpers
- export mandate helpers in API index
- define Mandate types

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f3bf7c80832cb3ed1086655a4966