### PR TITLE
Add memory relation update endpoint

### DIFF
--- a/backend/routers/memory/relations/relations.py
+++ b/backend/routers/memory/relations/relations.py
@@ -3,108 +3,111 @@ from sqlalchemy.orm import Session
 from typing import List, Optional
 
 from ....database import get_sync_db as get_db
-from ....services.memory_service import MemoryService  # Assuming relation management is part of memory service
+from ....services.memory_service import MemoryService
 from ....schemas.memory import MemoryRelation, MemoryRelationCreate
-from ....services.exceptions import EntityNotFoundError, DuplicateEntityError
+from ....services.exceptions import EntityNotFoundError
 
 router = APIRouter()
+
 
 def get_memory_service(db: Session = Depends(get_db)) -> MemoryService:
     return MemoryService(db)
 
+
 @router.post("/relations/", response_model=MemoryRelation)
-
-
 def create_relation(
     relation: MemoryRelationCreate,
-    memory_service: MemoryService = Depends(get_memory_service)
+    memory_service: MemoryService = Depends(get_memory_service),
 ):
     """Create a relationship between two memory entities."""
     try:
-    return memory_service.create_relation(relation)
-    except (EntityNotFoundError, DuplicateEntityError) as e:
-    raise HTTPException(status_code=400, detail=str(e))  # Use 400 for bad request if entities not found or duplicate
-    except Exception as e:
-    raise HTTPException(
-    status_code=500,
-    detail=f"Internal server error: {e}"
-    )
+        return memory_service.create_memory_relation(relation)
+    except HTTPException:
+        raise
+    except Exception as e:  # pragma: no cover - fallback error
+        raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+
+
+@router.put("/relations/{relation_id}", response_model=MemoryRelation)
+def update_relation(
+    relation: MemoryRelationCreate,
+    relation_id: int = Path(..., description="ID of the relation to update."),
+    memory_service: MemoryService = Depends(get_memory_service),
+):
+    """Update a memory relation."""
+    try:
+        return memory_service.update_memory_relation(relation_id, relation)
+    except EntityNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except HTTPException:
+        raise
+    except Exception as e:  # pragma: no cover - fallback error
+        raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+
 
 @router.get("/relations/by-type/{relation_type}", response_model=List[MemoryRelation])
-
-
 def read_relations_by_type(
     relation_type: str = Path(..., description="The type of relations to filter by."),
-    skip: int = Query(0, description="The number of items to skip before returning"
-        "results."),
+    skip: int = Query(0, description="The number of items to skip before returning results."),
     limit: int = Query(100, description="The maximum number of items to return."),
-    memory_service: MemoryService = Depends(get_memory_service)
+    memory_service: MemoryService = Depends(get_memory_service),
 ):
-    """Retrieve a list of memory relations filtered by type."""
+    """Retrieve memory relations filtered by type."""
     try:
-    return memory_service.get_relations_by_type(relation_type=relation_type, skip=skip, limit=limit)
-    except Exception as e:
-    raise HTTPException(
-    status_code=500,
-    detail=f"Internal server error: {e}"
-    )
+        return memory_service.get_memory_relations_by_type(relation_type, skip=skip, limit=limit)
+    except Exception as e:  # pragma: no cover - fallback error
+        raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+
+
 @router.get("/entities/{from_entity_id}/relations/{to_entity_id}", response_model=List[MemoryRelation])
-
-
 def read_relations_between_entities(
     from_entity_id: int = Path(..., description="ID of the source entity."),
     to_entity_id: int = Path(..., description="ID of the target entity."),
     relation_type: Optional[str] = Query(None, description="Optional relation type to filter by."),
-    skip: int = Query(0, description="The number of items to skip before returning"
-        "results."),
+    skip: int = Query(0, description="The number of items to skip before returning results."),
     limit: int = Query(100, description="The maximum number of items to return."),
-    memory_service: MemoryService = Depends(get_memory_service)
+    memory_service: MemoryService = Depends(get_memory_service),
 ):
     """Retrieve relations between two specific memory entities."""
     try:
-    return memory_service.get_relations_between_entities(from_entity_id=from_entity_id, to_entity_id=to_entity_id, relation_type=relation_type, skip=skip, limit=limit)
-    except Exception as e:
-    raise HTTPException(
-    status_code=500,
-    detail=f"Internal server error: {e}"
-    )
+        return memory_service.get_memory_relations_between_entities(
+            from_entity_id=from_entity_id,
+            to_entity_id=to_entity_id,
+            relation_type=relation_type,
+            skip=skip,
+            limit=limit,
+        )
+    except Exception as e:  # pragma: no cover - fallback error
+        raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+
 
 @router.get("/entities/{entity_id}/relations/", response_model=List[MemoryRelation])
-
-
 def get_entity_relations(
     entity_id: int = Path(..., description="ID of the entity to retrieve relations for."),
     relation_type: Optional[str] = Query(None, description="Optional relation type to filter by."),
-    memory_service: MemoryService = Depends(get_memory_service)
+    memory_service: MemoryService = Depends(get_memory_service),
 ):
