### PR TITLE
Add audit log deletion

### DIFF
--- a/frontend/src/services/api/__tests__/audit_logs.test.ts
+++ b/frontend/src/services/api/__tests__/audit_logs.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { deleteLog } from '../audit_logs';
+import { buildApiUrl, API_CONFIG } from '../config';
+import { request } from '../request';
+
+vi.mock('../request', () => ({ request: vi.fn() }));
+
+const requestMock = request as unknown as vi.Mock;
+
+describe('audit_logs service', () => {
+  beforeEach(() => {
+    requestMock.mockResolvedValue(undefined);
+    vi.clearAllMocks();
+  });
+
+  it('deleteLog calls correct URL', async () => {
+    await deleteLog('123');
+    expect(requestMock).toHaveBeenCalledWith(
+      buildApiUrl(API_CONFIG.ENDPOINTS.AUDIT_LOGS, '/123'),
+      { method: 'DELETE' }
+    );
+  });
+});

--- a/frontend/src/services/api/audit_logs.ts
+++ b/frontend/src/services/api/audit_logs.ts
@@ -1,10 +1,12 @@
-import { request } from "./request";
-import { AuditLog, AuditLogFilters } from "@/types/audit_log";
-import { buildApiUrl, API_CONFIG } from "./config";
+import { request } from './request';
+import { AuditLog, AuditLogFilters } from '@/types/audit_log';
+import { buildApiUrl, API_CONFIG } from './config';
 
 // Fetch a single audit log entry by ID
 export const getAuditLogById = async (logId: string): Promise<AuditLog> => {
-  return request<AuditLog>(buildApiUrl(API_CONFIG.ENDPOINTS.AUDIT_LOGS, `/${logId}`));
+  return request<AuditLog>(
+    buildApiUrl(API_CONFIG.ENDPOINTS.AUDIT_LOGS, `/${logId}`)
+  );
 };
 
 // Fetch audit log entries by Entity
@@ -15,10 +17,13 @@ export const getAuditLogsByEntity = async (
   limit: number = 100
 ): Promise<AuditLog[]> => {
   const queryParams = new URLSearchParams();
-  queryParams.append("skip", String(skip));
-  queryParams.append("limit", String(limit));
+  queryParams.append('skip', String(skip));
+  queryParams.append('limit', String(limit));
   const queryString = queryParams.toString();
-  const url = buildApiUrl(API_CONFIG.ENDPOINTS.AUDIT_LOGS, `/entity/${entityType}/${entityId}${queryString ? `?${queryString}` : ""}`);
+  const url = buildApiUrl(
+    API_CONFIG.ENDPOINTS.AUDIT_LOGS,
+    `/entity/${entityType}/${entityId}${queryString ? `?${queryString}` : ''}`
+  );
   return request<AuditLog[]>(url);
 };
 
@@ -29,13 +34,23 @@ export const getAuditLogsByUser = async (
   limit: number = 100
 ): Promise<AuditLog[]> => {
   const queryParams = new URLSearchParams();
-  queryParams.append("skip", String(skip));
-  queryParams.append("limit", String(limit));
+  queryParams.append('skip', String(skip));
+  queryParams.append('limit', String(limit));
   const queryString = queryParams.toString();
-  const url = buildApiUrl(API_CONFIG.ENDPOINTS.AUDIT_LOGS, `/user/${userId}${queryString ? `?${queryString}` : ""}`);
+  const url = buildApiUrl(
+    API_CONFIG.ENDPOINTS.AUDIT_LOGS,
+    `/user/${userId}${queryString ? `?${queryString}` : ''}`
+  );
   return request<AuditLog[]>(url);
 };
 
 // Note: The backend also has a POST /audit_logs/ endpoint,
 // but creating audit logs is typically handled internally by the backend
 // when events occur, not directly by the frontend via a user action.
+
+// Delete an audit log entry by ID
+export const deleteLog = async (id: string): Promise<void> => {
+  await request<void>(buildApiUrl(API_CONFIG.ENDPOINTS.AUDIT_LOGS, `/${id}`), {
+    method: 'DELETE',
+  });
+};


### PR DESCRIPTION
## Summary
- add `deleteLog` API call for audit logs
- allow removing logs in `AuditLogListForEntity`
- test audit log deletion

## Testing
- `npm run lint`
- `npm run type-check` *(fails: src/components/forms/AddProjectTemplateForm.tsx ...)*
- `npm test` *(fails: various integration tests fail)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6840f3a60af4832cb36c34de1b21336e