### PR TITLE
Add user role MCP tools

### DIFF
--- a/backend/docs/fastapi_mcp/README.md
+++ b/backend/docs/fastapi_mcp/README.md
@@ -93,6 +93,9 @@ FastAPI-MCP automatically exposes selected API endpoints as tools under the `/mc
 - `/mcp-tools/memory/add-observation` (POST)
 - `/mcp-tools/memory/add-relation` (POST)
 - `/mcp-tools/memory/search` (GET)
+- `/mcp-tools/user-role/assign` (POST)
+- `/mcp-tools/user-role/list` (GET)
+- `/mcp-tools/user-role/remove` (POST)
 
 ## Development and Contributing
 

--- a/backend/mcp_tools/__init__.py
+++ b/backend/mcp_tools/__init__.py
@@ -12,5 +12,8 @@ __all__ = [
     'search_memory_tool',
     'add_project_file_tool',
     'list_project_files_tool',
-    'remove_project_file_tool'
+    'remove_project_file_tool',
+    'assign_role_tool',
+    'list_roles_tool',
+    'remove_role_tool'
 ]

--- a/backend/mcp_tools/user_role_tools.py
+++ b/backend/mcp_tools/user_role_tools.py
@@ -1,0 +1,64 @@
+"""MCP Tools for user role management."""
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+import logging
+
+from backend.services.user_role_service import UserRoleService
+
+logger = logging.getLogger(__name__)
+
+
+async def assign_role_tool(
+    user_id: str,
+    role_name: str,
+    db: Session,
+) -> dict:
+    """Assign a role to a user."""
+    try:
+        service = UserRoleService(db)
+        role = service.assign_role_to_user(user_id, role_name)
+        return {
+            "success": True,
+            "role": {
+                "user_id": role.user_id,
+                "role_name": role.role_name,
+            },
+        }
+    except Exception as exc:
+        logger.error(f"MCP assign role failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+async def list_roles_tool(
+    user_id: str,
+    db: Session,
+) -> dict:
+    """List roles assigned to a user."""
+    try:
+        service = UserRoleService(db)
+        roles = service.get_user_roles(user_id)
+        return {
+            "success": True,
+            "roles": [
+                {"user_id": r.user_id, "role_name": r.role_name} for r in roles
+            ],
+        }
+    except Exception as exc:
+        logger.error(f"MCP list roles failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+async def remove_role_tool(
+    user_id: str,
+    role_name: str,
+    db: Session,
+) -> dict:
+    """Remove a role from a user."""
+    try:
+        service = UserRoleService(db)
+        success = service.remove_role_from_user(user_id, role_name)
+        return {"success": success}
+    except Exception as exc:
+        logger.error(f"MCP remove role failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/backend/routers/mcp/core.py
+++ b/backend/routers/mcp/core.py
@@ -14,6 +14,7 @@ from ....services.task_service import TaskService
 from ....services.audit_log_service import AuditLogService
 from ....services.memory_service import MemoryService
 from ....services.project_file_association_service import ProjectFileAssociationService
+from ....services.user_role_service import UserRoleService
 from ....services.rules_service import RulesService
 from ....schemas.project import ProjectCreate
 from ....schemas.task import TaskCreate
@@ -395,6 +396,76 @@ async def mcp_remove_project_file(
         return {"success": True, "message": "Project file association removed successfully"}
     except Exception as e:
         logger.error(f"MCP remove project file failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/mcp-tools/user-role/assign",
+    tags=["mcp-tools"],
+    operation_id="assign_role_tool",
+)
+async def mcp_assign_role(
+    user_id: str,
+    role_name: str,
+    db: Session = Depends(get_db_session),
+):
+    """Assign a role to a user."""
+    try:
+        service = UserRoleService(db)
+        role = service.assign_role_to_user(user_id, role_name)
+        return {
+            "success": True,
+            "role": {
+                "user_id": role.user_id,
+                "role_name": role.role_name,
+            },
+        }
+    except Exception as e:
+        logger.error(f"MCP assign role failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get(
+    "/mcp-tools/user-role/list",
+    tags=["mcp-tools"],
+    operation_id="list_roles_tool",
+)
+async def mcp_list_roles(
+    user_id: str,
+    db: Session = Depends(get_db_session),
+):
+    """List roles assigned to a user."""
+    try:
+        service = UserRoleService(db)
+        roles = service.get_user_roles(user_id)
+        return {
+            "success": True,
+            "roles": [
+                {"user_id": r.user_id, "role_name": r.role_name} for r in roles
+            ],
+        }
+    except Exception as e:
+        logger.error(f"MCP list roles failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/mcp-tools/user-role/remove",
+    tags=["mcp-tools"],
+    operation_id="remove_role_tool",
+)
+async def mcp_remove_role(
+    user_id: str,
+    role_name: str,
+    db: Session = Depends(get_db_session),
+):
+    """Remove a role from a user."""
+    try:
+        service = UserRoleService(db)
+        success = service.remove_role_from_user(user_id, role_name)
+        return {"success": success}
+    except Exception as e:
+        logger.error(f"MCP remove role failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 


### PR DESCRIPTION
## Summary
- add user role tools for MCP
- register new tools in the MCP router
- document endpoints in FastAPI MCP docs

## Testing
- `flake8 mcp_tools/user_role_tools.py`
- `pytest -q` *(fails: AttributeError, assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68416c0c44ac832c9442b0f212e6032c