### PR TITLE
Add project template MCP tools

### DIFF
--- a/backend/docs/fastapi_mcp/README.md
+++ b/backend/docs/fastapi_mcp/README.md
@@ -93,6 +93,9 @@ FastAPI-MCP automatically exposes selected API endpoints as tools under the `/mc
 - `/mcp-tools/memory/add-observation` (POST)
 - `/mcp-tools/memory/add-relation` (POST)
 - `/mcp-tools/memory/search` (GET)
+- `/mcp-tools/template/create` (POST)
+- `/mcp-tools/templates/list` (GET)
+- `/mcp-tools/template/delete` (POST)
 
 ## Development and Contributing
 

--- a/backend/mcp_tools/README.md
+++ b/backend/mcp_tools/README.md
@@ -25,6 +25,7 @@ graph TD
 - `memory_tools.py`
 - `project_tools.py`
 - `task_tools.py`
+- `template_tools.py`
 
 <!-- File List End -->
 

--- a/backend/mcp_tools/__init__.py
+++ b/backend/mcp_tools/__init__.py
@@ -12,5 +12,8 @@ __all__ = [
     'search_memory_tool',
     'add_project_file_tool',
     'list_project_files_tool',
-    'remove_project_file_tool'
+    'remove_project_file_tool',
+    'create_template_tool',
+    'list_templates_tool',
+    'delete_template_tool'
 ]

--- a/backend/mcp_tools/template_tools.py
+++ b/backend/mcp_tools/template_tools.py
@@ -1,0 +1,82 @@
+"""MCP Tools for managing project templates."""
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+import logging
+
+from backend.services.project_template_service import ProjectTemplateService
+from backend.schemas.project_template import ProjectTemplateCreate
+
+logger = logging.getLogger(__name__)
+
+
+async def create_template_tool(
+    template_data: ProjectTemplateCreate,
+    db: Session,
+) -> dict:
+    """MCP Tool: Create a new project template."""
+    try:
+        service = ProjectTemplateService(db)
+        existing = service.get_template_by_name(template_data.name)
+        if existing:
+            raise HTTPException(status_code=400, detail="Template already exists")
+
+        template = service.create_template(template_data)
+        return {
+            "success": True,
+            "template": {
+                "id": template.id,
+                "name": template.name,
+                "description": template.description,
+                "created_at": template.created_at.isoformat(),
+            },
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"MCP create template failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+async def list_templates_tool(
+    skip: int = 0,
+    limit: int = 100,
+    db: Session = None,
+) -> dict:
+    """MCP Tool: List project templates."""
+    try:
+        service = ProjectTemplateService(db)
+        templates = service.get_templates(skip=skip, limit=limit)
+        return {
+            "success": True,
+            "templates": [
+                {
+                    "id": t.id,
+                    "name": t.name,
+                    "description": t.description,
+                    "created_at": t.created_at.isoformat(),
+                }
+                for t in templates
+            ],
+        }
+    except Exception as e:
+        logger.error(f"MCP list templates failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+async def delete_template_tool(
+    template_id: str,
+    db: Session,
+) -> dict:
+    """MCP Tool: Delete a project template."""
+    try:
+        service = ProjectTemplateService(db)
+        success = service.delete_template(template_id)
+        if not success:
+            raise HTTPException(status_code=404, detail="Template not found")
+        return {"success": True, "template_id": template_id}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"MCP delete template failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
## Summary
- implement template management tools
- register template tools in MCP router
- document new MCP template routes
- update MCP tools README

## Testing
- `flake8 backend/mcp_tools/template_tools.py backend/mcp_tools/__init__.py backend/routers/mcp/core.py`
- `pytest -q` *(fails: ModuleNotFoundError/AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_6840f3b8f2a0832cad0e4fdcd2f44600