### PR TITLE
Add project file management

### DIFF
--- a/frontend/src/components/project/ProjectFiles.tsx
+++ b/frontend/src/components/project/ProjectFiles.tsx
@@ -1,20 +1,26 @@
-"use client";
+'use client';
 
 import React, { useEffect, useState } from 'react';
-import { getProjectFiles, disassociateFileFromProject, ProjectFileAssociation } from '@/services/api/projects';
+import { Box, Button, Input, List, ListItem, useToast } from '@chakra-ui/react';
+import { mcpApi, memoryApi } from '@/services/api';
+import type { ProjectFileAssociation } from '@/services/api/projects';
 
 interface ProjectFilesProps {
   projectId: string;
 }
 
 const ProjectFiles: React.FC<ProjectFilesProps> = ({ projectId }) => {
+  const toast = useToast();
   const [files, setFiles] = useState<ProjectFileAssociation[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [filePath, setFilePath] = useState('');
+  const [uploading, setUploading] = useState(false);
 
   const fetchFiles = async () => {
+    setLoading(true);
     try {
-      const data = await getProjectFiles(projectId);
+      const data = await mcpApi.projectFile.list(projectId);
       setFiles(data);
     } catch (err) {
       setError('Failed to fetch project files');
@@ -28,13 +34,52 @@ const ProjectFiles: React.FC<ProjectFilesProps> = ({ projectId }) => {
     fetchFiles();
   }, [projectId]);
 
-  const handleDisassociateFile = async (fileId: string) => {
+  const handleUpload = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!filePath) return;
+    setUploading(true);
     try {
-      await disassociateFileFromProject(projectId, fileId);
-      fetchFiles(); // Refresh the list
+      const entity = await memoryApi.ingestFile(filePath);
+      await mcpApi.projectFile.add({
+        project_id: projectId,
+        file_id: String(entity.id),
+      });
+      setFilePath('');
+      toast({
+        title: 'File uploaded',
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+      });
+      fetchFiles();
     } catch (err) {
-      alert('Failed to disassociate file');
       console.error(err);
+      toast({
+        title: 'Upload failed',
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleRemove = async (fileId: string) => {
+    try {
+      await mcpApi.projectFile.remove({
+        project_id: projectId,
+        file_id: fileId,
+      });
+      fetchFiles();
+    } catch (err) {
+      console.error(err);
+      toast({
+        title: 'Remove failed',
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
     }
   };
 
@@ -47,23 +92,38 @@ const ProjectFiles: React.FC<ProjectFilesProps> = ({ projectId }) => {
   }
 
   return (
-    <div>
+    <Box>
       <h3>Project Files</h3>
-      {
-        files.length === 0 ? (
-          <p>No files associated.</p>
-        ) : (
-          <ul>
-            {files.map((file) => (
-              <li key={file.file_id}>
-                {file.file_id}
-                <button onClick={() => handleDisassociateFile(file.file_id)}>Disassociate</button>
-              </li>
-            ))}
-          </ul>
-        )
-      }
-    </div>
+      {files.length === 0 ? (
+        <p>No files associated.</p>
+      ) : (
+        <List>
+          {files.map((file) => (
+            <ListItem
+              key={file.file_id}
+              display="flex"
+              gap={2}
+              alignItems="center"
+            >
+              <span>{file.file_id}</span>
+              <Button size="xs" onClick={() => handleRemove(file.file_id)}>
+                Delete
+              </Button>
+            </ListItem>
+          ))}
+        </List>
+      )}
+      <form onSubmit={handleUpload} style={{ marginTop: '1rem' }}>
+        <Input
+          value={filePath}
+          onChange={(e) => setFilePath(e.target.value)}
+          placeholder="/path/to/file.txt"
+        />
+        <Button type="submit" mt={2} isLoading={uploading}>
+          Upload
+        </Button>
+      </form>
+    </Box>
   );
 };
 

--- a/frontend/src/components/project/__tests__/ProjectFiles.test.tsx
+++ b/frontend/src/components/project/__tests__/ProjectFiles.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor } from '@testing-library/react';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import ProjectFiles from '../ProjectFiles';
 
@@ -9,60 +9,79 @@ vi.mock('@chakra-ui/react', async () => {
   return {
     ...actual,
     useToast: () => vi.fn(),
-    useColorModeValue: (light: any, dark: any) => light,
+    useColorModeValue: (l: any, d: any) => l,
   };
 });
+
+vi.mock('@/services/api', () => ({
+  mcpApi: {
+    projectFile: {
+      list: vi.fn(),
+      add: vi.fn(),
+      remove: vi.fn(),
+    },
+  },
+  memoryApi: {
+    ingestFile: vi.fn(),
+  },
+}));
+
+const { mcpApi, memoryApi } = await import('@/services/api');
 
 describe('ProjectFiles', () => {
   const user = userEvent.setup();
 
   beforeEach(() => {
     vi.clearAllMocks();
+    (mcpApi.projectFile.list as any).mockResolvedValue([]);
   });
 
-  it('should render without crashing', () => {
+  it('refreshes list after upload', async () => {
+    (memoryApi.ingestFile as any).mockResolvedValue({ id: 1 });
     render(
       <TestWrapper>
-        <ProjectFiles />
+        <ProjectFiles projectId="p1" />
       </TestWrapper>
     );
-    expect(document.body).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mcpApi.projectFile.list).toHaveBeenCalledTimes(1)
+    );
+    const input = screen.getByPlaceholderText('/path/to/file.txt');
+    await user.type(input, '/tmp/file.txt');
+    await user.click(screen.getByRole('button', { name: /upload/i }));
+    await waitFor(() => expect(memoryApi.ingestFile).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(mcpApi.projectFile.add).toHaveBeenCalledWith({
+        project_id: 'p1',
+        file_id: '1',
+      })
+    );
+    await waitFor(() =>
+      expect(mcpApi.projectFile.list).toHaveBeenCalledTimes(2)
+    );
   });
 
-  it('should handle props correctly', () => {
-    const props = { 
-      testId: 'test-component',
-      'data-testid': 'test-component'
-    };
-    
+  it('refreshes list after deletion', async () => {
+    (mcpApi.projectFile.list as any)
+      .mockResolvedValueOnce([{ project_id: 'p1', file_id: '1' }])
+      .mockResolvedValueOnce([]);
     render(
       <TestWrapper>
-        <ProjectFiles {...props} />
+        <ProjectFiles projectId="p1" />
       </TestWrapper>
     );
-    
-    const component = screen.queryByTestId('test-component');
-    expect(component || document.body).toBeInTheDocument();
-  });
-
-  it('should handle user interactions', async () => {
-    render(
-      <TestWrapper>
-        <ProjectFiles />
-      </TestWrapper>
+    await waitFor(() =>
+      expect(mcpApi.projectFile.list).toHaveBeenCalledTimes(1)
     );
-    
-    const buttons = screen.queryAllByRole('button');
-    const inputs = screen.queryAllByRole('textbox');
-    
-    if (buttons.length > 0) {
-      await user.click(buttons[0]);
-    }
-    
-    if (inputs.length > 0) {
-      await user.type(inputs[0], 'test input');
-    }
-    
-    expect(document.body).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /delete/i }));
+    await waitFor(() =>
+      expect(mcpApi.projectFile.remove).toHaveBeenCalledWith({
+        project_id: 'p1',
+        file_id: '1',
+      })
+    );
+    await waitFor(() =>
+      expect(mcpApi.projectFile.list).toHaveBeenCalledTimes(2)
+    );
   });
 });

--- a/frontend/src/services/api/mcp.ts
+++ b/frontend/src/services/api/mcp.ts
@@ -1,5 +1,5 @@
-import { request } from "./request";
-import { buildApiUrl, API_CONFIG } from "./config";
+import { request } from './request';
+import { buildApiUrl, API_CONFIG } from './config';
 import type {
   MCPToolResponse,
   MCPProjectCreateRequest,
@@ -18,16 +18,17 @@ import type {
   MCPProjectFileAddRequest,
   MCPProjectFileRemoveRequest,
   MCPToolInfo,
-} from "@/types/mcp";
+} from '@/types/mcp';
+import type { ProjectFileAssociation } from './projects';
 
 export const mcpApi = {
   // --- Project MCP Tools ---
   project: {
     create: async (data: MCPProjectCreateRequest): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/project/create"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/project/create'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -35,9 +36,9 @@ export const mcpApi = {
 
     update: async (data: MCPProjectUpdateRequest): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/project/update"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/project/update'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -45,9 +46,9 @@ export const mcpApi = {
 
     delete: async (data: MCPProjectDeleteRequest): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/project/delete"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/project/delete'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -58,9 +59,9 @@ export const mcpApi = {
   task: {
     create: async (data: MCPTaskCreateRequest): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/task/create"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/task/create'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -68,9 +69,9 @@ export const mcpApi = {
 
     update: async (data: MCPTaskUpdateRequest): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/task/update"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/task/update'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -78,20 +79,26 @@ export const mcpApi = {
 
     delete: async (data: MCPTaskDeleteRequest): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/task/delete"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/task/delete'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
     },
 
-    complete: async (projectId: string, taskNumber: number): Promise<MCPToolResponse> => {
+    complete: async (
+      projectId: string,
+      taskNumber: number
+    ): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/task/complete"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/task/complete'),
         {
-          method: "POST",
-          body: JSON.stringify({ project_id: projectId, task_number: taskNumber }),
+          method: 'POST',
+          body: JSON.stringify({
+            project_id: projectId,
+            task_number: taskNumber,
+          }),
         }
       );
     },
@@ -102,9 +109,9 @@ export const mcpApi = {
       content: string
     ): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/task/comment"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/task/comment'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify({
             project_id: projectId,
             task_number: taskNumber,
@@ -121,9 +128,9 @@ export const mcpApi = {
       data: MCPMemoryCreateEntityRequest
     ): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/memory/entity/create"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/memory/entity/create'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -132,9 +139,12 @@ export const mcpApi = {
       data: MCPMemoryCreateObservationRequest
     ): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/memory/observation/create"),
+        buildApiUrl(
+          API_CONFIG.ENDPOINTS.MCP_TOOLS,
+          '/memory/observation/create'
+        ),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -144,9 +154,9 @@ export const mcpApi = {
       data: MCPMemoryCreateRelationRequest
     ): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/memory/relation/create"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/memory/relation/create'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -156,9 +166,9 @@ export const mcpApi = {
       data: MCPMemoryGetContentRequest
     ): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/memory/get-content"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/memory/get-content'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -168,9 +178,9 @@ export const mcpApi = {
       data: MCPMemoryGetMetadataRequest
     ): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/memory/get-metadata"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/memory/get-metadata'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -178,20 +188,21 @@ export const mcpApi = {
 
     search: async (query: string): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, `/memory/search?q=${encodeURIComponent(query)}`)
+        buildApiUrl(
+          API_CONFIG.ENDPOINTS.MCP_TOOLS,
+          `/memory/search?q=${encodeURIComponent(query)}`
+        )
       );
     },
   },
 
   // --- Project Member MCP Tools ---
   projectMember: {
-    add: async (
-      data: MCPProjectMemberAddRequest
-    ): Promise<MCPToolResponse> => {
+    add: async (data: MCPProjectMemberAddRequest): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/project/member/add"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/project/member/add'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -201,9 +212,9 @@ export const mcpApi = {
       data: MCPProjectMemberRemoveRequest
     ): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/project/member/remove"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/project/member/remove'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -214,21 +225,44 @@ export const mcpApi = {
   projectFile: {
     add: async (data: MCPProjectFileAddRequest): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/project/file/add"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/project/file/add'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
+    },
+
+    list: async (
+      projectId: string,
+      skip = 0,
+      limit = 100
+    ): Promise<ProjectFileAssociation[]> => {
+      const params = new URLSearchParams();
+      params.append('project_id', projectId);
+      params.append('skip', String(skip));
+      params.append('limit', String(limit));
+      const response = await request<{
+        files: { project_id: string; file_memory_entity_id: number }[];
+      }>(
+        buildApiUrl(
+          API_CONFIG.ENDPOINTS.MCP_TOOLS,
+          `/project/file/list?${params.toString()}`
+        )
+      );
+      return response.files.map((f) => ({
+        project_id: f.project_id,
+        file_id: String(f.file_memory_entity_id),
+      }));
     },
 
     remove: async (
       data: MCPProjectFileRemoveRequest
     ): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/project/file/remove"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/project/file/remove'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -244,9 +278,9 @@ export const mcpApi = {
       category?: string;
     }): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/rule/mandate/create"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/rule/mandate/create'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -258,9 +292,9 @@ export const mcpApi = {
       rule_content: string;
     }): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/rule/agent/create"),
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/rule/agent/create'),
         {
-          method: "POST",
+          method: 'POST',
           body: JSON.stringify(data),
         }
       );
@@ -271,7 +305,7 @@ export const mcpApi = {
   tools: {
     list: async (): Promise<MCPToolInfo[]> => {
       const response = await request<{ tools: MCPToolInfo[] }>(
-        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, "/list")
+        buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/list')
       );
       return response.tools;
     },


### PR DESCRIPTION
## Summary
- enable frontend use of project_file_tools API
- show project files with upload via memory ingestion
- refresh file list after upload or deletion

## Testing
- `npm run lint`
- `npm run test:coverage` *(fails: TypeError, ts errors)*

------
https://chatgpt.com/codex/tasks/task_e_6840f0f76c18832c8d7ce76142cab5ab