-    """Get all relations for a specific entity (where it is either the source or target)."""
+    """Get all relations for a specific entity."""
     try:
-    return memory_service.get_entity_relations(entity_id=entity_id, relation_type=relation_type)
-    except EntityNotFoundError as e:
-    raise HTTPException(status_code=404, detail=str(e))
-    except Exception as e:
-    raise HTTPException(
-    status_code=500,
-    detail=f"Internal server error: {e}"
-    )
+        return memory_service.get_relations_for_entity(entity_id, relation_type=relation_type)
+    except HTTPException:
+        raise
+    except Exception as e:  # pragma: no cover - fallback error
+        raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+
 
 @router.delete("/relations/{relation_id}", status_code=status.HTTP_204_NO_CONTENT)
-
-
 def delete_relation(
     relation_id: int = Path(..., description="ID of the relation to delete."),
-    memory_service: MemoryService = Depends(get_memory_service)
+    memory_service: MemoryService = Depends(get_memory_service),
 ):
     """Delete a memory relation."""
     try:
-    success = memory_service.delete_relation(relation_id)
-    if not success:
-    raise EntityNotFoundError("MemoryRelation", relation_id)
-    return {"message": "Memory relation deleted successfully"}
+        deleted = memory_service.delete_memory_relation(relation_id)
+        if not deleted:
+            raise EntityNotFoundError("MemoryRelation", relation_id)
+        return {"message": "Memory relation deleted successfully"}
     except EntityNotFoundError as e:
-    raise HTTPException(status_code=404, detail=str(e))
-    except Exception as e:
-    raise HTTPException(
-    status_code=500,
-    detail=f"Internal server error: {e}"
-    )
+        raise HTTPException(status_code=404, detail=str(e))
+    except Exception as e:  # pragma: no cover - fallback error
+        raise HTTPException(status_code=500, detail=f"Internal server error: {e}")

--- a/backend/tests/test_memory_relations.py
+++ b/backend/tests/test_memory_relations.py
@@ -1,0 +1,87 @@
+import types
+from datetime import datetime, timezone
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient, ASGITransport
+
+from backend.routers.memory.relations.relations import (
+    router,
+    get_memory_service,
+)
+from backend.schemas.memory import MemoryRelation, MemoryRelationCreate
+from backend.services.exceptions import EntityNotFoundError
+
+
+class DummyService:
+    def __init__(self):
+        self.relations = {}
+        self.next_id = 1
+
+    def create_memory_relation(self, relation: MemoryRelationCreate):
+        rel = MemoryRelation(
+            id=self.next_id,
+            from_entity_id=relation.from_entity_id,
+            to_entity_id=relation.to_entity_id,
+            relation_type=relation.relation_type,
+            metadata_=relation.metadata_,
+            created_at=datetime.now(timezone.utc),
+            updated_at=None,
+            from_entity=None,
+            to_entity=None,
+        )
+        self.relations[self.next_id] = rel
+        self.next_id += 1
+        return rel
+
+    def update_memory_relation(self, relation_id: int, relation: MemoryRelationCreate):
+        if relation_id not in self.relations:
+            raise EntityNotFoundError("MemoryRelation", relation_id)
+        rel = self.relations[relation_id]
+        rel.from_entity_id = relation.from_entity_id
+        rel.to_entity_id = relation.to_entity_id
+        rel.relation_type = relation.relation_type
+        rel.metadata_ = relation.metadata_
+        rel.updated_at = datetime.now(timezone.utc)
+        return rel
+
+
+dummy_service = DummyService()
+
+
+def override_service():
+    return dummy_service
+
+
+app = FastAPI()
+app.include_router(router)
+app.dependency_overrides[get_memory_service] = override_service
+
+
+@pytest.mark.asyncio
+async def test_update_relation_success():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/relations/",
+            json={"from_entity_id": 1, "to_entity_id": 2, "relation_type": "link"},
+        )
+        assert resp.status_code == 200
+        relation_id = resp.json()["id"]
+
+        resp = await client.put(
+            f"/relations/{relation_id}",
+            json={"from_entity_id": 1, "to_entity_id": 2, "relation_type": "updated", "metadata_": {"x": 1}},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["relation_type"] == "updated"
+        assert data["metadata_"] == {"x": 1}
+
+
+@pytest.mark.asyncio
+async def test_update_relation_not_found():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.put(
+            "/relations/999",
+            json={"from_entity_id": 1, "to_entity_id": 2, "relation_type": "none"},
+        )
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- implement `update_memory_relation` in memory service
- add update route for relations
- cover relation updates with new tests

## Testing
- `flake8`
- `pytest tests/test_memory_relations.py -q`
- `pytest -q` *(fails: test_ingest_file_and_retrieve, test_openapi_contains_key_paths, project task endpoints)*

------
https://chatgpt.com/codex/tasks/task_e_6840f3b56dd0832cbee11ba0ce2f0226