### PR TITLE
Add MemoryRelationEditor

### DIFF
--- a/frontend/src/components/memory/MemoryRelationEditor.tsx
+++ b/frontend/src/components/memory/MemoryRelationEditor.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Textarea,
+  VStack,
+  useToast,
+  HStack,
+} from '@chakra-ui/react';
+import { memoryApi } from '@/services/api';
+import type {
+  MemoryRelation,
+  MemoryRelationCreateData,
+  MemoryRelationUpdateData,
+} from '@/types/memory';
+
+interface MemoryRelationEditorProps {
+  relation?: MemoryRelation;
+  onSuccess?: (relation: MemoryRelation) => void;
+  onDelete?: (relationId: number) => void;
+}
+
+const MemoryRelationEditor: React.FC<MemoryRelationEditorProps> = ({
+  relation,
+  onSuccess,
+  onDelete,
+}) => {
+  const toast = useToast();
+  const [fromId, setFromId] = useState('');
+  const [toId, setToId] = useState('');
+  const [type, setType] = useState('');
+  const [metadata, setMetadata] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (relation) {
+      setFromId(String(relation.from_entity_id));
+      setToId(String(relation.to_entity_id));
+      setType(relation.relation_type);
+      setMetadata(
+        relation.metadata ? JSON.stringify(relation.metadata, null, 2) : ''
+      );
+    }
+  }, [relation]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const base = {
+        from_entity_id: Number(fromId),
+        to_entity_id: Number(toId),
+        relation_type: type,
+        metadata: metadata ? JSON.parse(metadata) : undefined,
+      };
+      let saved: MemoryRelation;
+      if (relation) {
+        await memoryApi.updateRelation(
+          relation.id,
+          base as MemoryRelationUpdateData
+        );
+        saved = { ...relation, ...base } as MemoryRelation;
+      } else {
+        saved = await memoryApi.createRelation(
+          base as MemoryRelationCreateData
+        );
+      }
+      toast({
+        title: 'Relation saved',
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+      });
+      onSuccess?.(saved);
+    } catch (err) {
+      toast({
+        title: 'Error saving relation',
+        description: err instanceof Error ? err.message : 'Unknown error',
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!relation) return;
+    setLoading(true);
+    try {
+      await memoryApi.deleteRelation(relation.id);
+      toast({
+        title: 'Relation deleted',
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+      });
+      onDelete?.(relation.id);
+    } catch (err) {
+      toast({
+        title: 'Error deleting relation',
+        description: err instanceof Error ? err.message : 'Unknown error',
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box
+      as="form"
+      onSubmit={handleSubmit}
+      p={4}
+      borderWidth="1px"
+      borderRadius="md"
+      bg="bg.surface"
+    >
+      <VStack spacing={4} align="stretch">
+        <FormControl>
+          <FormLabel>From Entity ID</FormLabel>
+          <Input value={fromId} onChange={(e) => setFromId(e.target.value)} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>To Entity ID</FormLabel>
+          <Input value={toId} onChange={(e) => setToId(e.target.value)} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Relation Type</FormLabel>
+          <Input value={type} onChange={(e) => setType(e.target.value)} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Metadata (JSON)</FormLabel>
+          <Textarea
+            value={metadata}
+            onChange={(e) => setMetadata(e.target.value)}
+          />
+        </FormControl>
+        <HStack>
+          {relation && (
+            <Button
+              colorScheme="red"
+              onClick={handleDelete}
+              isLoading={loading}
+              type="button"
+            >
+              Delete
+            </Button>
+          )}
+          <Button type="submit" colorScheme="blue" isLoading={loading}>
+            {relation ? 'Update' : 'Create'}
+          </Button>
+        </HStack>
+      </VStack>
+    </Box>
+  );
+};
+
+export default MemoryRelationEditor;

--- a/frontend/src/components/memory/__tests__/MemoryRelationEditor.test.tsx
+++ b/frontend/src/components/memory/__tests__/MemoryRelationEditor.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen, TestWrapper } from '@/__tests__/utils/test-utils';
+import MemoryRelationEditor from '../MemoryRelationEditor';
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual('@chakra-ui/react');
+  return {
+    ...actual,
+    useToast: () => vi.fn(),
+    useColorModeValue: (l: any, d: any) => l,
+  };
+});
+
+vi.mock('@/services/api', () => ({
+  memoryApi: {
+    createRelation: vi.fn(),
+    updateRelation: vi.fn(),
+    deleteRelation: vi.fn(),
+  },
+}));
+
+describe('MemoryRelationEditor', () => {
+  const user = userEvent.setup();
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders in create mode and submits data', async () => {
+    const { memoryApi } = require('@/services/api');
+    render(
+      <TestWrapper>
+        <MemoryRelationEditor />
+      </TestWrapper>
+    );
+    const inputs = screen.getAllByRole('textbox');
+    if (inputs.length >= 3) {
+      await user.type(inputs[0], '1');
+      await user.type(inputs[1], '2');
+      await user.type(inputs[2], 'rel');
+    }
+    const button = screen.getByRole('button', { name: /create/i });
+    await user.click(button);
+    expect(memoryApi.createRelation).toHaveBeenCalled();
+  });
+
+  it('renders in edit mode and calls update/delete', async () => {
+    const { memoryApi } = require('@/services/api');
+    const relation = {
+      id: 1,
+      from_entity_id: 1,
+      to_entity_id: 2,
+      relation_type: 'rel',
+      created_at: '',
+      metadata: null,
+    };
+    render(
+      <TestWrapper>
+        <MemoryRelationEditor relation={relation} />
+      </TestWrapper>
+    );
+    const updateButton = screen.getByRole('button', { name: /update/i });
+    await user.click(updateButton);
+    expect(memoryApi.updateRelation).toHaveBeenCalled();
+    const deleteButton = screen.getByRole('button', { name: /delete/i });
+    await user.click(deleteButton);
+    expect(memoryApi.deleteRelation).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/services/api/memory.ts
+++ b/frontend/src/services/api/memory.ts
@@ -1,5 +1,5 @@
-import { request } from "./request";
-import { buildApiUrl, API_CONFIG } from "./config";
+import { request } from './request';
+import { buildApiUrl, API_CONFIG } from './config';
 import type {
   MemoryEntity,
   MemoryEntityCreateData,
@@ -11,9 +11,10 @@ import type {
   MemoryObservationCreateData,
   MemoryRelation,
   MemoryRelationCreateData,
+  MemoryRelationUpdateData,
   MemoryRelationFilters,
   KnowledgeGraph,
-} from "@/types/memory";
+} from '@/types/memory';
 
 // --- Memory Entity APIs ---
 export const memoryApi = {
@@ -22,7 +23,7 @@ export const memoryApi = {
     const response = await request<MemoryEntityResponse>(
       buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify(data),
       }
     );
@@ -61,7 +62,7 @@ export const memoryApi = {
     const response = await request<MemoryEntityResponse>(
       buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/${entityId}`),
       {
-        method: "PUT",
+        method: 'PUT',
         body: JSON.stringify(data),
       }
     );
@@ -70,20 +71,17 @@ export const memoryApi = {
 
   // Delete a memory entity
   deleteEntity: async (entityId: number): Promise<void> => {
-    await request(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/${entityId}`),
-      {
-        method: "DELETE",
-      }
-    );
+    await request(buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/${entityId}`), {
+      method: 'DELETE',
+    });
   },
 
   // Ingest a file from the server filesystem
   ingestFile: async (filePath: string): Promise<MemoryEntity> => {
     const response = await request<MemoryEntityResponse>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/entities/ingest/file"),
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/entities/ingest/file'),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify({ file_path: filePath }),
       }
     );
@@ -93,9 +91,9 @@ export const memoryApi = {
   // Ingest content directly from a URL
   ingestUrl: async (url: string): Promise<MemoryEntity> => {
     const response = await request<MemoryEntityResponse>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/ingest-url"),
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/ingest-url'),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify({ url }),
       }
     );
@@ -105,9 +103,9 @@ export const memoryApi = {
   // Ingest a raw text snippet
   ingestText: async (text: string): Promise<MemoryEntity> => {
     const response = await request<MemoryEntityResponse>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/ingest-text"),
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/ingest-text'),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify({ text }),
       }
     );
@@ -116,11 +114,13 @@ export const memoryApi = {
 
   // --- Memory Observation APIs ---
   // Add an observation to an entity
-  addObservation: async (data: MemoryObservationCreateData): Promise<MemoryObservation> => {
+  addObservation: async (
+    data: MemoryObservationCreateData
+  ): Promise<MemoryObservation> => {
     const response = await request<{ data: MemoryObservation }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/observations"),
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/observations'),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify(data),
       }
     );
@@ -130,7 +130,10 @@ export const memoryApi = {
   // Get observations for an entity
   getObservations: async (entityId: number): Promise<MemoryObservation[]> => {
     const response = await request<{ data: MemoryObservation[] }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/entities/${entityId}/observations`)
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.MEMORY,
+        `/entities/${entityId}/observations`
+      )
     );
     return response.data;
   },
