### PR TITLE
Add user role management tools

### DIFF
--- a/backend/docs/fastapi_mcp/README.md
+++ b/backend/docs/fastapi_mcp/README.md
@@ -93,6 +93,9 @@ FastAPI-MCP automatically exposes selected API endpoints as tools under the `/mc
 - `/mcp-tools/memory/add-observation` (POST)
 - `/mcp-tools/memory/add-relation` (POST)
 - `/mcp-tools/memory/search` (GET)
+- `/mcp-tools/user-role/assign` (POST)
+- `/mcp-tools/user-role/remove` (POST)
+- `/mcp-tools/user-role/list` (GET)
 
 ## Development and Contributing
 

--- a/backend/mcp_tools/README.md
+++ b/backend/mcp_tools/README.md
@@ -25,6 +25,7 @@ graph TD
 - `memory_tools.py`
 - `project_tools.py`
 - `task_tools.py`
+- `user_role_tools.py`
 
 <!-- File List End -->
 

--- a/backend/mcp_tools/__init__.py
+++ b/backend/mcp_tools/__init__.py
@@ -12,5 +12,8 @@ __all__ = [
     'search_memory_tool',
     'add_project_file_tool',
     'list_project_files_tool',
-    'remove_project_file_tool'
+    'remove_project_file_tool',
+    'assign_user_role_tool',
+    'remove_user_role_tool',
+    'list_user_roles_tool'
 ]

--- a/backend/mcp_tools/user_role_tools.py
+++ b/backend/mcp_tools/user_role_tools.py
@@ -1,0 +1,45 @@
+"""MCP tools for managing user roles."""
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+import logging
+
+from backend.services.user_role_service import UserRoleService
+
+logger = logging.getLogger(__name__)
+
+
+async def assign_user_role_tool(user_id: str, role_name: str, db: Session) -> dict:
+    """Assign a role to a user."""
+    try:
+        service = UserRoleService(db)
+        role = service.assign_role_to_user(user_id, role_name)
+        return {
+            "success": True,
+            "user_role": {"user_id": role.user_id, "role_name": role.role_name},
+        }
+    except Exception as e:
+        logger.error(f"MCP assign user role failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+async def remove_user_role_tool(user_id: str, role_name: str, db: Session) -> dict:
+    """Remove a role from a user."""
+    try:
+        service = UserRoleService(db)
+        success = service.remove_role_from_user(user_id, role_name)
+        return {"success": success}
+    except Exception as e:
+        logger.error(f"MCP remove user role failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+async def list_user_roles_tool(user_id: str, db: Session) -> dict:
+    """List all roles assigned to a user."""
+    try:
+        service = UserRoleService(db)
+        roles = service.get_user_roles(user_id)
+        return {"success": True, "roles": [r.role_name for r in roles]}
+    except Exception as e:
+        logger.error(f"MCP list user roles failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/routers/mcp/core.py
+++ b/backend/routers/mcp/core.py
@@ -17,6 +17,7 @@ from ....services.task_service import TaskService
 from ....services.audit_log_service import AuditLogService
 from ....services.memory_service import MemoryService
 from ....services.project_file_association_service import ProjectFileAssociationService
+from ....services.user_role_service import UserRoleService
 from ....schemas.project import ProjectCreate
 from ....schemas.task import TaskCreate
 from ....schemas.memory import (
@@ -550,6 +551,68 @@ async def mcp_get_memory_metadata(
         return {"success": True, "metadata": metadata}
     except Exception as e:
         logger.error(f"MCP get memory metadata failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/mcp-tools/user-role/assign",
+    tags=["mcp-tools"],
+    operation_id="assign_user_role_tool",
+)
+async def mcp_assign_user_role(
+    user_id: str,
+    role_name: str,
+    db: Session = Depends(get_db_session),
+):
+    """MCP Tool: Assign a role to a user."""
+    try:
+        service = UserRoleService(db)
+        role = service.assign_role_to_user(user_id, role_name)
+        return {
+            "success": True,
+            "user_role": {"user_id": role.user_id, "role_name": role.role_name},
+        }
+    except Exception as e:
+        logger.error(f"MCP assign user role failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/mcp-tools/user-role/remove",
+    tags=["mcp-tools"],
+    operation_id="remove_user_role_tool",
+)
+async def mcp_remove_user_role(
+    user_id: str,
+    role_name: str,
+    db: Session = Depends(get_db_session),
+):
+    """MCP Tool: Remove a role from a user."""
+    try:
+        service = UserRoleService(db)
+        success = service.remove_role_from_user(user_id, role_name)
+        return {"success": success}
+    except Exception as e:
+        logger.error(f"MCP remove user role failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get(
+    "/mcp-tools/user-role/list",
+    tags=["mcp-tools"],
+    operation_id="list_user_roles_tool",
+)
+async def mcp_list_user_roles(
+    user_id: str,
+    db: Session = Depends(get_db_session),
+):
+    """MCP Tool: List roles assigned to a user."""
+    try:
+        service = UserRoleService(db)
+        roles = service.get_user_roles(user_id)
+        return {"success": True, "roles": [r.role_name for r in roles]}
+    except Exception as e:
+        logger.error(f"MCP list user roles failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 


### PR DESCRIPTION
## Summary
- add `user_role_tools.py` with assign/remove/list tools
- expose user role tools in MCP router
- document new endpoints

## Testing
- `flake8 backend/mcp_tools/user_role_tools.py backend/routers/mcp/core.py`
- `pytest -q` *(fails: EntityNotFound errors)*
- `npm test --prefix frontend` *(fails: observer.observe is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6840f3ac80f8832cb2f248ddd0ded4df