### PR TITLE
Add universal mandate tools

### DIFF
--- a/SYSTEM_GUIDE.md
+++ b/SYSTEM_GUIDE.md
@@ -53,6 +53,12 @@ node dev_start.js
 - **Project Management**: `/projects`
 - **Task Dashboard**: `/tasks`
 
+### MCP Tools
+The backend exposes additional MCP tool endpoints under `/api/mcp/mcp-tools`:
+- `POST /universal-mandate/create` – create a universal mandate
+- `GET /universal-mandate/list` – list mandates (filterable by `active_only`)
+- `POST /universal-mandate/delete` – delete a mandate by ID
+
 ## 🔧 Development Tools
 
 ### 🧪 Testing

--- a/backend/mcp_tools/__init__.py
+++ b/backend/mcp_tools/__init__.py
@@ -12,5 +12,8 @@ __all__ = [
     'search_memory_tool',
     'add_project_file_tool',
     'list_project_files_tool',
-    'remove_project_file_tool'
+    'remove_project_file_tool',
+    'create_universal_mandate_tool',
+    'list_universal_mandates_tool',
+    'delete_universal_mandate_tool'
 ]

--- a/backend/mcp_tools/mandate_tools.py
+++ b/backend/mcp_tools/mandate_tools.py
@@ -1,0 +1,130 @@
+"""MCP tools for managing universal mandates."""
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+import logging
+
+from backend import models, schemas
+from backend.services.audit_log_service import AuditLogService
+
+logger = logging.getLogger(__name__)
+
+
+async def create_universal_mandate_tool(
+    mandate_data: schemas.UniversalMandateCreate,
+    db: Session,
+) -> dict:
+    """Create a new universal mandate."""
+    try:
+        existing = (
+            db.query(models.UniversalMandate)
+            .filter(models.UniversalMandate.title == mandate_data.title)
+            .first()
+        )
+        if existing:
+            raise HTTPException(status_code=400, detail="Mandate already exists")
+
+        mandate = models.UniversalMandate(**mandate_data.model_dump())
+        db.add(mandate)
+        db.commit()
+        db.refresh(mandate)
+
+        audit_service = AuditLogService(db)
+        if hasattr(audit_service, "log_action"):
+            await audit_service.log_action(
+                action="universal_mandate_created",
+                entity_type="universal_mandate",
+                entity_id=mandate.id,
+                changes=mandate_data.model_dump(),
+            )
+        else:
+            await audit_service.create_log(
+                action="universal_mandate_created",
+                details={"entity_id": mandate.id, **mandate_data.model_dump()},
+            )
+
+        return {
+            "success": True,
+            "mandate": {
+                "id": mandate.id,
+                "title": mandate.title,
+                "description": mandate.description,
+                "priority": mandate.priority,
+                "is_active": mandate.is_active,
+                "created_at": mandate.created_at.isoformat(),
+            },
+        }
+    except HTTPException:
+        raise
+    except Exception as e:  # pragma: no cover - unforeseen errors
+        logger.error(f"MCP create universal mandate failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+async def list_universal_mandates_tool(
+    active_only: bool = True,
+    db: Session | None = None,
+) -> dict:
+    """List universal mandates."""
+    try:
+        query = db.query(models.UniversalMandate)
+        if active_only:
+            query = query.filter(models.UniversalMandate.is_active.is_(True))
+        mandates = query.order_by(models.UniversalMandate.priority.desc()).all()
+
+        return {
+            "success": True,
+            "mandates": [
+                {
+                    "id": m.id,
+                    "title": m.title,
+                    "description": m.description,
+                    "priority": m.priority,
+                    "is_active": m.is_active,
+                    "created_at": m.created_at.isoformat(),
+                }
+                for m in mandates
+            ],
+        }
+    except Exception as e:  # pragma: no cover - unforeseen errors
+        logger.error(f"MCP list universal mandates failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+async def delete_universal_mandate_tool(
+    mandate_id: str,
+    db: Session,
+) -> dict:
+    """Delete a universal mandate."""
+    try:
+        mandate = (
+            db.query(models.UniversalMandate)
+            .filter(models.UniversalMandate.id == mandate_id)
+            .first()
+        )
+        if not mandate:
+            raise HTTPException(status_code=404, detail="Mandate not found")
+
+        db.delete(mandate)
+        db.commit()
+
+        audit_service = AuditLogService(db)
+        if hasattr(audit_service, "log_action"):
+            await audit_service.log_action(
+                action="universal_mandate_deleted",
+                entity_type="universal_mandate",
+                entity_id=mandate_id,
+                changes=None,
+            )
+        else:
+            await audit_service.create_log(
+                action="universal_mandate_deleted",
+                details={"entity_id": mandate_id},
+            )
+
+        return {"success": True}
+    except HTTPException:
+        raise
+    except Exception as e:  # pragma: no cover - unforeseen errors
+        logger.error(f"MCP delete universal mandate failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/routers/mcp/core.py
+++ b/backend/routers/mcp/core.py
@@ -7,9 +7,8 @@ Provides MCP tool definitions.
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
-from typing import List, Dict, Any, Optional
+from typing import Optional
 import logging
-import json
 
 from ....database import get_sync_db as get_db
 from ....services.project_service import ProjectService
@@ -18,12 +17,18 @@ from ....services.audit_log_service import AuditLogService
 from ....services.memory_service import MemoryService
 from ....services.project_file_association_service import ProjectFileAssociationService
 from ....schemas.project import ProjectCreate
-from ....schemas.task import TaskCreate
+from ....schemas.task import TaskCreate, TaskUpdate
 from ....schemas.memory import (
     MemoryEntityCreate,
     MemoryEntityUpdate,
     MemoryObservationCreate,
     MemoryRelationCreate
+)
+from ....schemas.universal_mandate import UniversalMandateCreate
+from ....mcp_tools.mandate_tools import (
+    create_universal_mandate_tool,
+    list_universal_mandates_tool,
+    delete_universal_mandate_tool,
 )
 
 logger = logging.getLogger(__name__)
@@ -551,6 +556,45 @@ async def mcp_get_memory_metadata(
     except Exception as e:
         logger.error(f"MCP get memory metadata failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/mcp-tools/universal-mandate/create",
+    tags=["mcp-tools"],
+    operation_id="create_universal_mandate_tool",
+)
+async def mcp_create_universal_mandate(
+    mandate: UniversalMandateCreate,
+    db: Session = Depends(get_db_session),
+):
+    """MCP Tool: Create a universal mandate."""
+    return await create_universal_mandate_tool(mandate, db)
+
+
+@router.get(
+    "/mcp-tools/universal-mandate/list",
+    tags=["mcp-tools"],
+    operation_id="list_universal_mandates_tool",
+)
+async def mcp_list_universal_mandates(
+    active_only: bool = True,
+    db: Session = Depends(get_db_session),
+):
+    """MCP Tool: List universal mandates."""
+    return await list_universal_mandates_tool(active_only=active_only, db=db)
+
+
+@router.post(
+    "/mcp-tools/universal-mandate/delete",
+    tags=["mcp-tools"],
+    operation_id="delete_universal_mandate_tool",
+)
+async def mcp_delete_universal_mandate(
+    mandate_id: str,
+    db: Session = Depends(get_db_session),
+):
+    """MCP Tool: Delete a universal mandate."""
+    return await delete_universal_mandate_tool(mandate_id, db)
 
 
 @router.get(


### PR DESCRIPTION
## Summary
- implement universal mandate MCP tools
- register new endpoints in the MCP router
- document mandate tool endpoints in SYSTEM_GUIDE

## Testing
- `python3 -m flake8 backend/mcp_tools/mandate_tools.py backend/mcp_tools/__init__.py`
- `pytest -q` *(fails: test_ingest_file_and_retrieve, test_openapi_contains_key_paths, test_project_task_endpoints)*
- `npm --prefix frontend run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f3bd9f44832caaf20209a5e3e13f