### PR TITLE
fix: dynamic API base URL

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,2 +1,3 @@
 # Example environment configuration for the frontend
+# Base URL of your MCP backend API. Include the protocol and port.
 NEXT_PUBLIC_API_BASE_URL=http://localhost:8000

--- a/frontend/src/services/api/config.ts
+++ b/frontend/src/services/api/config.ts
@@ -2,28 +2,37 @@
  * Central API configuration for consistent base URLs across all API services
  */
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000";
-const API_VERSION = "/api"; // Backend uses /api, not /api/v1
+const API_VERSION = '/api'; // Backend uses /api, not /api/v1
+
+/**
+ * Returns the API base URL, falling back to localhost in development.
+ * The value is read at runtime so deployments can override it with
+ * environment variables.
+ */
+export const getApiBaseUrl = (): string =>
+  process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
 
 export const API_CONFIG = {
-  BASE_URL: `${API_BASE_URL}${API_VERSION}`,
+  get BASE_URL(): string {
+    return `${getApiBaseUrl()}${API_VERSION}`;
+  },
   ENDPOINTS: {
-    PROJECTS: "/projects/",
-    TASKS: "/tasks/", // This might need adjustment for nested structure
-    AGENTS: "/agents",
-    USERS: "/users",
-    AUTH: "/auth",
-    AUDIT_LOGS: "/audit-logs",
-    COMMENTS: "/comments",
-    MEMORY: "/memory",
-    RULES: "/rules",
-    MCP_TOOLS: "/mcp-tools",
+    PROJECTS: '/projects/',
+    TASKS: '/tasks/', // This might need adjustment for nested structure
+    AGENTS: '/agents',
+    USERS: '/users',
+    AUTH: '/auth',
+    AUDIT_LOGS: '/audit-logs',
+    COMMENTS: '/comments',
+    MEMORY: '/memory',
+    RULES: '/rules',
+    MCP_TOOLS: '/mcp-tools',
   },
 } as const;
 
 /**
  * Helper function to build API URLs
  */
-export const buildApiUrl = (endpoint: string, path: string = ""): string => {
+export const buildApiUrl = (endpoint: string, path: string = ''): string => {
   return `${API_CONFIG.BASE_URL}${endpoint}${path}`;
 };


### PR DESCRIPTION
## Summary
- read `NEXT_PUBLIC_API_BASE_URL` at runtime via getter
- note API URL in `.env.local.example`

## Testing
- `npx eslint src/services/api/config.ts --ext .ts --config ./eslint.config.cjs --no-warn-ignored`
- `npx prettier --check src/services/api/config.ts`
- `./backend/.venv/bin/pytest tests/test_simple.py -q`
- `npm test -- --run` *(fails: observer.observe is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6840f1052068832c8229d9cbcc02c15b