### PR TITLE
Add health endpoint test

### DIFF
--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,30 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from backend.app_factory import create_app
+from backend.database import get_db, SessionLocal
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint(async_db_session):
+    app = create_app()
+
+    async def override_get_db():
+        db = SessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.get("/health")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "healthy"
+    assert data["database"] == "connected"


### PR DESCRIPTION
## Summary
- add pytest for `/health` endpoint
- test uses app factory and overrides DB with sync session

## Testing
- `flake8 tests/test_health.py`
- `pytest tests/test_health.py -q`
- `npm run lint`
- `npm run test:coverage` *(fails: TypeScript test and integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_6840f1023a90832caf58245ecf645269