### PR TITLE
Add TypeScript enum generator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,16 @@ npm run update-readmes
 
 This ensures all `README.md` files reflect up-to-date directory contents.
 
+### Sync TypeScript Enums
+
+If you modify `backend/enums.py`, regenerate the frontend enum file:
+
+```bash
+npm run generate
+```
+
+Commit the updated `frontend/src/types/generatedEnums.ts` along with your changes.
+
 ---
 
 ## 📐 Coding Standards

--- a/frontend/src/types/generatedEnums.ts
+++ b/frontend/src/types/generatedEnums.ts
@@ -1,0 +1,42 @@
+// This file is auto-generated from backend/enums.py.
+// Do not edit directly.
+
+export enum TaskStatusEnum {
+  TO_DO = "To Do",
+  IN_PROGRESS = "In Progress",
+  IN_REVIEW = "In Review",
+  COMPLETED = "Completed",
+  BLOCKED = "Blocked",
+  CANCELLED = "Cancelled",
+  CONTEXT_ACQUIRED = "Context Acquired",
+  PLANNING_COMPLETE = "Planning Complete",
+  EXECUTION_IN_PROGRESS = "Execution In Progress",
+  PENDING_VERIFICATION = "Pending Verification",
+  VERIFICATION_COMPLETE = "Verification Complete",
+  VERIFICATION_FAILED = "Verification Failed",
+  COMPLETED_AWAITING_PROJECT_MANAGER = "Completed Awaiting Project Manager",
+  COMPLETED_HANDOFF = "Completed Handoff",
+  FAILED = "Failed",
+  IN_PROGRESS_AWAITING_SUBTASK = "In Progress Awaiting Subtask",
+  PENDING_RECOVERY_ATTEMPT = "Pending Recovery Attempt",
+}
+
+export enum UserRoleEnum {
+  ADMIN = "admin",
+  MANAGER = "manager",
+  ENGINEER = "engineer",
+  VIEWER = "viewer",
+  USER = "user",
+  AGENT = "agent",
+}
+
+export enum ActionType {
+  CREATE = "create",
+  READ = "read",
+  UPDATE = "update",
+  DELETE = "delete",
+  LOGIN = "login",
+  LOGOUT = "logout",
+  ASSIGN = "assign",
+  COMPLETE = "complete",
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "type-check": "npm --prefix frontend run type-check",
     "fix": "cd frontend && npm run fix",
     "format": "cd frontend && npm run format",
+    "generate": "python scripts/generate_ts_enums.py",
     "update-readmes": "python scripts/update_readmes.py",
     "prettier:check": "prettier --check .",
     "prettier:write": "prettier --write ."

--- a/scripts/generate_ts_enums.py
+++ b/scripts/generate_ts_enums.py
@@ -1,0 +1,41 @@
+import enum
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BACKEND_ENUMS = ROOT / "backend" / "enums.py"
+OUTPUT = ROOT / "frontend" / "src" / "types" / "generatedEnums.ts"
+
+def load_enums(path: Path):
+    spec = importlib.util.spec_from_file_location("backend.enums", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore
+    enums = {}
+    for name, obj in module.__dict__.items():
+        if isinstance(obj, enum.EnumMeta):
+            enums[name] = obj
+    return enums
+
+def to_ts(enums: dict) -> str:
+    lines = [
+        "// This file is auto-generated from backend/enums.py.",
+        "// Do not edit directly.\n",
+    ]
+    for name, enum_cls in enums.items():
+        lines.append(f"export enum {name} {{")
+        for member in enum_cls:
+            value = member.value
+            # escape quotes
+            value_str = str(value).replace('"', '\\"')
+            lines.append(f"  {member.name} = \"{value_str}\",")
+        lines.append("}\n")
+    return "\n".join(lines)
+
+def main():
+    enums = load_enums(BACKEND_ENUMS)
+    ts_content = to_ts(enums)
+    OUTPUT.write_text(ts_content)
+    print(f"Generated {OUTPUT.relative_to(ROOT)}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- generate TypeScript enums from backend enums
- expose generator via `npm run generate`
- document enum generation workflow

## Testing
- `npm run generate`
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f118962c832ca96689c196b227e2