### PR TITLE
Implement rule creation tools

### DIFF
--- a/backend/mcp_tools/rule_tools.py
+++ b/backend/mcp_tools/rule_tools.py
@@ -1,0 +1,55 @@
+import logging
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from backend.services.rules_service import RulesService
+from backend.schemas import AgentRuleCreate
+from backend.schemas.universal_mandate import UniversalMandateCreate
+
+logger = logging.getLogger(__name__)
+
+
+def create_universal_mandate_tool(
+    mandate_data: UniversalMandateCreate,
+    db: Session,
+) -> dict:
+    """Create a universal mandate via MCP."""
+    try:
+        service = RulesService(db)
+        mandate = service.create_universal_mandate(mandate_data)
+        return {
+            "success": True,
+            "mandate": {
+                "id": mandate.id,
+                "title": mandate.title,
+                "description": mandate.description,
+                "priority": mandate.priority,
+                "is_active": mandate.is_active,
+            },
+        }
+    except Exception as exc:
+        logger.error(f"MCP create mandate failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+def create_agent_rule_tool(
+    rule_data: AgentRuleCreate,
+    db: Session,
+) -> dict:
+    """Create an agent rule via MCP."""
+    try:
+        service = RulesService(db)
+        rule = service.create_agent_rule(rule_data)
+        return {
+            "success": True,
+            "agent_rule": {
+                "id": rule.id,
+                "agent_id": rule.agent_id,
+                "rule_type": rule.rule_type,
+                "rule_content": rule.rule_content,
+                "is_active": rule.is_active,
+            },
+        }
+    except Exception as exc:
+        logger.error(f"MCP create agent rule failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/frontend/src/services/api/mcp.ts
+++ b/frontend/src/services/api/mcp.ts
@@ -1,5 +1,5 @@
-import { request } from "./request";
-import { buildApiUrl, API_CONFIG } from "./config";
+import { request } from './request';
+import { buildApiUrl, API_CONFIG } from './config';
 import type {
   MCPToolResponse,
   MCPProjectCreateRequest,
@@ -18,16 +18,16 @@ import type {
   MCPProjectFileAddRequest,
   MCPProjectFileRemoveRequest,
   MCPToolInfo,
-} from "@/types/mcp";
+} from '@/types/mcp';
 
 export const mcpApi = {
   // --- Project MCP Tools ---
   project: {
     create: async (data: MCPProjectCreateRequest): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/project/create"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/project/create'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -35,9 +35,9 @@ export const mcpApi = {
 
     update: async (data: MCPProjectUpdateRequest): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/project/update"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/project/update'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -45,9 +45,9 @@ export const mcpApi = {
 
     delete: async (data: MCPProjectDeleteRequest): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/project/delete"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/project/delete'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -58,9 +58,9 @@ export const mcpApi = {
   task: {
     create: async (data: MCPTaskCreateRequest): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/task/create"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/task/create'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -68,9 +68,9 @@ export const mcpApi = {
 
     update: async (data: MCPTaskUpdateRequest): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/task/update"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/task/update'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -78,20 +78,26 @@ export const mcpApi = {
 
     delete: async (data: MCPTaskDeleteRequest): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/task/delete"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/task/delete'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
     },
 
-    complete: async (projectId: string, taskNumber: number): Promise<MCPToolResponse> => {
+    complete: async (
+      projectId: string,
+      taskNumber: number
+    ): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/task/complete"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/task/complete'),
         {
-          method: "POST",
-          body: JSON.stringify({ project_id: projectId, task_number: taskNumber }),
+          method: 'POST',
+          body: JSON.stringify({
+            project_id: projectId,
+            task_number: taskNumber,
+          }),
         }
       );
     },
@@ -102,9 +108,9 @@ export const mcpApi = {
       content: string
     ): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/task/comment"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/task/comment'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify({
             project_id: projectId,
             task_number: taskNumber,
@@ -121,9 +127,9 @@ export const mcpApi = {
       data: MCPMemoryCreateEntityRequest
     ): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/memory/entity/create"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/memory/entity/create'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -132,9 +138,12 @@ export const mcpApi = {
       data: MCPMemoryCreateObservationRequest
     ): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/memory/observation/create"),
+        buildApiUrl(
+          API_CONFIG.ENDPOINTS.MCP_TOOLS,
+          '/memory/observation/create'
+        ),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -144,9 +153,9 @@ export const mcpApi = {
       data: MCPMemoryCreateRelationRequest
     ): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/memory/relation/create"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/memory/relation/create'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -156,9 +165,9 @@ export const mcpApi = {
       data: MCPMemoryGetContentRequest
     ): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/memory/get-content"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/memory/get-content'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -168,9 +177,9 @@ export const mcpApi = {
       data: MCPMemoryGetMetadataRequest
     ): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/memory/get-metadata"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/memory/get-metadata'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -178,20 +187,21 @@ export const mcpApi = {
 
     search: async (query: string): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, `/memory/search?q=${encodeURIComponent(query)}`)
+        buildApiUrl(
+          API_CONFIG.ENDPOINTS.MCP_TOOLS,
+          `/memory/search?q=${encodeURIComponent(query)}`
+        )
       );
     },
   },
 
   // --- Project Member MCP Tools ---
   projectMember: {
-    add: async (
-      data: MCPProjectMemberAddRequest
-    ): Promise<MCPToolResponse> => {
+    add: async (data: MCPProjectMemberAddRequest): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/project/member/add"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/project/member/add'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -201,9 +211,9 @@ export const mcpApi = {
       data: MCPProjectMemberRemoveRequest
     ): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/project/member/remove"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/project/member/remove'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -214,9 +224,9 @@ export const mcpApi = {
   projectFile: {
     add: async (data: MCPProjectFileAddRequest): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/project/file/add"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/project/file/add'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -226,9 +236,9 @@ export const mcpApi = {
       data: MCPProjectFileRemoveRequest
     ): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/project/file/remove"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/project/file/remove'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -239,14 +249,14 @@ export const mcpApi = {
   rule: {
     createMandate: async (data: {
       title: string;
-      content: string;
+      description: string;
       priority?: number;
-      category?: string;
+      is_active?: boolean;
     }): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/rule/mandate/create"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/rule/mandate/create'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -256,11 +266,12 @@ export const mcpApi = {
       agent_id: string;
       rule_type: string;
       rule_content: string;
+      is_active?: boolean;
     }): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/rule/agent/create"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/rule/agent/create'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -271,7 +282,7 @@ export const mcpApi = {
   tools: {
     list: async (): Promise<MCPToolInfo[]> => {
       const response = await request<{ tools: MCPToolInfo[] }>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/list")
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/list')
       );
       return response.tools;
     },


### PR DESCRIPTION
## Summary
- extend MCP router with rule creation endpoints
- add rule MCP tool wrappers
- update MCP API module for mandate and agent rule creation

## Testing
- `flake8 routers/mcp/core.py ../backend/mcp_tools/rule_tools.py`
- `pytest` *(fails: ModuleNotFoundError)*
- `npm --prefix frontend test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f0e4b1cc832c89bb3bccffa67653