### PR TITLE
Add MemoryObservationEditor component

### DIFF
--- a/frontend/src/components/memory/MemoryObservationEditor.tsx
+++ b/frontend/src/components/memory/MemoryObservationEditor.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import React, { useState } from 'react';
+import {
+  Box,
+  Button,
+  HStack,
+  IconButton,
+  Textarea,
+  VStack,
+  useToast,
+} from '@chakra-ui/react';
+import { EditIcon, DeleteIcon } from '@chakra-ui/icons';
+import { memoryApi } from '@/services/api';
+import type { MemoryObservation } from '@/types/memory';
+
+interface MemoryObservationEditorProps {
+  observation: MemoryObservation;
+  onUpdated?: (obs: MemoryObservation) => void;
+  onDeleted?: (id: number) => void;
+}
+
+const MemoryObservationEditor: React.FC<MemoryObservationEditorProps> = ({
+  observation,
+  onUpdated,
+  onDeleted,
+}) => {
+  const toast = useToast();
+  const [isEditing, setIsEditing] = useState(false);
+  const [content, setContent] = useState(observation.content);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSave = async () => {
+    setIsLoading(true);
+    try {
+      const updated = await memoryApi.updateObservation(observation.id, {
+        content,
+      });
+      onUpdated?.(updated);
+      toast({ title: 'Observation updated', status: 'success' });
+      setIsEditing(false);
+    } catch (err) {
+      toast({ title: 'Failed to update', status: 'error' });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    setIsLoading(true);
+    try {
+      await memoryApi.deleteObservation(observation.id);
+      onDeleted?.(observation.id);
+      toast({ title: 'Observation deleted', status: 'success' });
+    } catch (err) {
+      toast({ title: 'Failed to delete', status: 'error' });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Box>
+      {isEditing ? (
+        <VStack align="stretch">
+          <Textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+          />
+          <HStack>
+            <Button
+              onClick={handleSave}
+              isLoading={isLoading}
+              colorScheme="blue"
+            >
+              Save
+            </Button>
+            <Button
+              onClick={() => {
+                setContent(observation.content);
+                setIsEditing(false);
+              }}
+            >
+              Cancel
+            </Button>
+          </HStack>
+        </VStack>
+      ) : (
+        <HStack justifyContent="space-between">
+          <Box flex="1">{observation.content}</Box>
+          <HStack>
+            <IconButton
+              aria-label="Edit observation"
+              icon={<EditIcon />}
+              onClick={() => setIsEditing(true)}
+              size="sm"
+            />
+            <IconButton
+              aria-label="Delete observation"
+              icon={<DeleteIcon />}
+              onClick={handleDelete}
+              isLoading={isLoading}
+              size="sm"
+            />
+          </HStack>
+        </HStack>
+      )}
+    </Box>
+  );
+};
+
+export default MemoryObservationEditor;

--- a/frontend/src/components/memory/__tests__/MemoryObservationEditor.test.tsx
+++ b/frontend/src/components/memory/__tests__/MemoryObservationEditor.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen, TestWrapper } from '@/__tests__/utils/test-utils';
+import MemoryObservationEditor from '../MemoryObservationEditor';
+import type { MemoryObservation } from '@/types/memory';
+import { memoryApi } from '@/services/api';
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual('@chakra-ui/react');
+  return {
+    ...actual,
+    useToast: () => vi.fn(),
+    useColorModeValue: (l: any, d: any) => l,
+  };
+});
+
+vi.mock('@/services/api', () => ({
+  memoryApi: {
+    updateObservation: vi.fn(),
+    deleteObservation: vi.fn(),
+  },
+}));
+
+const observation: MemoryObservation = {
+  id: 1,
+  entity_id: 1,
+  content: 'test',
+  created_at: '2024-01-01',
+};
+
+describe('MemoryObservationEditor', () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls updateObservation on save', async () => {
+    render(
+      <TestWrapper>
+        <MemoryObservationEditor observation={observation} />
+      </TestWrapper>
+    );
+
+    await user.click(screen.getByRole('button', { name: /edit/i }));
+    const textbox = screen.getByRole('textbox');
+    await user.clear(textbox);
+    await user.type(textbox, 'updated');
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(memoryApi.updateObservation).toHaveBeenCalled();
+  });
+
+  it('calls deleteObservation on delete', async () => {
+    render(
+      <TestWrapper>
+        <MemoryObservationEditor observation={observation} />
+      </TestWrapper>
+    );
+
+    await user.click(screen.getByRole('button', { name: /delete/i }));
+
+    expect(memoryApi.deleteObservation).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/services/api/memory.ts
+++ b/frontend/src/services/api/memory.ts
@@ -1,5 +1,5 @@
-import { request } from "./request";
-import { buildApiUrl, API_CONFIG } from "./config";
+import { request } from './request';
+import { buildApiUrl, API_CONFIG } from './config';
 import type {
   MemoryEntity,
   MemoryEntityCreateData,
@@ -9,11 +9,12 @@ import type {
   MemoryEntityFilters,
   MemoryObservation,
   MemoryObservationCreateData,
+  MemoryObservationUpdateData,
   MemoryRelation,
   MemoryRelationCreateData,
   MemoryRelationFilters,
   KnowledgeGraph,
-} from "@/types/memory";
+} from '@/types/memory';
 
 // --- Memory Entity APIs ---
 export const memoryApi = {
@@ -22,7 +23,7 @@ export const memoryApi = {
     const response = await request<MemoryEntityResponse>(
       buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify(data),
       }
     );
@@ -61,7 +62,7 @@ export const memoryApi = {
     const response = await request<MemoryEntityResponse>(
       buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/${entityId}`),
       {
-        method: "PUT",
+        method: 'PUT',
         body: JSON.stringify(data),
       }
     );
@@ -70,20 +71,17 @@ export const memoryApi = {
 
   // Delete a memory entity
   deleteEntity: async (entityId: number): Promise<void> => {
-    await request(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/${entityId}`),
-      {
-        method: "DELETE",
-      }
-    );
+    await request(buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/${entityId}`), {
+      method: 'DELETE',
+    });
   },
 
   // Ingest a file from the server filesystem
   ingestFile: async (filePath: string): Promise<MemoryEntity> => {
     const response = await request<MemoryEntityResponse>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/entities/ingest/file"),
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/entities/ingest/file'),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify({ file_path: filePath }),
       }
     );
@@ -93,9 +91,9 @@ export const memoryApi = {
   // Ingest content directly from a URL
   ingestUrl: async (url: string): Promise<MemoryEntity> => {
     const response = await request<MemoryEntityResponse>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/ingest-url"),
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/ingest-url'),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify({ url }),
       }
     );
@@ -105,9 +103,9 @@ export const memoryApi = {
   // Ingest a raw text snippet
   ingestText: async (text: string): Promise<MemoryEntity> => {
     const response = await request<MemoryEntityResponse>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/ingest-text"),
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/ingest-text'),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify({ text }),
       }
     );
@@ -116,11 +114,13 @@ export const memoryApi = {
 
   // --- Memory Observation APIs ---
   // Add an observation to an entity
-  addObservation: async (data: MemoryObservationCreateData): Promise<MemoryObservation> => {
+  addObservation: async (
+    data: MemoryObservationCreateData
+  ): Promise<MemoryObservation> => {
     const response = await request<{ data: MemoryObservation }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/observations"),
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/observations'),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify(data),
       }
     );
@@ -130,7 +130,28 @@ export const memoryApi = {
   // Get observations for an entity
   getObservations: async (entityId: number): Promise<MemoryObservation[]> => {
     const response = await request<{ data: MemoryObservation[] }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/entities/${entityId}/observations`)
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.MEMORY,
+        `/entities/${entityId}/observations`
+      )
+    );
+    return response.data;
+  },
+
+  // Update an observation
+  updateObservation: async (
+    observationId: number,
+    data: MemoryObservationUpdateData
+  ): Promise<MemoryObservation> => {
+    const response = await request<{ data: MemoryObservation }>(
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.MEMORY,
+        `/observations/${observationId}`
+      ),
+      {
+        method: 'PUT',
+        body: JSON.stringify(data),
+      }
     );
     return response.data;
   },
