### PR TITLE
Add basic MCP tool commands to CLI

### DIFF
--- a/DEV_SCRIPTS.md
+++ b/DEV_SCRIPTS.md
@@ -5,6 +5,7 @@ located in the project root and provide different ways to launch the backend and
 frontend or manage the full stack.
 
 ## `dev_launcher.js`
+
 - **Purpose:** Cross‑platform Node.js launcher.
 - **What it does:**
   - Kills any processes on ports **8000** and **3000**.
@@ -17,6 +18,7 @@ frontend or manage the full stack.
   ```
 
 ## `run_backend.py`
+
 - **Purpose:** Launch only the backend API.
 - **What it does:**
   - Verifies that `backend/.venv` exists.
@@ -28,6 +30,7 @@ frontend or manage the full stack.
   ```
 
 ## `start_system.py`
+
 - **Purpose:** Set up and start the entire development system.
 - **What it does:**
   - Checks the project structure for `backend/` and `frontend/`.
@@ -42,3 +45,15 @@ frontend or manage the full stack.
 
 These scripts simplify local development by automating common setup and startup
 steps. See `DEV_LAUNCHER_GUIDE.md` for more launcher details.
+
+## `cli.js`
+
+- **Purpose:** Primary command line interface.
+- **Additional Commands:**
+  - `mcp list-tools` – Display available MCP tools.
+  - `mcp run-tool <name> [jsonArgs]` – Execute a tool with optional JSON parameters.
+- **Usage Examples:**
+  ```bash
+  node cli.js list-tools
+  node cli.js run-tool create_project_tool '{"name":"demo","description":"test"}'
+  ```

--- a/cli.js
+++ b/cli.js
@@ -2,9 +2,68 @@
 
 const [major] = process.versions.node.split('.').map(Number);
 if (major < 18) {
-  console.error(`Node.js 18 or higher is required. Current version: ${process.version}`);
+  console.error(
+    `Node.js 18 or higher is required. Current version: ${process.version}`
+  );
   process.exit(1);
 }
 
-require('./dev_launcher.js');
+const API_BASE_URL =
+  process.env.MCP_API_BASE_URL || 'http://localhost:8000/api';
 
+async function listTools() {
+  try {
+    const res = await fetch(`${API_BASE_URL}/mcp-tools/list`);
+    const data = await res.json();
+    if (Array.isArray(data.tools)) {
+      console.log('Available MCP tools:');
+      for (const tool of data.tools) {
+        console.log(`- ${tool.name}: ${tool.description}`);
+      }
+    } else {
+      console.log('No tools found.');
+    }
+  } catch (err) {
+    console.error('Failed to list tools:', err.message);
+  }
+}
+
+async function runTool(name, argsJson = '{}') {
+  if (!name) {
+    console.error('Tool name required.');
+    return;
+  }
+  let args = {};
+  try {
+    args = JSON.parse(argsJson);
+  } catch {
+    console.error('Invalid JSON for tool arguments.');
+    return;
+  }
+  try {
+    const infoRes = await fetch(`${API_BASE_URL}/mcp-tools/info/${name}`);
+    const info = await infoRes.json();
+    const path = info.path || `/mcp-tools/${name}`;
+    const method = (info.method || 'POST').toUpperCase();
+    const fetchOpts = {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+    };
+    if (method !== 'GET') fetchOpts.body = JSON.stringify(args);
+    const res = await fetch(`${API_BASE_URL}${path}`, fetchOpts);
+    const data = await res.json();
+    console.log(JSON.stringify(data, null, 2));
+  } catch (err) {
+    console.error('Failed to run tool:', err.message);
+  }
+}
+
+const [, , command, arg1, arg2] = process.argv;
+
+if (command === 'list-tools') {
+  listTools();
+} else if (command === 'run-tool') {
+  runTool(arg1, arg2);
+} else {
+  require('./dev_launcher.js');
+}


### PR DESCRIPTION
## Summary
- expose `list-tools` and `run-tool` commands in `cli.js`
- document new CLI usage in `DEV_SCRIPTS.md`

## Testing
- `npx prettier -w cli.js DEV_SCRIPTS.md`

------
https://chatgpt.com/codex/tasks/task_e_6840f0d043ec832cb6b73e01a674b13e