### PR TITLE
Add memory search component

### DIFF
--- a/frontend/src/components/memory/MemorySearch.tsx
+++ b/frontend/src/components/memory/MemorySearch.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import React, { useState } from 'react';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  List,
+  ListItem,
+  Text,
+} from '@chakra-ui/react';
+import Link from 'next/link';
+import { memoryApi } from '@/services/api';
+import type { MemoryEntity } from '@/types/memory';
+
+const MemorySearch: React.FC = () => {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<MemoryEntity[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSearch = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!query.trim()) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await memoryApi.searchGraph(query.trim());
+      setResults(data);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box
+      as="form"
+      onSubmit={handleSearch}
+      p={4}
+      borderWidth="1px"
+      borderRadius="md"
+      bg="bg.surface"
+    >
+      <FormControl mb={4}>
+        <FormLabel>Search Memory</FormLabel>
+        <Input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search knowledge graph"
+        />
+      </FormControl>
+      <Button type="submit" colorScheme="blue" isLoading={loading} mb={4}>
+        Search
+      </Button>
+      {error && (
+        <Text color="textError" mb={2}>
+          {error}
+        </Text>
+      )}
+      <List spacing={2}>
+        {results.map((entity) => (
+          <ListItem key={entity.id}>
+            <Link href={`/memory/entities/${entity.id}`}>
+              {entity.entity_type}: {entity.content}
+            </Link>
+          </ListItem>
+        ))}
+      </List>
+    </Box>
+  );
+};
+
+export default MemorySearch;

--- a/frontend/src/components/memory/__tests__/MemorySearch.test.tsx
+++ b/frontend/src/components/memory/__tests__/MemorySearch.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen, TestWrapper } from '@/__tests__/utils/test-utils';
+import MemorySearch from '../MemorySearch';
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual('@chakra-ui/react');
+  return {
+    ...actual,
+    useToast: () => vi.fn(),
+    useColorModeValue: (l: any, d: any) => l,
+  };
+});
+
+vi.mock('@/services/api', () => ({
+  memoryApi: {
+    searchGraph: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+describe('MemorySearch', () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders without crashing', () => {
+    render(
+      <TestWrapper>
+        <MemorySearch />
+      </TestWrapper>
+    );
+    expect(document.body).toBeInTheDocument();
+  });
+
+  it('handles search interaction', async () => {
+    render(
+      <TestWrapper>
+        <MemorySearch />
+      </TestWrapper>
+    );
+
+    const input = screen.getByRole('textbox');
+    const button = screen.getByRole('button');
+
+    await user.type(input, 'test');
+    await user.click(button);
+
+    expect(document.body).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add MemorySearch component for searching the knowledge graph
- list search results with links to entity pages
- add basic tests for MemorySearch

## Testing
- `npx vitest run src/components/memory/__tests__/MemorySearch.test.tsx --threads=false` *(fails: Cannot read properties of undefined (reading 'matches'))*

------
https://chatgpt.com/codex/tasks/task_e_6840f3ae9d80832c8714900c870455cd