### PR TITLE
Add error boundary wrapper for layout

### DIFF
--- a/frontend/src/app/__tests__/layout.test.tsx
+++ b/frontend/src/app/__tests__/layout.test.tsx
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@/__tests__/utils/test-utils';
+import RootLayout from '../layout';
+
+const ProblemChild = () => {
+  throw new Error('Test error');
+};
+
+describe('RootLayout ErrorBoundary', () => {
+  it('renders fallback UI when child throws', () => {
+    render(
+      <RootLayout>
+        <ProblemChild />
+      </RootLayout>
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('Something went wrong');
+  });
+});

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -18,12 +18,9 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
     this.state = { hasError: false };
   }
 
-  static getDerivedStateFromError() {
-    return { hasError: true };
-  }
-
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     console.error("ErrorBoundary caught an error", error, errorInfo);
+    this.setState({ hasError: true });
   }
 
   render() {


### PR DESCRIPTION
## Summary
- handle errors in ErrorBoundary with componentDidCatch
- cover RootLayout error boundary in new test

## Testing
- `npm test` *(fails: Cannot read properties of undefined)*
- `pytest` *(fails: various backend tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_6840f10fd3b0832c9f83e92e8aaf716b