### PR TITLE
Add memory detail route

### DIFF
--- a/frontend/src/__tests__/integration/memoryPages.test.tsx
+++ b/frontend/src/__tests__/integration/memoryPages.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@/__tests__/utils/test-utils';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__tests__/mocks/server';
+import MemoryDetailPage from '@/app/memory/[id]/page';
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ id: '1' }),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+describe('Memory detail page', () => {
+  it('renders content and metadata', async () => {
+    server.use(
+      http.get(`${API_BASE_URL}/api/memory/entities/1/content`, () =>
+        HttpResponse.json({ content: 'hello world' })
+      ),
+      http.get(`${API_BASE_URL}/api/memory/entities/1/metadata`, () =>
+        HttpResponse.json({ metadata: { filename: 'sample.txt' } })
+      )
+    );
+
+    render(<MemoryDetailPage />);
+
+    expect(await screen.findByText('hello world')).toBeInTheDocument();
+    expect(screen.getByText('sample.txt')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /download/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/mocks/handlers.ts
+++ b/frontend/src/__tests__/mocks/handlers.ts
@@ -76,4 +76,12 @@ export const handlers = [
     const user = createMockUser({ id: params.userId as string })
     return HttpResponse.json(user)
   }),
+
+  // Memory retrieval endpoints
+  http.get(`${API_BASE_URL}/api/memory/entities/:id/content`, ({ params }) => {
+    return HttpResponse.json({ content: `content for ${params.id}` })
+  }),
+  http.get(`${API_BASE_URL}/api/memory/entities/:id/metadata`, ({ params }) => {
+    return HttpResponse.json({ metadata: { filename: `file-${params.id}.txt` } })
+  }),
 ]

--- a/frontend/src/app/README.md
+++ b/frontend/src/app/README.md
@@ -137,6 +137,7 @@ graph TD
 - `layout.tsx`
 - `page.tsx`
 - `not-found.tsx`
+- `memory/[id]/`
 
 <!-- File List End -->
 

--- a/frontend/src/app/memory/[id]/README.md
+++ b/frontend/src/app/memory/[id]/README.md
@@ -1,0 +1,11 @@
+# Memory Detail Page (`frontend/src/app/memory/[id]`)
+
+This directory contains the page for displaying a single memory entity from the Knowledge Graph. The page retrieves the entity's content and metadata using the MCP memory retrieval APIs and allows downloading the content as a file.
+
+<!-- File List Start -->
+
+## File List
+
+- `page.tsx`
+
+<!-- File List End -->

--- a/frontend/src/app/memory/[id]/page.tsx
+++ b/frontend/src/app/memory/[id]/page.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { Box, Heading, Spinner, Text, Button, VStack } from '@chakra-ui/react';
+import { useParams } from 'next/navigation';
+import { memoryApi } from '@/services/api';
+import type {
+  MemoryMetadataResponse,
+  MemoryContentResponse,
+} from '@/types/memory';
+
+const MemoryDetailPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const [content, setContent] = useState<string>('');
+  const [metadata, setMetadata] = useState<Record<string, any> | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!id) return;
+      try {
+        const contentResp: MemoryContentResponse =
+          await memoryApi.getFileContent(Number(id));
+        const metadataResp: MemoryMetadataResponse =
+          await memoryApi.getFileMetadata(Number(id));
+        setContent(contentResp.content);
+        setMetadata(metadataResp.metadata);
+      } catch (err) {
+        setError('Failed to load memory entity');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [id]);
+
+  const handleDownload = () => {
+    const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `memory-${id}.txt`;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
+  };
+
+  if (loading) return <Spinner />;
+  if (error) return <Text color="red.500">{error}</Text>;
+
+  return (
+    <Box p="4">
+      <Heading size="md" mb="4">
+        Memory {id}
+      </Heading>
+      <VStack align="start" spacing={4}>
+        <Text whiteSpace="pre-wrap">{content}</Text>
+        {metadata && (
+          <Box width="full">
+            <Heading size="sm" mb="2">
+              Metadata
+            </Heading>
+            <pre data-testid="metadata">
+              {JSON.stringify(metadata, null, 2)}
+            </pre>
+          </Box>
+        )}
+        <Button colorScheme="blue" onClick={handleDownload}>
+          Download
+        </Button>
+      </VStack>
+    </Box>
+  );
+};
+
+export default MemoryDetailPage;

--- a/frontend/src/services/api/memory.ts
+++ b/frontend/src/services/api/memory.ts
@@ -13,6 +13,8 @@ import type {
   MemoryRelationCreateData,
   MemoryRelationFilters,
   KnowledgeGraph,
+  MemoryContentResponse,
+  MemoryMetadataResponse,
 } from "@/types/memory";
 
 // --- Memory Entity APIs ---
@@ -75,6 +77,24 @@ export const memoryApi = {
       {
         method: "DELETE",
       }
+    );
+  },
+
+  // Retrieve raw content for a memory entity
+  getFileContent: async (
+    entityId: number,
+  ): Promise<MemoryContentResponse> => {
+    return request<MemoryContentResponse>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/entities/${entityId}/content`)
+    );
+  },
+
+  // Retrieve metadata for a memory entity
+  getFileMetadata: async (
+    entityId: number,
+  ): Promise<MemoryMetadataResponse> => {
+    return request<MemoryMetadataResponse>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/entities/${entityId}/metadata`)
     );
   },
 

--- a/frontend/src/types/memory.ts
+++ b/frontend/src/types/memory.ts
@@ -91,3 +91,11 @@ export interface KnowledgeGraph {
   entities: MemoryEntity[];
   relations: MemoryRelation[];
 }
+
+export interface MemoryContentResponse {
+  content: string;
+}
+
+export interface MemoryMetadataResponse {
+  metadata: Record<string, any>;
+}


### PR DESCRIPTION
## Summary
- fetch single memory entity content and metadata via new APIs
- render details with Chakra UI and download link
- mock retrieval APIs for tests
- add integration test for memory page
- document memory route

## Testing
- `npm run lint`
- `npm test` *(fails: observer.observe is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6840edc8dfa8832c9989dd5272b4b3e8