### PR TITLE
Add agent capability API wrappers

### DIFF
--- a/frontend/src/services/api/agent_capabilities.ts
+++ b/frontend/src/services/api/agent_capabilities.ts
@@ -1,0 +1,69 @@
+import { request } from './request';
+import { buildApiUrl, API_CONFIG } from './config';
+import type { AgentCapability } from '@/types';
+
+/**
+ * API wrapper for managing agent role capabilities.
+ */
+export const agentCapabilitiesApi = {
+  /** Add a capability to an agent role */
+  async create(
+    roleId: string,
+    data: AgentCapability
+  ): Promise<AgentCapability> {
+    return request<AgentCapability>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/roles/${roleId}/capabilities`),
+      {
+        method: 'POST',
+        body: JSON.stringify(data),
+      }
+    );
+  },
+
+  /** List capabilities for an agent role */
+  async list(roleId: string): Promise<AgentCapability[]> {
+    return request<AgentCapability[]>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/roles/${roleId}/capabilities`)
+    );
+  },
+
+  /** Get a specific capability by ID */
+  async get(capabilityId: string): Promise<AgentCapability> {
+    return request<AgentCapability>(
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.RULES,
+        `/roles/capabilities/${capabilityId}`
+      )
+    );
+  },
+
+  /** Update an existing capability */
+  async update(
+    capabilityId: string,
+    data: Partial<AgentCapability>
+  ): Promise<AgentCapability> {
+    return request<AgentCapability>(
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.RULES,
+        `/roles/capabilities/${capabilityId}`
+      ),
+      {
+        method: 'PUT',
+        body: JSON.stringify(data),
+      }
+    );
+  },
+
+  /** Delete a capability */
+  async delete(capabilityId: string): Promise<{ message: string }> {
+    return request<{ message: string }>(
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.RULES,
+        `/roles/capabilities/${capabilityId}`
+      ),
+      {
+        method: 'DELETE',
+      }
+    );
+  },
+};

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -11,3 +11,4 @@ export * from "./mcp";
 export * from "./users";
 export * from "./audit_logs";
 export * from "./project_templates";
+export * from "./agent_capabilities";


### PR DESCRIPTION
## Summary
- add CRUD wrappers for agent capabilities
- export agentCapabilitiesApi from api index

## Testing
- `npm run format`
- `cd frontend && npm run lint` *(fails: next not found)*
- `npm run test` *(fails: vitest not found)*
- `pytest` *(fails: ModuleNotFoundError: sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68416c0efc60832cb62fa2e9f32605e1