### PR TITLE
Add workflows API and page

### DIFF
--- a/frontend/src/app/workflows/__tests__/page.test.tsx
+++ b/frontend/src/app/workflows/__tests__/page.test.tsx
@@ -1,0 +1,18 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@/__tests__/utils/test-utils';
+import WorkflowsPage from '../page';
+import { workflowsApi } from '@/services/api/workflows';
+
+vi.mock('@/services/api/workflows');
+
+describe('WorkflowsPage', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    (workflowsApi.list as unknown as vi.Mock).mockResolvedValue([]);
+  });
+
+  it('renders heading', async () => {
+    render(<WorkflowsPage />);
+    expect(screen.getByText(/Workflows/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/workflows/page.tsx
+++ b/frontend/src/app/workflows/page.tsx
@@ -1,0 +1,187 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Heading,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Button,
+  Input,
+  Checkbox,
+  VStack,
+} from '@chakra-ui/react';
+import { workflowsApi } from '@/services/api';
+import type { Workflow, WorkflowCreateData, WorkflowUpdateData } from '@/types/workflow';
+
+const WorkflowsPage: React.FC = () => {
+  const [workflows, setWorkflows] = useState<Workflow[]>([]);
+  const [newWorkflow, setNewWorkflow] = useState<WorkflowCreateData>({
+    name: '',
+    workflow_type: '',
+    description: '',
+    entry_criteria: '',
+    success_criteria: '',
+    is_active: true,
+  });
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editData, setEditData] = useState<WorkflowUpdateData>({});
+
+  const fetchData = async () => {
+    try {
+      const data = await workflowsApi.list();
+      setWorkflows(data);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const handleCreate = async () => {
+    await workflowsApi.create(newWorkflow);
+    setNewWorkflow({
+      name: '',
+      workflow_type: '',
+      description: '',
+      entry_criteria: '',
+      success_criteria: '',
+      is_active: true,
+    });
+    fetchData();
+  };
+
+  const handleUpdate = async (id: string) => {
+    await workflowsApi.update(id, editData);
+    setEditingId(null);
+    setEditData({});
+    fetchData();
+  };
+
+  const handleDelete = async (id: string) => {
+    await workflowsApi.delete(id);
+    fetchData();
+  };
+
+  return (
+    <Box p="4">
+      <Heading size="md" mb="4">Workflows</Heading>
+      <VStack align="start" spacing="2" mb="6">
+        <Input
+          placeholder="Name"
+          value={newWorkflow.name}
+          onChange={(e) => setNewWorkflow({ ...newWorkflow, name: e.target.value })}
+        />
+        <Input
+          placeholder="Type"
+          value={newWorkflow.workflow_type}
+          onChange={(e) =>
+            setNewWorkflow({ ...newWorkflow, workflow_type: e.target.value })
+          }
+        />
+        <Input
+          placeholder="Description"
+          value={newWorkflow.description || ''}
+          onChange={(e) =>
+            setNewWorkflow({ ...newWorkflow, description: e.target.value })
+          }
+        />
+        <Button onClick={handleCreate} colorScheme="blue">
+          Create Workflow
+        </Button>
+      </VStack>
+      <Table variant="simple">
+        <Thead>
+          <Tr>
+            <Th>Name</Th>
+            <Th>Type</Th>
+            <Th>Active</Th>
+            <Th>Actions</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {workflows.map((wf) => (
+            <Tr key={wf.id} data-testid="workflow-row">
+              <Td>
+                {editingId === wf.id ? (
+                  <Input
+                    value={editData.name ?? wf.name}
+                    onChange={(e) =>
+                      setEditData({ ...editData, name: e.target.value })
+                    }
+                  />
+                ) : (
+                  wf.name
+                )}
+              </Td>
+              <Td>
+                {editingId === wf.id ? (
+                  <Input
+                    value={editData.workflow_type ?? wf.workflow_type}
+                    onChange={(e) =>
+                      setEditData({ ...editData, workflow_type: e.target.value })
+                    }
+                  />
+                ) : (
+                  wf.workflow_type
+                )}
+              </Td>
+              <Td>
+                {editingId === wf.id ? (
+                  <Checkbox
+                    isChecked={editData.is_active ?? wf.is_active}
+                    onChange={(e) =>
+                      setEditData({ ...editData, is_active: e.target.checked })
+                    }
+                  />
+                ) : wf.is_active ? (
+                  'Yes'
+                ) : (
+                  'No'
+                )}
+              </Td>
+              <Td>
+                {editingId === wf.id ? (
+                  <>
+                    <Button size="sm" onClick={() => handleUpdate(wf.id)}>
+                      Save
+                    </Button>
+                    <Button
+                      size="sm"
+                      ml="2"
+                      onClick={() => {
+                        setEditingId(null);
+                        setEditData({});
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                  </>
+                ) : (
+                  <>
+                    <Button size="sm" onClick={() => {
+                      setEditingId(wf.id);
+                      setEditData(wf);
+                    }}>
+                      Edit
+                    </Button>
+                    <Button size="sm" ml="2" onClick={() => handleDelete(wf.id)}>
+                      Delete
+                    </Button>
+                  </>
+                )}
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </Box>
+  );
+};
+
+export default WorkflowsPage;

--- a/frontend/src/services/api/__tests__/workflows.test.tsx
+++ b/frontend/src/services/api/__tests__/workflows.test.tsx
@@ -1,0 +1,16 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { workflowsApi } from '../workflows';
+import { mockFetchResponse } from '@/__tests__/utils/test-utils';
+
+describe('workflowsApi', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('list returns data', async () => {
+    const mock = [{ id: '1', name: 'WF', workflow_type: 'type', is_active: true, created_at: '', updated_at: '' }];
+    mockFetchResponse(mock);
+    const data = await workflowsApi.list();
+    expect(data).toEqual(mock);
+  });
+});

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -11,3 +11,4 @@ export * from "./mcp";
 export * from "./users";
 export * from "./audit_logs";
 export * from "./project_templates";
+export * from "./workflows";

--- a/frontend/src/services/api/workflows.ts
+++ b/frontend/src/services/api/workflows.ts
@@ -1,0 +1,42 @@
+import { request } from "./request";
+import { buildApiUrl, API_CONFIG } from "./config";
+import type { Workflow, WorkflowCreateData, WorkflowUpdateData } from "@/types/workflow";
+
+export const workflowsApi = {
+  async list(workflowType?: string, activeOnly = true): Promise<Workflow[]> {
+    const params = new URLSearchParams();
+    if (workflowType) params.append("workflow_type", workflowType);
+    if (activeOnly !== undefined) params.append("active_only", String(activeOnly));
+    const query = params.toString();
+    return request<Workflow[]>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/workflows${query ? `?${query}` : ""}`)
+    );
+  },
+
+  async get(id: string): Promise<Workflow> {
+    return request<Workflow>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/workflows/${id}`)
+    );
+  },
+
+  async create(data: WorkflowCreateData): Promise<Workflow> {
+    return request<Workflow>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/workflows`),
+      { method: "POST", body: JSON.stringify(data) }
+    );
+  },
+
+  async update(id: string, data: WorkflowUpdateData): Promise<Workflow> {
+    return request<Workflow>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/workflows/${id}`),
+      { method: "PUT", body: JSON.stringify(data) }
+    );
+  },
+
+  async delete(id: string): Promise<{ message: string }> {
+    return request<{ message: string }>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/workflows/${id}`),
+      { method: "DELETE" }
+    );
+  },
+};

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -9,6 +9,7 @@ export * from "./rules";
 export * from "./mcp";
 export * from "./project_template";
 export * from "./agent_prompt_template";
+export * from "./workflow";
 
 // Common types used across the application
 // Canonical shared sort direction type for all entities

--- a/frontend/src/types/workflow.ts
+++ b/frontend/src/types/workflow.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+export const workflowBaseSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  description: z.string().nullable().optional(),
+  workflow_type: z.string().min(1, "Type is required"),
+  entry_criteria: z.string().nullable().optional(),
+  success_criteria: z.string().nullable().optional(),
+  is_active: z.boolean().optional(),
+});
+
+export const workflowCreateSchema = workflowBaseSchema;
+export type WorkflowCreateData = z.infer<typeof workflowCreateSchema>;
+
+export const workflowUpdateSchema = workflowBaseSchema.partial();
+export type WorkflowUpdateData = z.infer<typeof workflowUpdateSchema>;
+
+export const workflowSchema = workflowBaseSchema.extend({
+  id: z.string(),
+  created_at: z.string(),
+  updated_at: z.string().optional(),
+});
+export type Workflow = z.infer<typeof workflowSchema>;


### PR DESCRIPTION
## Summary
- implement workflows API service
- export workflows API from index
- define workflow types
- add workflows page with CRUD form
- create basic tests for workflows

## Testing
- `npm run lint`
- `npm run test` *(fails: Cannot read properties of undefined - matches)*

------
https://chatgpt.com/codex/tasks/task_e_6840f3a43604832ca824165fd03d7bdc