@@ -138,19 +141,39 @@ export const memoryApi = {
   // Delete an observation
   deleteObservation: async (observationId: number): Promise<void> => {
     await request(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/observations/${observationId}`),
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.MEMORY,
+        `/observations/${observationId}`
+      ),
       {
-        method: "DELETE",
+        method: 'DELETE',
       }
     );
   },
   // --- Memory Relation APIs ---
   // Create a relation between entities
-  createRelation: async (data: MemoryRelationCreateData): Promise<MemoryRelation> => {
+  createRelation: async (
+    data: MemoryRelationCreateData
+  ): Promise<MemoryRelation> => {
     const response = await request<{ data: MemoryRelation }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/relations"),
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/relations'),
       {
-        method: "POST",
+        method: 'POST',
+        body: JSON.stringify(data),
+      }
+    );
+    return response.data;
+  },
+
+  // Update an existing relation
+  updateRelation: async (
+    relationId: number,
+    data: MemoryRelationUpdateData
+  ): Promise<MemoryRelation> => {
+    const response = await request<{ data: MemoryRelation }>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/relations/${relationId}`),
+      {
+        method: 'PUT',
         body: JSON.stringify(data),
       }
     );
@@ -158,7 +181,9 @@ export const memoryApi = {
   },
 
   // Get relations with filters
-  getRelations: async (filters?: MemoryRelationFilters): Promise<MemoryRelation[]> => {
+  getRelations: async (
+    filters?: MemoryRelationFilters
+  ): Promise<MemoryRelation[]> => {
     const params = new URLSearchParams();
     if (filters) {
       Object.entries(filters).forEach(([key, value]) => {
@@ -168,7 +193,10 @@ export const memoryApi = {
       });
     }
     const response = await request<{ data: MemoryRelation[] }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/relations?${params.toString()}`)
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.MEMORY,
+        `/relations?${params.toString()}`
+      )
     );
     return response.data;
   },
@@ -178,7 +206,7 @@ export const memoryApi = {
     await request(
       buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/relations/${relationId}`),
       {
-        method: "DELETE",
+        method: 'DELETE',
       }
     );
   },
@@ -187,7 +215,7 @@ export const memoryApi = {
   // Get the full knowledge graph
   getKnowledgeGraph: async (): Promise<KnowledgeGraph> => {
     const response = await request<{ data: KnowledgeGraph }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/graph")
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/graph')
     );
     return response.data;
   },
@@ -195,7 +223,10 @@ export const memoryApi = {
   // Search the knowledge graph
   searchGraph: async (query: string): Promise<MemoryEntity[]> => {
     const response = await request<{ data: MemoryEntity[] }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/search?q=${encodeURIComponent(query)}`)
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.MEMORY,
+        `/search?q=${encodeURIComponent(query)}`
+      )
     );
     return response.data;
   },

--- a/frontend/src/types/memory.ts
+++ b/frontend/src/types/memory.ts
@@ -1,8 +1,8 @@
-import { z } from "zod";
+import { z } from 'zod';
 
 // --- Memory Entity Schemas ---
 export const memoryEntityBaseSchema = z.object({
-  entity_type: z.string().min(1, "Entity type is required"),
+  entity_type: z.string().min(1, 'Entity type is required'),
   content: z.string().nullable().optional(),
   metadata: z.record(z.any()).nullable().optional(),
 });
@@ -26,12 +26,14 @@ export type MemoryEntity = z.infer<typeof memoryEntitySchema>;
 // --- Memory Observation Schemas ---
 export const memoryObservationBaseSchema = z.object({
   entity_id: z.number(),
-  content: z.string().min(1, "Content is required"),
+  content: z.string().min(1, 'Content is required'),
 });
 
 export const memoryObservationCreateSchema = memoryObservationBaseSchema;
 
-export type MemoryObservationCreateData = z.infer<typeof memoryObservationCreateSchema>;
+export type MemoryObservationCreateData = z.infer<
+  typeof memoryObservationCreateSchema
+>;
 
 export const memoryObservationSchema = memoryObservationBaseSchema.extend({
   id: z.number(),
@@ -44,13 +46,21 @@ export type MemoryObservation = z.infer<typeof memoryObservationSchema>;
 export const memoryRelationBaseSchema = z.object({
   from_entity_id: z.number(),
   to_entity_id: z.number(),
-  relation_type: z.string().min(1, "Relation type is required"),
+  relation_type: z.string().min(1, 'Relation type is required'),
   metadata: z.record(z.any()).nullable().optional(),
 });
 
 export const memoryRelationCreateSchema = memoryRelationBaseSchema;
 
-export type MemoryRelationCreateData = z.infer<typeof memoryRelationCreateSchema>;
+export type MemoryRelationCreateData = z.infer<
+  typeof memoryRelationCreateSchema
+>;
+
+export const memoryRelationUpdateSchema = memoryRelationBaseSchema.partial();
+
+export type MemoryRelationUpdateData = z.infer<
+  typeof memoryRelationUpdateSchema
+>;
 
 export const memoryRelationSchema = memoryRelationBaseSchema.extend({
   id: z.number(),


### PR DESCRIPTION
## Summary
- support updating memory relations in API
- add MemoryRelationEditor component for create, edit, delete
- document update type in memory types
- test MemoryRelationEditor form submissions

## Testing
- `npx prettier --write frontend/src/types/memory.ts frontend/src/services/api/memory.ts frontend/src/components/memory/MemoryRelationEditor.tsx frontend/src/components/memory/__tests__/MemoryRelationEditor.test.tsx`
- `npx vitest run --include src/components/memory/__tests__/MemoryRelationEditor.test.tsx` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f3b4ab6c832cae21986ce61cb054