### PR TITLE
Add task status enums endpoint

### DIFF
--- a/backend/enums.py
+++ b/backend/enums.py
@@ -1,6 +1,11 @@
 import enum
 
-__all__ = ["TaskStatusEnum", "UserRoleEnum", "ActionType"]
+from typing import List
+from fastapi import APIRouter
+
+
+__all__ = ["TaskStatusEnum", "UserRoleEnum", "ActionType", "router"]
+
 
 class TaskStatusEnum(enum.Enum):
     """Enum for standardized task statuses."""
@@ -22,6 +27,7 @@ class TaskStatusEnum(enum.Enum):
     IN_PROGRESS_AWAITING_SUBTASK = "In Progress Awaiting Subtask"
     PENDING_RECOVERY_ATTEMPT = "Pending Recovery Attempt"
 
+
 class UserRoleEnum(enum.Enum):
     """Enum for user roles."""
     ADMIN = "admin"
@@ -30,6 +36,7 @@ class UserRoleEnum(enum.Enum):
     VIEWER = "viewer"
     USER = "user"
     AGENT = "agent"  # For AI agents if they have user accounts
+
 
 class ActionType(enum.Enum):
     """Enum for audit log action types."""
@@ -41,3 +48,12 @@ class ActionType(enum.Enum):
     LOGOUT = "logout"
     ASSIGN = "assign"
     COMPLETE = "complete"
+
+
+router = APIRouter(prefix="/task-status")
+
+
+@router.get("/", response_model=List[str], summary="Get all task statuses")
+async def get_task_statuses() -> List[str]:
+    """Return all task status values."""
+    return [status.value for status in TaskStatusEnum]

--- a/backend/main.py
+++ b/backend/main.py
@@ -48,6 +48,7 @@ def include_app_routers(app: FastAPI):
     )
     from .routers.admin import router as admin_router
     from .routers.users.auth.auth import router as auth_router
+    from .enums import router as enums_router
 
     app.include_router(users.router, prefix="/api/v1/users", tags=["users"])
     app.include_router(admin_router, prefix="/api/v1", tags=["admin"])
@@ -65,6 +66,7 @@ def include_app_routers(app: FastAPI):
         tags=["templates"],
     )
     app.include_router(audit_logs.router, prefix="/api/audit-logs", tags=["audit-logs"])
+    app.include_router(enums_router, prefix="/api/enums", tags=["enums"])
 
 
 @asynccontextmanager

--- a/backend/tests/test_enums_endpoint.py
+++ b/backend/tests/test_enums_endpoint.py
@@ -1,0 +1,20 @@
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient, ASGITransport
+
+from backend.enums import router as enums_router
+
+app = FastAPI()
+app.include_router(enums_router, prefix="/api/enums")
+
+
+@pytest.mark.asyncio
+async def test_get_task_statuses():
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/enums/task-status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert "To Do" in data

--- a/frontend/src/components/BulkActionsBar.tsx
+++ b/frontend/src/components/BulkActionsBar.tsx
@@ -14,6 +14,8 @@ import {
 } from "@chakra-ui/react";
 import { ChevronDownIcon, DeleteIcon } from "@chakra-ui/icons";
 import * as statusUtils from "@/lib/statusUtils";
+import { getTaskStatuses } from "@/services/api";
+import type { StatusID } from "@/lib/statusUtils";
 import AppIcon from "./common/AppIcon";
 import { typography } from "../tokens";
 