@@ -138,19 +159,24 @@ export const memoryApi = {
   // Delete an observation
   deleteObservation: async (observationId: number): Promise<void> => {
     await request(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/observations/${observationId}`),
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.MEMORY,
+        `/observations/${observationId}`
+      ),
       {
-        method: "DELETE",
+        method: 'DELETE',
       }
     );
   },
   // --- Memory Relation APIs ---
   // Create a relation between entities
-  createRelation: async (data: MemoryRelationCreateData): Promise<MemoryRelation> => {
+  createRelation: async (
+    data: MemoryRelationCreateData
+  ): Promise<MemoryRelation> => {
     const response = await request<{ data: MemoryRelation }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/relations"),
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/relations'),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify(data),
       }
     );
@@ -158,7 +184,9 @@ export const memoryApi = {
   },
 
   // Get relations with filters
-  getRelations: async (filters?: MemoryRelationFilters): Promise<MemoryRelation[]> => {
+  getRelations: async (
+    filters?: MemoryRelationFilters
+  ): Promise<MemoryRelation[]> => {
     const params = new URLSearchParams();
     if (filters) {
       Object.entries(filters).forEach(([key, value]) => {
@@ -168,7 +196,10 @@ export const memoryApi = {
       });
     }
     const response = await request<{ data: MemoryRelation[] }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/relations?${params.toString()}`)
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.MEMORY,
+        `/relations?${params.toString()}`
+      )
     );
     return response.data;
   },
