### PR TITLE
Add universal mandates page

### DIFF
--- a/frontend/src/app/universal-mandates/page.tsx
+++ b/frontend/src/app/universal-mandates/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+import React from 'react';
+import UniversalMandateList from '@/components/mandate/UniversalMandateList';
+
+const UniversalMandatesPage: React.FC = () => {
+  return <UniversalMandateList />;
+};
+
+export default UniversalMandatesPage;

--- a/frontend/src/components/mandate/UniversalMandateList.tsx
+++ b/frontend/src/components/mandate/UniversalMandateList.tsx
@@ -1,0 +1,252 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Flex,
+  Heading,
+  IconButton,
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+  useDisclosure,
+  useToast,
+  FormControl,
+  FormLabel,
+  Input,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ModalCloseButton,
+} from '@chakra-ui/react';
+import { DeleteIcon, EditIcon, AddIcon } from '@chakra-ui/icons';
+import { useUniversalMandateStore } from '@/store/universalMandateStore';
+import type {
+  UniversalMandate,
+  UniversalMandateCreateData,
+  UniversalMandateUpdateData,
+} from '@/types/rules';
+
+interface MandateModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (
+    data: UniversalMandateCreateData | UniversalMandateUpdateData
+  ) => Promise<void>;
+  initial?: Partial<UniversalMandate>;
+}
+
+const MandateModal: React.FC<MandateModalProps> = ({
+  isOpen,
+  onClose,
+  onSubmit,
+  initial,
+}) => {
+  const [title, setTitle] = useState(initial?.title || '');
+  const [description, setDescription] = useState(
+    initial?.content || initial?.description || ''
+  );
+  const [priority, setPriority] = useState(initial?.priority ?? 5);
+
+  useEffect(() => {
+    setTitle(initial?.title || '');
+    setDescription(initial?.content || initial?.description || '');
+    setPriority(initial?.priority ?? 5);
+  }, [initial]);
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="lg">
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>{initial ? 'Edit Mandate' : 'Add Mandate'}</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <FormControl mb={3} isRequired>
+            <FormLabel>Title</FormLabel>
+            <Input value={title} onChange={(e) => setTitle(e.target.value)} />
+          </FormControl>
+          <FormControl mb={3} isRequired>
+            <FormLabel>Description</FormLabel>
+            <Input
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </FormControl>
+          <FormControl mb={3}>
+            <FormLabel>Priority</FormLabel>
+            <Input
+              type="number"
+              value={priority}
+              onChange={(e) => setPriority(Number(e.target.value))}
+            />
+          </FormControl>
+        </ModalBody>
+        <ModalFooter>
+          <Button mr={3} onClick={onClose} variant="ghost">
+            Cancel
+          </Button>
+          <Button
+            colorScheme="blue"
+            onClick={async () => {
+              await onSubmit({
+                title,
+                content: description,
+                priority,
+                is_active: true,
+              });
+              onClose();
+            }}
+            isDisabled={!title.trim() || !description.trim()}
+          >
+            {initial ? 'Update' : 'Create'}
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+const UniversalMandateList: React.FC = () => {
+  const mandates = useUniversalMandateStore((s) => s.mandates);
+  const fetchMandates = useUniversalMandateStore((s) => s.fetchMandates);
+  const addMandate = useUniversalMandateStore((s) => s.addMandate);
+  const updateMandate = useUniversalMandateStore((s) => s.updateMandate);
+  const removeMandate = useUniversalMandateStore((s) => s.removeMandate);
+  const toast = useToast();
+
+  const {
+    isOpen: isAddOpen,
+    onOpen: onAddOpen,
+    onClose: onAddClose,
+  } = useDisclosure();
+  const {
+    isOpen: isEditOpen,
+    onOpen: onEditOpen,
+    onClose: onEditClose,
+  } = useDisclosure();
+
+  const [editing, setEditing] = useState<UniversalMandate | null>(null);
+
+  useEffect(() => {
+    fetchMandates();
+  }, [fetchMandates]);
+
+  const handleDelete = async (id: string) => {
+    try {
+      await removeMandate(id);
+      toast({ title: 'Mandate deleted', status: 'success', duration: 3000 });
+    } catch (err) {
+      toast({
+        title: 'Error deleting mandate',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+      });
+    }
+  };
+
+  const handleAdd = async (data: UniversalMandateCreateData) => {
+    try {
+      await addMandate(data);
+      toast({ title: 'Mandate created', status: 'success', duration: 3000 });
+    } catch (err) {
+      toast({
+        title: 'Error creating mandate',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+      });
+    }
+  };
+
+  const handleUpdate = async (data: UniversalMandateUpdateData) => {
+    if (!editing) return;
+    try {
+      await updateMandate(editing.id, data);
+      toast({ title: 'Mandate updated', status: 'success', duration: 3000 });
+    } catch (err) {
+      toast({
+        title: 'Error updating mandate',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+      });
+    }
+  };
+
+  return (
+    <Box p="4">
+      <Flex justify="space-between" align="center" mb="4">
+        <Heading size="md">Universal Mandates</Heading>
+        <Button
+          leftIcon={<AddIcon />}
+          onClick={onAddOpen}
+          size="sm"
+          colorScheme="blue"
+        >
+          Add Mandate
+        </Button>
+      </Flex>
+      <Table variant="simple">
+        <Thead>
+          <Tr>
+            <Th>Title</Th>
+            <Th>Description</Th>
+            <Th>Priority</Th>
+            <Th>Actions</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {mandates.map((m) => (
+            <Tr key={m.id} data-testid="mandate-row">
+              <Td>{m.title}</Td>
+              <Td>{(m as any).description || (m as any).content}</Td>
+              <Td>{m.priority}</Td>
+              <Td>
+                <IconButton
+                  aria-label="Edit"
+                  icon={<EditIcon />}
+                  size="sm"
+                  mr="2"
+                  onClick={() => {
+                    setEditing(m);
+                    onEditOpen();
+                  }}
+                />
+                <IconButton
+                  aria-label="Delete"
+                  icon={<DeleteIcon />}
+                  size="sm"
+                  colorScheme="red"
+                  onClick={() => handleDelete(m.id)}
+                />
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+      <MandateModal
+        isOpen={isAddOpen}
+        onClose={onAddClose}
+        onSubmit={handleAdd}
+      />
+      <MandateModal
+        isOpen={isEditOpen}
+        onClose={() => {
+          setEditing(null);
+          onEditClose();
+        }}
+        onSubmit={handleUpdate}
+        initial={editing || undefined}
+      />
+    </Box>
+  );
+};
+
+export default UniversalMandateList;

--- a/frontend/src/store/universalMandateStore.ts
+++ b/frontend/src/store/universalMandateStore.ts
@@ -1,0 +1,63 @@
+import { createBaseStore, BaseState, withLoading } from './baseStore';
+import { rulesApi } from '@/services/api';
+import type {
+  UniversalMandate,
+  UniversalMandateCreateData,
+  UniversalMandateUpdateData,
+} from '@/types/rules';
+
+export interface UniversalMandateState extends BaseState {
+  mandates: UniversalMandate[];
+  fetchMandates: () => Promise<void>;
+  addMandate: (data: UniversalMandateCreateData) => Promise<void>;
+  updateMandate: (
+    id: string,
+    data: UniversalMandateUpdateData
+  ) => Promise<void>;
+  removeMandate: (id: string) => Promise<void>;
+}
+
+const initialData: Omit<
+  UniversalMandateState,
+  | keyof BaseState
+  | 'fetchMandates'
+  | 'addMandate'
+  | 'updateMandate'
+  | 'removeMandate'
+> = {
+  mandates: [],
+};
+
+const actionsCreator = (set: any, get: any) => ({
+  fetchMandates: async () =>
+    withLoading(set, async () => {
+      const response = await rulesApi.mandates.list();
+      set({ mandates: response.data });
+    }),
+  addMandate: async (data: UniversalMandateCreateData) =>
+    withLoading(set, async () => {
+      const created = await rulesApi.mandates.create(data);
+      set((state: UniversalMandateState) => ({
+        mandates: [...state.mandates, created],
+      }));
+    }),
+  updateMandate: async (id: string, data: UniversalMandateUpdateData) =>
+    withLoading(set, async () => {
+      const updated = await rulesApi.mandates.update(id, data);
+      set((state: UniversalMandateState) => ({
+        mandates: state.mandates.map((m) => (m.id === id ? updated : m)),
+      }));
+    }),
+  removeMandate: async (id: string) =>
+    withLoading(set, async () => {
+      await rulesApi.mandates.delete(id);
+      set((state: UniversalMandateState) => ({
+        mandates: state.mandates.filter((m) => m.id !== id),
+      }));
+    }),
+});
+
+export const useUniversalMandateStore = createBaseStore<
+  UniversalMandateState,
+  ReturnType<typeof actionsCreator>
+>(initialData as any, actionsCreator, { name: 'universal-mandate-store' });

--- a/frontend/tests-e2e/universal-mandate-crud.e2e.spec.ts
+++ b/frontend/tests-e2e/universal-mandate-crud.e2e.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+
+test.describe('Universal Mandate CRUD', () => {
+  let mandateId: string;
+
+  test('should create, update and delete a universal mandate via API', async ({ request }) => {
+    const createRes = await request.post(`${API_BASE_URL}/api/rules/mandates`, {
+      data: { title: 'E2E Mandate', description: 'created by e2e', priority: 5 }
+    });
+    expect(createRes.ok()).toBeTruthy();
+    const created = await createRes.json();
+    mandateId = created.data?.id || created.id;
+    expect(mandateId).toBeTruthy();
+
+    const updateRes = await request.put(`${API_BASE_URL}/api/rules/mandates/${mandateId}`, {
+      data: { description: 'updated by e2e' }
+    });
+    expect(updateRes.ok()).toBeTruthy();
+
+    const deleteRes = await request.delete(`${API_BASE_URL}/api/rules/mandates/${mandateId}`);
+    expect(deleteRes.status()).toBeLessThan(300);
+  });
+});


### PR DESCRIPTION
## Summary
- list universal mandates via new page
- manage mandates with edit/delete controls
- store and UI for mandates
- add e2e test covering mandate CRUD API flow

## Testing
- `npm run lint`
- `npm run test:run` *(fails: Cannot read properties of undefined (reading 'matches'))*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6840f3bea230832cb0986c92a8b82c30