### PR TITLE
Add prompt template deletion support

### DIFF
--- a/backend/routers/rules/templates/templates.py
+++ b/backend/routers/rules/templates/templates.py
@@ -22,7 +22,7 @@ def get_prompt_template(
     """Get prompt template for an agent"""
     template = crud_rules.get_agent_prompt_template(db, agent_name, template_name)
     if not template:
-    raise HTTPException(status_code=404, detail="Prompt template not found")
+        raise HTTPException(status_code=404, detail="Prompt template not found")
     return template
 
 @router.post("/", response_model=AgentPromptTemplate)
@@ -46,5 +46,19 @@ def update_prompt_template(
     """Update a prompt template"""
     result = crud_rules.update_agent_prompt_template(db, template_id, template_update)
     if not result:
-    raise HTTPException(status_code=404, detail="Prompt template not found")
+        raise HTTPException(status_code=404, detail="Prompt template not found")
     return result
+
+
+@router.delete("/{template_id}")
+
+
+def delete_prompt_template(
+    template_id: str,
+    db: Session = Depends(get_db),
+):
+    """Delete a prompt template"""
+    success = crud_rules.delete_agent_prompt_template(db, template_id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Prompt template not found")
+    return {"message": "Prompt template deleted successfully"}

--- a/backend/services/rules_service.py
+++ b/backend/services/rules_service.py
@@ -183,10 +183,21 @@ def get_error_protocol(self, agent_name: str, error_type: str) -> Optional[str]:
 
         return None
 
-def get_universal_mandates_for_prompt(self) -> List[str]:
+    def get_universal_mandates_for_prompt(self) -> List[str]:
         """Get universal mandates formatted for agent prompts"""
         mandates = crud_rules.get_universal_mandates(self.db)
         return [f"**{mandate.title}**: {mandate.description}" for mandate in mandates]
+
+def delete_prompt_template(self, template_id: str) -> bool:
+        """Delete an agent prompt template by ID."""
+        template = self.db.query(crud_rules.AgentPromptTemplate).filter(
+            crud_rules.AgentPromptTemplate.id == template_id
+        ).first()
+        if not template:
+            return False
+        self.db.delete(template)
+        self.db.commit()
+        return True
 
 def initialize_default_rules(self):
         """Initialize default rules for the system"""

--- a/backend/tests/test_prompt_templates.py
+++ b/backend/tests/test_prompt_templates.py
@@ -1,0 +1,73 @@
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient, ASGITransport
+from unittest.mock import MagicMock
+
+from backend.routers.rules.templates import templates as templates_router
+from backend.services import rules_service
+from backend.database import get_sync_db
+from backend.crud import rules as crud_rules
+
+
+class DummySession:
+    def __init__(self):
+        self.deleted = []
+        self.committed = False
+
+    def query(self, model):
+        obj = MagicMock()
+        obj.filter.return_value.first.return_value = MagicMock(id="temp1")
+        return obj
+
+    def delete(self, obj):
+        self.deleted.append(obj)
+
+    def commit(self):
+        self.committed = True
+
+
+async def override_db():
+    yield DummySession()
+
+
+@pytest.mark.asyncio
+async def test_delete_prompt_template_endpoint(monkeypatch):
+    async def fake_delete(db, template_id):
+        return True
+
+    monkeypatch.setattr(crud_rules, "delete_agent_prompt_template", fake_delete)
+
+    app = FastAPI()
+    app.dependency_overrides[get_sync_db] = override_db
+    app.include_router(templates_router.router)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.delete("/temp1")
+    assert resp.status_code == 200
+    assert "deleted" in resp.json()["message"]
+
+
+def test_delete_prompt_template_service_success():
+    session = DummySession()
+    service = rules_service.RulesService(session)
+    result = rules_service.delete_prompt_template(service, "temp1")
+    assert result is True
+    assert session.deleted
+    assert session.committed
+
+
+def test_delete_prompt_template_service_not_found():
+    class EmptySession(DummySession):
+        def query(self, model):
+            obj = MagicMock()
+            obj.filter.return_value.first.return_value = None
+            return obj
+
+    session = EmptySession()
+    service = rules_service.RulesService(session)
+    result = rules_service.delete_prompt_template(service, "missing")
+    assert result is False
+    assert not session.deleted
+    assert session.committed is False


### PR DESCRIPTION
## Summary
- allow deleting prompt templates via API
- support deletion in rules service
- cover new behavior in tests

## Testing
- `flake8 routers/rules/templates/templates.py services/rules_service.py tests/test_prompt_templates.py`
- `pytest -q backend/tests/test_prompt_templates.py` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_6840f3bd22f4832c9c2cff8bb61e6060