@@ -178,7 +209,7 @@ export const memoryApi = {
     await request(
       buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/relations/${relationId}`),
       {
-        method: "DELETE",
+        method: 'DELETE',
       }
     );
   },
@@ -187,7 +218,7 @@ export const memoryApi = {
   // Get the full knowledge graph
   getKnowledgeGraph: async (): Promise<KnowledgeGraph> => {
     const response = await request<{ data: KnowledgeGraph }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/graph")
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/graph')
     );
     return response.data;
   },
@@ -195,7 +226,10 @@ export const memoryApi = {
   // Search the knowledge graph
   searchGraph: async (query: string): Promise<MemoryEntity[]> => {
     const response = await request<{ data: MemoryEntity[] }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/search?q=${encodeURIComponent(query)}`)
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.MEMORY,
+        `/search?q=${encodeURIComponent(query)}`
+      )
     );
     return response.data;
   },

--- a/frontend/src/types/memory.ts
+++ b/frontend/src/types/memory.ts
@@ -1,8 +1,8 @@
-import { z } from "zod";
+import { z } from 'zod';
 
 // --- Memory Entity Schemas ---
 export const memoryEntityBaseSchema = z.object({
-  entity_type: z.string().min(1, "Entity type is required"),
+  entity_type: z.string().min(1, 'Entity type is required'),
   content: z.string().nullable().optional(),
   metadata: z.record(z.any()).nullable().optional(),
 });
@@ -26,12 +26,21 @@ export type MemoryEntity = z.infer<typeof memoryEntitySchema>;
 // --- Memory Observation Schemas ---
 export const memoryObservationBaseSchema = z.object({
   entity_id: z.number(),
-  content: z.string().min(1, "Content is required"),
+  content: z.string().min(1, 'Content is required'),
 });
 
 export const memoryObservationCreateSchema = memoryObservationBaseSchema;
 
-export type MemoryObservationCreateData = z.infer<typeof memoryObservationCreateSchema>;
+export type MemoryObservationCreateData = z.infer<
+  typeof memoryObservationCreateSchema
+>;
+
+export const memoryObservationUpdateSchema =
+  memoryObservationBaseSchema.partial();
+
+export type MemoryObservationUpdateData = z.infer<
+  typeof memoryObservationUpdateSchema
+>;
 
 export const memoryObservationSchema = memoryObservationBaseSchema.extend({
   id: z.number(),
@@ -44,13 +53,15 @@ export type MemoryObservation = z.infer<typeof memoryObservationSchema>;
 export const memoryRelationBaseSchema = z.object({
   from_entity_id: z.number(),
   to_entity_id: z.number(),
-  relation_type: z.string().min(1, "Relation type is required"),
+  relation_type: z.string().min(1, 'Relation type is required'),
   metadata: z.record(z.any()).nullable().optional(),
 });
 
 export const memoryRelationCreateSchema = memoryRelationBaseSchema;
 
-export type MemoryRelationCreateData = z.infer<typeof memoryRelationCreateSchema>;
+export type MemoryRelationCreateData = z.infer<
+  typeof memoryRelationCreateSchema
+>;
 
 export const memoryRelationSchema = memoryRelationBaseSchema.extend({
   id: z.number(),


### PR DESCRIPTION
## Summary
- support updating MemoryObservation via new API call
- implement MemoryObservationEditor component
- test update and delete logic

## Testing
- `npx prettier --write frontend/src/components/memory/MemoryObservationEditor.tsx frontend/src/components/memory/__tests__/MemoryObservationEditor.test.tsx frontend/src/services/api/memory.ts frontend/src/types/memory.ts`
- `npx vitest run frontend/src/components/memory/__tests__/MemoryObservationEditor.test.tsx` *(fails: Need to install vitest)*

------
https://chatgpt.com/codex/tasks/task_e_6840f3b6754c832c8bf1c0b6464d7f37