### PR TITLE
Add updateRelation to memory API

### DIFF
--- a/frontend/src/services/api/memory.ts
+++ b/frontend/src/services/api/memory.ts
@@ -11,6 +11,7 @@ import type {
   MemoryObservationCreateData,
   MemoryRelation,
   MemoryRelationCreateData,
+  MemoryRelationUpdateData,
   MemoryRelationFilters,
   KnowledgeGraph,
 } from "@/types/memory";
@@ -151,6 +152,21 @@ export const memoryApi = {
       buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/relations"),
       {
         method: "POST",
+        body: JSON.stringify(data),
+      }
+    );
+    return response.data;
+  },
+
+  // Update an existing relation
+  updateRelation: async (
+    relationId: number,
+    data: MemoryRelationUpdateData
+  ): Promise<MemoryRelation> => {
+    const response = await request<{ data: MemoryRelation }>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/relations/${relationId}`),
+      {
+        method: "PUT",
         body: JSON.stringify(data),
       }
     );

--- a/frontend/src/types/memory.ts
+++ b/frontend/src/types/memory.ts
@@ -52,6 +52,10 @@ export const memoryRelationCreateSchema = memoryRelationBaseSchema;
 
 export type MemoryRelationCreateData = z.infer<typeof memoryRelationCreateSchema>;
 
+export const memoryRelationUpdateSchema = memoryRelationBaseSchema.partial();
+
+export type MemoryRelationUpdateData = z.infer<typeof memoryRelationUpdateSchema>;
+
 export const memoryRelationSchema = memoryRelationBaseSchema.extend({
   id: z.number(),
   created_at: z.string(),


### PR DESCRIPTION
## Summary
- support updating relations in memory service
- add MemoryRelationUpdateData type

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6840f3b4e8b0832cb30139cccc08c8ac