### PR TITLE
Add user role router

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -48,8 +48,10 @@ def include_app_routers(app: FastAPI):
     )
     from .routers.admin import router as admin_router
     from .routers.users.auth.auth import router as auth_router
+    from .routers.users.roles import router as user_roles_router
 
     app.include_router(users.router, prefix="/api/v1/users", tags=["users"])
+    app.include_router(user_roles_router, prefix="/api/v1/users", tags=["user-roles"])
     app.include_router(admin_router, prefix="/api/v1", tags=["admin"])
     app.include_router(auth_router, prefix="/api/v1", tags=["auth"])
     app.include_router(projects.router, prefix="/api/v1/projects", tags=["projects"])

--- a/backend/routers/users/__init__.py
+++ b/backend/routers/users/__init__.py
@@ -1,7 +1,9 @@
 from fastapi import APIRouter
 from .core.core import router as core_router
 from .auth.auth import router as auth_router
+from .roles import router as roles_router
 
 router = APIRouter()
 router.include_router(core_router)
 router.include_router(auth_router)
+router.include_router(roles_router)

--- a/backend/routers/users/roles.py
+++ b/backend/routers/users/roles.py
@@ -1,0 +1,65 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from backend.database import get_sync_db as get_db
+from backend.services.user_role_service import UserRoleService
+from backend.schemas.user import UserRole, UserRoleCreate
+from backend.schemas.api_responses import DataResponse, ListResponse
+
+router = APIRouter(prefix="/{user_id}/roles", tags=["User Roles"])
+
+
+def get_user_role_service(db: Session = Depends(get_db)) -> UserRoleService:
+    return UserRoleService(db)
+
+
+@router.post("/", response_model=DataResponse[UserRole])
+def assign_role(user_id: str, role: UserRoleCreate, service: UserRoleService = Depends(get_user_role_service)):
+    try:
+        db_role = service.assign_role_to_user(user_id, role.role_name)
+        return DataResponse[UserRole](
+            data=UserRole.model_validate(db_role),
+            message="Role assigned successfully",
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/", response_model=ListResponse[UserRole])
+def list_roles(user_id: str, service: UserRoleService = Depends(get_user_role_service)):
+    roles = service.get_user_roles(user_id)
+    return ListResponse[UserRole](
+        data=[UserRole.model_validate(r) for r in roles],
+        total=len(roles),
+        page=1,
+        page_size=len(roles),
+        has_more=False,
+        message=f"Retrieved {len(roles)} roles",
+    )
+
+
+@router.put("/{role_name}", response_model=DataResponse[UserRole])
+def update_role(
+    user_id: str,
+    role_name: str,
+    role: UserRoleCreate,
+    service: UserRoleService = Depends(get_user_role_service),
+):
+    db_role = service.update_user_role(user_id, role_name, role.role_name)
+    if not db_role:
+        raise HTTPException(status_code=404, detail="User role not found")
+    return DataResponse[UserRole](
+        data=UserRole.model_validate(db_role),
+        message="Role updated successfully",
+    )
+
+
+@router.delete("/{role_name}", response_model=DataResponse[dict])
+def delete_role(user_id: str, role_name: str, service: UserRoleService = Depends(get_user_role_service)):
+    success = service.delete_user_role(user_id, role_name)
+    if not success:
+        raise HTTPException(status_code=404, detail="User role not found")
+    return DataResponse[dict](
+        data={"message": "Role deleted successfully"},
+        message="Role deleted successfully",
+    )

--- a/backend/services/user_role_service.py
+++ b/backend/services/user_role_service.py
@@ -1,43 +1,62 @@
 from sqlalchemy.orm import Session
-from .. import models, schemas
 from typing import List, Optional
+
+from .. import models
 
 
 class UserRoleService:
-def __init__(self, db: Session):
-    self.db = db
+    def __init__(self, db: Session):
+        self.db = db
 
-def assign_role_to_user(self, user_id: str, role_name: str) -> Optional[models.UserRole]:  # Check if the user and role exist (optional, depending on schema constraints)  # user = self.db.query(models.User).filter(models.User.id == user_id).first()  # role = self.db.query(models.Role).filter(models.Role.name == role_name).first()  # Assuming a separate Role model if roles are predefined  # if not user or not role:  # return None  # Check if the role is already assigned
-    existing_role = self.db.query(models.UserRole).filter(
-    models.UserRole.user_id == user_id,
-    models.UserRole.role_name == role_name
-    ).first()
+    def assign_role_to_user(self, user_id: str, role_name: str) -> Optional[models.UserRole]:
+        existing_role = (
+            self.db.query(models.UserRole)
+            .filter(models.UserRole.user_id == user_id, models.UserRole.role_name == role_name)
+            .first()
+        )
+        if existing_role:
+            return existing_role
+        db_user_role = models.UserRole(user_id=user_id, role_name=role_name)
+        self.db.add(db_user_role)
+        self.db.commit()
+        self.db.refresh(db_user_role)
+        return db_user_role
 
-    if existing_role:
-    return existing_role  # Role already assigned
+    def update_user_role(self, user_id: str, role_name: str, new_role_name: str) -> Optional[models.UserRole]:
+        db_user_role = (
+            self.db.query(models.UserRole)
+            .filter(models.UserRole.user_id == user_id, models.UserRole.role_name == role_name)
+            .first()
+        )
+        if not db_user_role:
+            return None
+        db_user_role.role_name = new_role_name
+        self.db.commit()
+        self.db.refresh(db_user_role)
+        return db_user_role
 
-    db_user_role = models.UserRole(user_id=user_id, role_name=role_name)
-    self.db.add(db_user_role)
-    self.db.commit()
-    self.db.refresh(db_user_role)
-    return db_user_role
+    def delete_user_role(self, user_id: str, role_name: str) -> bool:
+        db_user_role = (
+            self.db.query(models.UserRole)
+            .filter(models.UserRole.user_id == user_id, models.UserRole.role_name == role_name)
+            .first()
+        )
+        if db_user_role:
+            self.db.delete(db_user_role)
+            self.db.commit()
+            return True
+        return False
 
-def remove_role_from_user(self, user_id: str, role_name: str) -> bool:
-    db_user_role = self.db.query(models.UserRole).filter(
-    models.UserRole.user_id == user_id,
-    models.UserRole.role_name == role_name
-    ).first()
+    def remove_role_from_user(self, user_id: str, role_name: str) -> bool:
+        return self.delete_user_role(user_id, role_name)
 
-    if db_user_role:
-    self.db.delete(db_user_role)
-    self.db.commit()
-    return True
-    return False  # Role not found or not assigned
+    def get_user_roles(self, user_id: str) -> List[models.UserRole]:
+        return self.db.query(models.UserRole).filter(models.UserRole.user_id == user_id).all()
 
-def get_user_roles(self, user_id: str) -> List[models.UserRole]:
-    return self.db.query(models.UserRole).filter(models.UserRole.user_id == user_id).all()  # You might add other methods like checking if a user has a specific role
-def has_role(self, user_id: str, role_name: str) -> bool:
-    return self.db.query(models.UserRole).filter(
-    models.UserRole.user_id == user_id,
-    models.UserRole.role_name == role_name
-    ).first() is not None
+    def has_role(self, user_id: str, role_name: str) -> bool:
+        return (
+            self.db.query(models.UserRole)
+            .filter(models.UserRole.user_id == user_id, models.UserRole.role_name == role_name)
+            .first()
+            is not None
+        )


### PR DESCRIPTION
## Summary
- add endpoints for assigning, listing, updating and deleting user roles
- extend service with update and delete helpers
- wire user role router into users package and register in `main.py`

## Testing
- `flake8 backend/routers/users/roles.py backend/services/user_role_service.py backend/routers/users/__init__.py backend/main.py`
- `pytest -q` *(fails: AttributeError and API tests)*

------
https://chatgpt.com/codex/tasks/task_e_68416c0c3de8832cacd3d7aba15cac99