### PR TITLE
Add MCP server entrypoint

### DIFF
--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -1,0 +1,11 @@
+from .app_factory import create_app
+import uvicorn
+
+
+def main() -> None:
+    app = create_app()
+    uvicorn.run(app, host="0.0.0.0", port=8000)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `backend/mcp_server.py` for running the API with MCP enabled

## Testing
- `flake8 backend/mcp_server.py`
- `pytest -q` *(fails: AttributeError in tests/test_memory_ingestion.py)*

------
https://chatgpt.com/codex/tasks/task_e_6840f101235c832caf4139b5a94002f3