### PR TITLE
Add update-readmes pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,9 @@ repos:
         pass_filenames: false
         files: ^frontend/
         types: [javascript, jsx, ts, tsx, json, css, markdown]
+
+      - id: update-readmes
+        name: Update README file lists
+        entry: npm run update-readmes
+        language: system
+        pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,7 @@ pre-commit install
 
 * **Backend**: `flake8` runs on Python files
 * **Frontend**: `npm run lint` and `npm run type-check` run on JS/TS files (the type check can also be triggered from the repo root with `npm run type-check`)
+* **Docs**: `npm run update-readmes` keeps README file lists in sync
 
 These checks will automatically run on every commit.
 
@@ -48,13 +49,13 @@ These checks will automatically run on every commit.
 
 ## 📝 Before Committing Documentation Changes
 
-Run the README update script to refresh file lists:
+Pre-commit automatically runs the README update script. You can also run it manually if needed:
 
 ```bash
 npm run update-readmes
 ```
 
-This ensures all `README.md` files reflect up-to-date directory contents.
+This refreshes all README file lists.
 
 ---
 


### PR DESCRIPTION
## Summary
- run `npm run update-readmes` via pre-commit
- note automatic README updates in contribution guide

## Testing
- `npm run lint --prefix frontend`
- `pytest` *(fails)*
- `npm test --prefix frontend` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_6840f0fd309c832c8670bee894269b8f