### PR TITLE
Add logout route with test

### DIFF
--- a/frontend/src/__tests__/integration/logout.test.tsx
+++ b/frontend/src/__tests__/integration/logout.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, waitFor } from '@/__tests__/utils/test-utils'
+import { useAuthStore } from '@/store/authStore'
+import LogoutPage from '@/app/logout/page'
+
+const pushMock = vi.fn()
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+}))
+
+describe('LogoutPage', () => {
+  beforeEach(() => {
+    pushMock.mockReset()
+    useAuthStore.setState({
+      token: 'abc',
+      logout: useAuthStore.getState().logout,
+    } as any)
+    localStorage.setItem('token', 'abc')
+  })
+
+  it('clears token and redirects to login', async () => {
+    render(<LogoutPage />)
+
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith('/login'))
+    expect(localStorage.getItem('token')).toBeNull()
+    expect(useAuthStore.getState().token).toBeNull()
+  })
+})

--- a/frontend/src/app/logout/page.tsx
+++ b/frontend/src/app/logout/page.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuthStore } from '@/store/authStore'
+
+export default function LogoutPage() {
+  const router = useRouter()
+  const logout = useAuthStore((state) => state.logout)
+
+  useEffect(() => {
+    logout()
+    router.push('/login')
+  }, [logout, router])
+
+  return null
+}


### PR DESCRIPTION
## Summary
- add logout page that clears auth token and redirects to `/login`
- verify logout clears token in integration test

## Testing
- `npm run lint`
- `npx vitest run src/__tests__/integration/logout.test.tsx --reporter=basic`

------
https://chatgpt.com/codex/tasks/task_e_6840f103595c832ca78bd319f594a428