### PR TITLE
Implement audit log deletion

### DIFF
--- a/backend/routers/audit_logs/__init__.py
+++ b/backend/routers/audit_logs/__init__.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from .audit_logs import router as audit_logs_router
+from .core import router as core_router
 
 router = APIRouter()
-router.include_router(audit_logs_router)
+router.include_router(core_router)

--- a/backend/routers/audit_logs/core.py
+++ b/backend/routers/audit_logs/core.py
@@ -1,0 +1,46 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+import json
+
+from ...database import get_db
+from ...services.audit_log_service import AuditLogService
+from ...schemas.api_responses import DataResponse
+from ...schemas.audit_log import AuditLog
+
+router = APIRouter()
+
+
+def get_audit_log_service(db: AsyncSession = Depends(get_db)) -> AuditLogService:
+    return AuditLogService(db)
+
+
+@router.delete("/{log_id}", response_model=DataResponse[AuditLog])
+async def delete_audit_log(
+    log_id: str,
+    audit_log_service: AuditLogService = Depends(get_audit_log_service),
+):
+    """Delete an audit log by ID."""
+    existing_log = await audit_log_service.get_log(log_id)
+    if not existing_log:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Audit log not found")
+
+    await audit_log_service.delete_log(log_id)
+    details = existing_log.details
+    if isinstance(details, str):
+        try:
+            details = json.loads(details)
+        except Exception:
+            details = None
+
+    log_schema = AuditLog(
+        id=existing_log.id,
+        user_id=existing_log.user_id,
+        action=getattr(existing_log, "action_type", None),
+        details=details,
+        timestamp=existing_log.timestamp,
+    )
+
+    return DataResponse[AuditLog](
+        data=log_schema,
+        message="Audit log deleted successfully",
+    )

--- a/backend/services/audit_log_service.py
+++ b/backend/services/audit_log_service.py
@@ -76,11 +76,15 @@ class AuditLogService:
         )
 
     async def delete_log(self, audit_log_id: str) -> Optional[AuditLogModel]:
-        """Delete an audit log entry."""
-        return await audit_log_crud.delete_audit_log(
+        """Delete an audit log entry and return the deleted record if it existed."""
+        log = await self.get_log(audit_log_id)
+        if not log:
+            return None
+        await audit_log_crud.delete_audit_log(
             db=self.db,
-            audit_log_id=audit_log_id
+            log_id=audit_log_id
         )
+        return log
 
     async def log_user_action(
         self,

--- a/backend/tests/test_audit_logs.py
+++ b/backend/tests/test_audit_logs.py
@@ -1,0 +1,48 @@
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.routers.audit_logs.core import router
+from backend.database import get_db
+from backend.crud import audit_logs as audit_log_crud
+from backend.schemas.audit_log import AuditLogCreate
+
+
+@pytest.mark.asyncio
+async def test_delete_audit_log(async_db_session: AsyncSession):
+    app = FastAPI()
+    app.include_router(router, prefix="/audit-logs")
+
+    async def override_db():
+        yield async_db_session
+
+    app.dependency_overrides[get_db] = override_db
+
+    log_create = AuditLogCreate(action="test", details={"foo": "bar"})
+    created = await audit_log_crud.create_audit_log(async_db_session, log_create)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.delete(f"/audit-logs/{created.id}")
+        assert resp.status_code == 200
+        assert resp.json()["data"]["id"] == created.id
+
+    remaining = await audit_log_crud.get_audit_log(async_db_session, created.id)
+    assert remaining is None
+
+
+@pytest.mark.asyncio
+async def test_delete_audit_log_not_found(async_db_session: AsyncSession):
+    app = FastAPI()
+    app.include_router(router, prefix="/audit-logs")
+
+    async def override_db():
+        yield async_db_session
+
+    app.dependency_overrides[get_db] = override_db
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.delete("/audit-logs/nonexistent")
+        assert resp.status_code == 404
+
+


### PR DESCRIPTION
## Summary
- extend `AuditLogService.delete_log`
- add new audit log deletion router and use it
- provide tests for the delete endpoint

## Testing
- `flake8 routers/audit_logs/core.py services/audit_log_service.py tests/test_audit_logs.py`
- `pytest backend/tests/test_audit_logs.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6840f3ab2bfc832cb71cf86287faa24b