### PR TITLE
Validate project and agent IDs

### DIFF
--- a/backend/routers/agents/core.py
+++ b/backend/routers/agents/core.py
@@ -68,6 +68,11 @@ def get_agent_by_name(agent_name: str, db: Session = Depends(get_db)):
 
 
 def get_agent_by_id_endpoint(agent_id: str, db: Session = Depends(get_db)):  # Instantiate AgentService
+    try:
+        uuid.UUID(agent_id)
+    except ValueError:
+        raise HTTPException(status_code=422, detail="Invalid agent_id format")
+
     agent_service = AgentService(db)
     db_agent = agent_service.get_agent(agent_id=agent_id)
     if db_agent is None:
@@ -78,6 +83,11 @@ def get_agent_by_id_endpoint(agent_id: str, db: Session = Depends(get_db)):  # I
 
 
 def update_agent(agent_id: str, agent_update: AgentUpdate, db: Session = Depends(get_db)):  # Instantiate AgentService
+    try:
+        uuid.UUID(agent_id)
+    except ValueError:
+        raise HTTPException(status_code=422, detail="Invalid agent_id format")
+
     agent_service = AgentService(db)
     try:
         db_agent = agent_service.update_agent(
@@ -94,6 +104,11 @@ def update_agent(agent_id: str, agent_update: AgentUpdate, db: Session = Depends
 
 
 def delete_agent(agent_id: str, db: Session = Depends(get_db)):  # Instantiate AgentService
+    try:
+        uuid.UUID(agent_id)
+    except ValueError:
+        raise HTTPException(status_code=422, detail="Invalid agent_id format")
+
     agent_service = AgentService(db)
     db_agent = agent_service.delete_agent(agent_id=agent_id)
     if db_agent is None:
@@ -104,6 +119,11 @@ def delete_agent(agent_id: str, db: Session = Depends(get_db)):  # Instantiate A
 
 
 def archive_agent_endpoint(agent_id: str, db: Session = Depends(get_db)):  # Instantiate AgentService
+    try:
+        uuid.UUID(agent_id)
+    except ValueError:
+        raise HTTPException(status_code=422, detail="Invalid agent_id format")
+
     agent_service = AgentService(db)
     try:
         archived_agent = agent_service.archive_agent(agent_id=agent_id)
@@ -121,6 +141,11 @@ def archive_agent_endpoint(agent_id: str, db: Session = Depends(get_db)):  # Ins
 
 
 def unarchive_agent_endpoint(agent_id: str, db: Session = Depends(get_db)):  # Instantiate AgentService
+    try:
+        uuid.UUID(agent_id)
+    except ValueError:
+        raise HTTPException(status_code=422, detail="Invalid agent_id format")
+
     agent_service = AgentService(db)
     try:
         unarchived_agent = agent_service.unarchive_agent(agent_id=agent_id)

--- a/backend/routers/mcp/core.py
+++ b/backend/routers/mcp/core.py
@@ -228,6 +228,11 @@ async def mcp_update_task(
 ):
     """MCP Tool: Update an existing task."""
     try:
+        try:
+            uuid.UUID(project_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid project_id format")
+
         task_service = TaskService(db)
         task = task_service.update_task(
             project_id=project_id,
@@ -271,6 +276,11 @@ async def mcp_delete_task(
 ):
     """MCP Tool: Delete an existing task."""
     try:
+        try:
+            uuid.UUID(project_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid project_id format")
+
         task_service = TaskService(db)
         task_service.delete_task(
             project_id=project_id,
@@ -305,6 +315,11 @@ async def mcp_add_project_file(
 ):
     """MCP Tool: Associate a file (memory entity) with a project."""
     try:
+        try:
+            uuid.UUID(project_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid project_id format")
+
         project_file = service.add_project_file_association(
             project_id=project_id,
             file_memory_entity_id=file_memory_entity_id
@@ -338,6 +353,11 @@ async def mcp_list_project_files(
 ):
     """MCP Tool: List files associated with a project."""
     try:
+        try:
+            uuid.UUID(project_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid project_id format")
+
         project_files = service.get_project_file_associations(
             project_id=project_id,
             skip=skip,
@@ -372,6 +392,11 @@ async def mcp_remove_project_file(
 ):
     """MCP Tool: Remove a file (memory entity) association from a project."""
     try:
+        try:
+            uuid.UUID(project_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid project_id format")
+
         service.remove_project_file_association(
             project_id=project_id,
             file_memory_entity_id=file_memory_entity_id

--- a/backend/routers/projects/core.py
+++ b/backend/routers/projects/core.py
@@ -164,6 +164,11 @@ async def get_project_by_id_endpoint(
 ):
     """Retrieves a specific project by its ID."""
     try:
+        try:
+            uuid.UUID(project_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid project_id format")
+
         db_project = await project_service.get_project(
             project_id=project_id, is_archived=is_archived
         )  # Return standardized response
@@ -205,6 +210,11 @@ async def update_project(
 ):
     """Update a project by ID."""
     try:
+        try:
+            uuid.UUID(project_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid project_id format")
+
         # First get the project to check ownership
         db_project = await project_service.get_project(project_id=project_id)
 
@@ -260,6 +270,11 @@ async def delete_project(
 ):
     """Delete a project by ID."""
     try:
+        try:
+            uuid.UUID(project_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid project_id format")
+
         db_project = await project_service.delete_project(project_id=project_id)
         if db_project is None:
             # Use EntityNotFoundError from services
@@ -292,6 +307,11 @@ async def archive_project(
 ):
     """Archive a project by setting is_archived to True."""
     try:  # Use the update_project method with is_archived=True
+        try:
+            uuid.UUID(project_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid project_id format")
+
         project_update = ProjectUpdate(is_archived=True)
         db_project = await project_service.update_project(
             project_id=project_id, project_update=project_update
@@ -331,6 +351,11 @@ async def unarchive_project(
 ):
     """Unarchive a project by setting is_archived to False."""
     try:  # Use the update_project method with is_archived=False
+        try:
+            uuid.UUID(project_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid project_id format")
+
         project_update = ProjectUpdate(is_archived=False)
         db_project = await project_service.update_project(
             project_id=project_id, project_update=project_update

--- a/backend/routers/tasks/all_tasks/all_tasks.py
+++ b/backend/routers/tasks/all_tasks/all_tasks.py
@@ -111,7 +111,7 @@ async def get_all_tasks(
     (f" in project {project_id}" if project_id else "")
     )
     except ValueError as ve:
-    raise HTTPException(status_code=400, detail=f"Invalid UUID format for project_id or agent_id: {ve}")
+    raise HTTPException(status_code=422, detail=f"Invalid UUID format for project_id or agent_id: {ve}")
     except Exception as e:  # Consider logging the exception here
     raise HTTPException(
     status_code=500,

--- a/backend/routers/tasks/comments/comments.py
+++ b/backend/routers/tasks/comments/comments.py
@@ -34,8 +34,13 @@ async def get_task_comments_endpoint(
 ):
     """Retrieves a list of comments for a task."""
     try:
+        try:
+            project_uuid = uuid.UUID(project_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid project_id format")
+
         comments, total_comments = await task_service.get_task_comments(
-            project_id=uuid.UUID(project_id),
+            project_id=project_uuid,
             task_number=task_number,
             skip=pagination.offset,
             limit=pagination.page_size,
@@ -79,8 +84,13 @@ async def add_task_comment_endpoint(
 ):
     """Adds a new comment to a specific task."""
     try:
+        try:
+            project_uuid = uuid.UUID(project_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid project_id format")
+
         db_comment = await task_service.add_comment_to_task(
-            project_id=uuid.UUID(project_id),
+            project_id=project_uuid,
             task_number=task_number,
             author_id=comment_create.author_id, # Assuming author_id is part of CommentCreate
             content=comment_create.content

--- a/backend/routers/tasks/core/core.py
+++ b/backend/routers/tasks/core/core.py
@@ -54,8 +54,13 @@ async def create_task_for_project(
 ):
     """Create a new task in a project."""
     try:
+        try:
+            project_uuid = uuid.UUID(project_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid project_id format")
+
         db_task = await task_service.create_task(
-            project_id=uuid.UUID(project_id),
+            project_id=project_uuid,
             task=task
         )
 
@@ -120,6 +125,17 @@ async def get_tasks_list(
     Supported sort fields: created_at, updated_at, title, status, task_number, agent_id
     """
     try:
+        try:
+            project_uuid = uuid.UUID(project_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid project_id format")
+
+        if agent_id is not None:
+            try:
+                uuid.UUID(agent_id)
+            except ValueError:
+                raise HTTPException(status_code=422, detail="Invalid agent_id format")
+
         agent_id_val: Optional[str] = None
         if agent_name:
             agent = await agent_service.get_agent_by_name(name=agent_name)
@@ -136,7 +152,7 @@ async def get_tasks_list(
                 )
 
         all_tasks = await task_service.get_tasks_by_project(
-            project_id=uuid.UUID(project_id),
+            project_id=project_uuid,
             skip=0, limit=None,
             agent_id=agent_id_val or agent_id,
             search=search,
@@ -146,7 +162,7 @@ async def get_tasks_list(
         total = len(all_tasks)
 
         tasks = await task_service.get_tasks_by_project(
-            project_id=uuid.UUID(project_id),
+            project_id=project_uuid,
             skip=pagination.offset,
             limit=pagination.page_size,
             agent_id=agent_id_val or agent_id,
@@ -194,8 +210,13 @@ async def read_task(
 ):
     """Retrieve a specific task by project and task number."""
     try:
+        try:
+            project_uuid = uuid.UUID(project_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid project_id format")
+
         db_task = await task_service.get_task(
-            project_id=uuid.UUID(project_id),
+            project_id=project_uuid,
             task_number=task_number
         )
 
@@ -229,8 +250,13 @@ async def archive_task_endpoint(
 ):
     """Archive a task by setting is_archived to True."""
     try:
+        try:
+            project_uuid = uuid.UUID(project_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid project_id format")
+
         db_task = await task_service.archive_task(
-            project_id=uuid.UUID(project_id),
+            project_id=project_uuid,
             task_number=task_number
         )
 
@@ -273,8 +299,13 @@ async def unarchive_task_endpoint(
 ):
     """Unarchive a task by setting is_archived to False."""
     try:
+        try:
+            project_uuid = uuid.UUID(project_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid project_id format")
+
         db_task = await task_service.unarchive_task(
-            project_id=uuid.UUID(project_id),
+            project_id=project_uuid,
             task_number=task_number
         )
 
@@ -318,8 +349,13 @@ async def update_task(
 ):
     """Update a task by project and task number."""
     try:
+        try:
+            project_uuid = uuid.UUID(project_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid project_id format")
+
         db_task = await task_service.update_task(
-            project_id=uuid.UUID(project_id),
+            project_id=project_uuid,
             task_number=task_number,
             task_update=task_update
         )
@@ -368,8 +404,13 @@ async def delete_task(
 ):
     """Delete a task by project and task number."""
     try:
+        try:
+            project_uuid = uuid.UUID(project_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid project_id format")
+
         db_task = await task_service.delete_task(
-            project_id=uuid.UUID(project_id),
+            project_id=project_uuid,
             task_number=task_number
         )
 

--- a/backend/routers/tasks/dependencies/dependencies.py
+++ b/backend/routers/tasks/dependencies/dependencies.py
@@ -32,10 +32,16 @@ async def add_task_dependency_endpoint(
 ):
     """Add a dependency between two tasks."""
     try:
+        try:
+            successor_uuid = uuid.UUID(project_id)
+            predecessor_uuid = uuid.UUID(dependency.predecessor_project_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid project_id format")
+
         db_dependency = await task_dependency_service.add_task_dependency(
-            successor_project_id=uuid.UUID(project_id),
+            successor_project_id=successor_uuid,
             successor_task_number=task_number,
-            predecessor_project_id=uuid.UUID(dependency.predecessor_project_id),
+            predecessor_project_id=predecessor_uuid,
             predecessor_task_number=dependency.predecessor_task_number,
             dependency_type=dependency.dependency_type
         )
@@ -76,8 +82,13 @@ async def get_all_task_dependencies_endpoint(
 ):
     """Get all dependencies for a task (both predecessors and successors)."""
     try:
+        try:
+            project_uuid = uuid.UUID(project_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid project_id format")
+
         dependencies = await task_dependency_service.get_all_task_dependencies(
-            project_id=uuid.UUID(project_id),
+            project_id=project_uuid,
             task_number=task_number,
             sort_by=sort_by,
             sort_direction=sort_direction,
@@ -122,8 +133,13 @@ async def get_task_predecessors_endpoint(
 ):
     """Get the predecessors for a specific task."""
     try:
+        try:
+            project_uuid = uuid.UUID(project_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid project_id format")
+
         predecessors = await task_dependency_service.get_task_predecessors(
-            project_id=uuid.UUID(project_id),
+            project_id=project_uuid,
             task_number=task_number,
             sort_by=sort_by,
             sort_direction=sort_direction,
@@ -168,8 +184,13 @@ async def get_task_successors_endpoint(
 ):
     """Get the successors for a specific task."""
     try:
+        try:
+            project_uuid = uuid.UUID(project_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid project_id format")
+
         successors = await task_dependency_service.get_task_successors(
-            project_id=uuid.UUID(project_id),
+            project_id=project_uuid,
             task_number=task_number,
             sort_by=sort_by,
             sort_direction=sort_direction,
@@ -211,10 +232,16 @@ async def remove_task_dependency_endpoint(
 ):
     """Remove a dependency between two tasks."""
     try:
+        try:
+            successor_uuid = uuid.UUID(project_id)
+            predecessor_uuid = uuid.UUID(predecessor_project_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid project_id format")
+
         success = await task_dependency_service.remove_task_dependency(
-            successor_project_id=uuid.UUID(project_id),
+            successor_project_id=successor_uuid,
             successor_task_number=task_number,
-            predecessor_project_id=uuid.UUID(predecessor_project_id),
+            predecessor_project_id=predecessor_uuid,
             predecessor_task_number=predecessor_task_number
         )
         if not success:

--- a/backend/routers/tasks/files/files.py
+++ b/backend/routers/tasks/files/files.py
@@ -33,11 +33,16 @@ async def associate_file_with_task_endpoint(
 ):
     """Associate a file with a task."""
     try:
-    db_association = await task_file_association_service.associate_file_with_task(
-    project_id=uuid.UUID(project_id),
-    task_number=task_number,
-    file_memory_entity_id=file_association.file_memory_entity_id
-    )
+        try:
+            project_uuid = uuid.UUID(project_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid project_id format")
+
+        db_association = await task_file_association_service.associate_file_with_task(
+            project_id=project_uuid,
+            task_number=task_number,
+            file_memory_entity_id=file_association.file_memory_entity_id
+        )
     return DataResponse[TaskFileAssociation](
     data=db_association,
     message="File associated with task successfully"
@@ -69,13 +74,18 @@ async def get_files_for_task_endpoint(
 ):
     """Get all files associated with a task."""
     try:
-    files = await task_file_association_service.get_task_files(
-    project_id=uuid.UUID(project_id),
-    task_number=task_number,
-    sort_by=sort_by,
-    sort_direction=sort_direction,
-    filename=filename
-    )
+        try:
+            project_uuid = uuid.UUID(project_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid project_id format")
+
+        files = await task_file_association_service.get_task_files(
+            project_id=project_uuid,
+            task_number=task_number,
+            sort_by=sort_by,
+            sort_direction=sort_direction,
+            filename=filename
+        )
     return ListResponse[TaskFileAssociation](
     data=files,
     total=len(files),
@@ -110,11 +120,16 @@ async def get_task_file_association_by_file_memory_entity_id_endpoint(
 ):
     """Retrieve a specific task file association by file memory entity ID."""
     try:
-    association = await task_file_association_service.get_task_file_association_by_file_memory_entity_id(
-    project_id=uuid.UUID(project_id),
-    task_number=task_number,
-    file_memory_entity_id=file_memory_entity_id
-    )
+        try:
+            project_uuid = uuid.UUID(project_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid project_id format")
+
+        association = await task_file_association_service.get_task_file_association_by_file_memory_entity_id(
+            project_id=project_uuid,
+            task_number=task_number,
+            file_memory_entity_id=file_memory_entity_id
+        )
     return DataResponse[TaskFileAssociation](
     data=association,
     message="Task file association retrieved successfully"
@@ -141,25 +156,30 @@ async def disassociate_file_from_task_by_file_memory_entity_id_endpoint(
     task_number: int = Path(..., description="Task number unique within the project."),
     file_memory_entity_id: int = Path(..., description="ID of the associated file MemoryEntity."),
     task_file_association_service: TaskFileAssociationService = Depends(
-    get_task_file_association_service),
+        get_task_file_association_service),
 ):
     """Disassociate a file from a task by file memory entity ID."""
     try:
-    success = await task_file_association_service.disassociate_file_from_task(
-    project_id=uuid.UUID(project_id),
-    task_number=task_number,
-    file_memory_entity_id=file_memory_entity_id
-    )
-    if not success:
-    raise HTTPException(status_code=404, detail="Task file association not found")
-    return DataResponse[dict](
-    data={"success": success},
-    message="File disassociated from task successfully"
-    )
+        try:
+            project_uuid = uuid.UUID(project_id)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid project_id format")
+
+        success = await task_file_association_service.disassociate_file_from_task(
+            project_id=project_uuid,
+            task_number=task_number,
+            file_memory_entity_id=file_memory_entity_id
+        )
+        if not success:
+            raise HTTPException(status_code=404, detail="Task file association not found")
+        return DataResponse[dict](
+            data={"success": success},
+            message="File disassociated from task successfully",
+        )
     except EntityNotFoundError as e:
-    raise HTTPException(status_code=404, detail=str(e))
+        raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
-    raise HTTPException(
-    status_code=500,
-    detail=f"Internal server error: {e}"
-    )
+        raise HTTPException(
+            status_code=500,
+            detail=f"Internal server error: {e}"
+        )

--- a/backend/tests/test_project_task_endpoints.py
+++ b/backend/tests/test_project_task_endpoints.py
@@ -74,3 +74,15 @@ async def test_create_task_requires_project(authenticated_client):
         json={"title": "No Project"},
     )
     assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_invalid_project_id_returns_422(authenticated_client):
+    resp = await authenticated_client.get("/api/v1/projects/not-a-uuid")
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_invalid_agent_id_returns_422(authenticated_client):
+    resp = await authenticated_client.get("/api/v1/agents/id/not-a-uuid")
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- validate UUID format for `project_id` and `agent_id` in routers
- return HTTP 422 when IDs are invalid
- test invalid IDs

## Testing
- `flake8`
- `pytest tests/test_project_task_endpoints.py -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_6840f118125c832cbe6099bc996d85ca