### PR TITLE
Add template deletion support

### DIFF
--- a/frontend/src/app/templates/[templateId]/edit/page.tsx
+++ b/frontend/src/app/templates/[templateId]/edit/page.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import EditProjectTemplateForm from '@/components/forms/EditProjectTemplateForm';
 import { useTemplateStore } from '@/store/templateStore';
+import { Button } from '@chakra-ui/react';
 
 const EditTemplatePage: React.FC = () => {
   const params = useParams();
@@ -33,11 +34,20 @@ const EditTemplatePage: React.FC = () => {
   };
 
   return (
-    <EditProjectTemplateForm
-      template={template}
-      onSubmit={handleSubmit}
-      onCancel={() => router.push('/templates')}
-    />
+    <>
+      <EditProjectTemplateForm
+        template={template}
+        onSubmit={handleSubmit}
+        onCancel={() => router.push('/templates')}
+      />
+      <Button
+        mt="4"
+        colorScheme="red"
+        onClick={() => router.push(`/templates/${templateId}/delete`)}
+      >
+        Delete Template
+      </Button>
+    </>
   );
 };
 

--- a/frontend/src/store/__tests__/templateStore.test.ts
+++ b/frontend/src/store/__tests__/templateStore.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { act } from 'react-dom/test-utils';
+import { useTemplateStore } from '../templateStore';
+import * as api from '@/services/api';
+
+vi.mock('@/services/api', () => ({
+  projectTemplatesApi: {
+    list: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+const mockedApi = vi.mocked(api.projectTemplatesApi);
+
+const initialState = {
+  templates: [],
+  loading: false,
+  error: null,
+};
+
+describe('templateStore', () => {
+  beforeEach(() => {
+    useTemplateStore.setState({
+      ...initialState,
+      fetchTemplates: useTemplateStore.getState().fetchTemplates,
+      addTemplate: useTemplateStore.getState().addTemplate,
+      updateTemplate: useTemplateStore.getState().updateTemplate,
+      removeTemplate: useTemplateStore.getState().removeTemplate,
+      clearError: useTemplateStore.getState().clearError,
+    } as any);
+    vi.clearAllMocks();
+  });
+
+  it('removeTemplate calls API and updates state', async () => {
+    useTemplateStore.setState({
+      ...initialState,
+      templates: [
+        {
+          id: 't1',
+          name: 'T1',
+          description: '',
+          template_data: {},
+          created_at: '',
+          updated_at: '',
+        },
+      ],
+    } as any);
+    mockedApi.delete.mockResolvedValueOnce({} as any);
+
+    await act(async () => {
+      await useTemplateStore.getState().removeTemplate('t1');
+    });
+
+    expect(mockedApi.delete).toHaveBeenCalledWith('t1');
+    expect(useTemplateStore.getState().templates).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- include delete button in edit template page
- verify removeTemplate updates template store

## Testing
- `npm run lint`
- `npm run test` *(fails: Cannot read properties of undefined (reading 'matches'))*

------
https://chatgpt.com/codex/tasks/task_e_6840f3baf1f0832cb4bb1caf976de104