@@ -36,11 +38,21 @@ const BulkActionsBar: React.FC<BulkActionsBarProps> = ({
   bulkSetStatusTasks,
   loading = false,
 }) => {
-  const availableStatuses = React.useMemo(() => {
-    return statusUtils.getAllStatusIds().filter((id) => {
-      const attrs = statusUtils.getStatusAttributes(id);
-      return !attrs?.isTerminal && !attrs?.isDynamic;
-    });
+  const [availableStatuses, setAvailableStatuses] = React.useState<StatusID[]>([]);
+
+  React.useEffect(() => {
+    getTaskStatuses()
+      .then((statuses) => {
+        setAvailableStatuses(
+          statuses.filter((id) => {
+            const attrs = statusUtils.getStatusAttributes(id as StatusID);
+            return !attrs?.isTerminal && !attrs?.isDynamic;
+          }) as StatusID[]
+        );
+      })
+      .catch(() => {
+        setAvailableStatuses([]);
+      });
   }, []);
 
   if (selectedTaskIds.length === 0 && allFilterableTaskIds.length === 0) {

--- a/frontend/src/components/TaskControls.tsx
+++ b/frontend/src/components/TaskControls.tsx
@@ -19,6 +19,7 @@ import { ChevronDownIcon, DeleteIcon } from "@chakra-ui/icons";
 import { GroupByType, ViewMode } from "@/types";
 import { TaskStatus } from "@/types/task";
 import * as statusUtils from "@/lib/statusUtils";
+import { getTaskStatuses } from "@/services/api";
 import { useTaskStore } from "@/store/taskStore";
 
 import ConfirmationModal from "./common/ConfirmationModal";
@@ -41,14 +42,16 @@ interface TaskControlsProps {
 }
 
 // List of statuses a user can apply to multiple tasks at once.
-// Using enum values ensures type safety across the codebase.
-const availableStatusesForBulkUpdate: TaskStatus[] = [
-  TaskStatus.TO_DO,
-  TaskStatus.IN_PROGRESS,
-  TaskStatus.COMPLETED,
-  TaskStatus.BLOCKED,
-  TaskStatus.CANCELLED,
-];
+// Populated from backend enums at runtime.
+const useAvailableStatuses = (): TaskStatus[] => {
+  const [statuses, setStatuses] = React.useState<TaskStatus[]>([]);
+  React.useEffect(() => {
+    getTaskStatuses()
+      .then((vals) => setStatuses(vals as TaskStatus[]))
+      .catch(() => setStatuses([]));
+  }, []);
+  return statuses;
+};
 
 const TaskControls: React.FC<TaskControlsProps> = ({
   groupBy,
@@ -67,6 +70,7 @@ const TaskControls: React.FC<TaskControlsProps> = ({
   const bulkDeleteTasks = useTaskStore((s) => s.bulkDeleteTasks);
   const bulkSetStatusTasks = useTaskStore((s) => s.bulkSetStatusTasks);
   const taskStoreLoading = useTaskStore((s) => s.loading);
+  const availableStatusesForBulkUpdate = useAvailableStatuses();
 
   const {
     isOpen: isDeleteConfirmOpen,

--- a/frontend/src/services/api/config.ts
+++ b/frontend/src/services/api/config.ts
@@ -18,6 +18,7 @@ export const API_CONFIG = {
     MEMORY: "/memory",
     RULES: "/rules",
     MCP_TOOLS: "/mcp-tools",
+    ENUMS: "/enums",
   },
 } as const;
 

--- a/frontend/src/services/api/enumApi.ts
+++ b/frontend/src/services/api/enumApi.ts
@@ -1,0 +1,13 @@
+import { request } from "./request";
+import { buildApiUrl, API_CONFIG } from "./config";
+
+let cachedStatuses: string[] | null = null;
+
+export const getTaskStatuses = async (): Promise<string[]> => {
+  if (cachedStatuses) return cachedStatuses;
+  const statuses = await request<string[]>(
+    buildApiUrl(API_CONFIG.ENDPOINTS.ENUMS, "/task-status")
+  );
+  cachedStatuses = statuses;
+  return statuses;
+};

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -10,3 +10,4 @@ export * from "./rules";
 export * from "./mcp";
 export * from "./users";
 export * from "./audit_logs";
+export * from "./enumApi";

--- a/frontend/src/store/taskStore.ts
+++ b/frontend/src/store/taskStore.ts
@@ -472,6 +472,14 @@ export const useTaskStore = create<TaskState>(
     const { selectedTaskIds, tasks } = get();
     if (selectedTaskIds.length === 0) return;
 
+    const validStatuses = await api.getTaskStatuses().catch(() => []);
+    if (!validStatuses.includes(status as string)) {
+      set({
+        mutationError: { type: "bulk", message: "Invalid status selected" },
+      });
+      return;
+    }
+
     const originalTasks: Task[] = [];
     selectedTaskIds.forEach((id: string) => {
       const [project_id, task_number] = id.split('-');


### PR DESCRIPTION
## Summary
- expose `/api/enums/task-status` endpoint
- fetch task status enums on the frontend
- populate dropdowns and validate transitions using fetched enums
- add basic endpoint test

## Testing
- `python3 -m flake8 enums.py`
- `python3 -m flake8 tests/test_enums_endpoint.py`
- `pytest -q`
- `npm run lint`
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_6840f0d47628832ca0735c2544470a9a