### PR TITLE
Add user roles management page

### DIFF
--- a/frontend/src/__tests__/integration/userRolesPages.test.tsx
+++ b/frontend/src/__tests__/integration/userRolesPages.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, waitFor } from '@/__tests__/utils/test-utils'
+import userEvent from '@testing-library/user-event'
+import UserRolesPage from '@/app/user-roles/page'
+import { getUsers } from '@/services/api/users'
+import { assignRole, removeRole } from '@/services/api/userRoles'
+import { UserRole } from '@/types/user'
+
+vi.mock('@/services/api/users', () => ({
+  getUsers: vi.fn(),
+}))
+
+vi.mock('@/services/api/userRoles', () => ({
+  assignRole: vi.fn(),
+  removeRole: vi.fn(),
+}))
+
+describe('UserRolesPage', () => {
+  const user = userEvent.setup()
+  const getUsersMock = getUsers as unknown as vi.Mock
+  const assignRoleMock = assignRole as unknown as vi.Mock
+  const removeRoleMock = removeRole as unknown as vi.Mock
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getUsersMock.mockResolvedValue([
+      {
+        id: 'u1',
+        username: 'alice',
+        email: '',
+        full_name: null,
+        disabled: false,
+        created_at: '',
+        updated_at: '',
+        user_roles: [],
+      },
+    ])
+    assignRoleMock.mockResolvedValue({ user_id: 'u1', role_name: UserRole.ADMIN })
+    removeRoleMock.mockResolvedValue(undefined)
+  })
+
+  it('renders user table', async () => {
+    render(<UserRolesPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('alice')).toBeInTheDocument()
+    })
+  })
+
+  it('assigns and removes role', async () => {
+    render(<UserRolesPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('alice')).toBeInTheDocument()
+    })
+
+    await user.selectOptions(screen.getByRole('combobox'), UserRole.ADMIN)
+    await user.click(screen.getByRole('button', { name: /assign/i }))
+
+    await waitFor(() =>
+      expect(assignRoleMock).toHaveBeenCalledWith('u1', UserRole.ADMIN),
+    )
+
+    await user.click(screen.getByRole('button', { name: /admin/i }))
+
+    await waitFor(() =>
+      expect(removeRoleMock).toHaveBeenCalledWith('u1', UserRole.ADMIN),
+    )
+  })
+})

--- a/frontend/src/app/user-roles/page.tsx
+++ b/frontend/src/app/user-roles/page.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import {
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Select,
+  Button,
+  Box,
+} from '@chakra-ui/react'
+import { getUsers } from '@/services/api/users'
+import { assignRole, removeRole } from '@/services/api/userRoles'
+import { User, UserRole, UserRoleObject } from '@/types/user'
+
+const UserRolesPage: React.FC = () => {
+  const [users, setUsers] = useState<User[]>([])
+  const [roleSelections, setRoleSelections] = useState<Record<string, UserRole | ''>>({})
+
+  useEffect(() => {
+    const loadUsers = async () => {
+      try {
+        const data = await getUsers(0, 100)
+        setUsers(data)
+      } catch (err) {
+        console.error('Failed to load users', err)
+      }
+    }
+    loadUsers()
+  }, [])
+
+  const handleAssign = async (userId: string) => {
+    const role = roleSelections[userId]
+    if (!role) return
+    try {
+      const newRole: UserRoleObject = await assignRole(userId, role)
+      setUsers(prev =>
+        prev.map(u =>
+          u.id === userId ? { ...u, user_roles: [...u.user_roles, newRole] } : u,
+        ),
+      )
+      setRoleSelections(prev => ({ ...prev, [userId]: '' }))
+    } catch (err) {
+      console.error('Failed to assign role', err)
+    }
+  }
+
+  const handleRemove = async (userId: string, role: UserRole) => {
+    try {
+      await removeRole(userId, role)
+      setUsers(prev =>
+        prev.map(u =>
+          u.id === userId
+            ? { ...u, user_roles: u.user_roles.filter(r => r.role_name !== role) }
+            : u,
+        ),
+      )
+    } catch (err) {
+      console.error('Failed to remove role', err)
+    }
+  }
+
+  return (
+    <Box p={4}>
+      <Table variant="simple">
+        <Thead>
+          <Tr>
+            <Th>Username</Th>
+            <Th>Roles</Th>
+            <Th>Assign Role</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {users.map(user => (
+            <Tr key={user.id}>
+              <Td>{user.username}</Td>
+              <Td>
+                {user.user_roles.map(role => (
+                  <Button
+                    key={role.role_name}
+                    size="sm"
+                    mr={2}
+                    onClick={() => handleRemove(user.id, role.role_name)}
+                  >
+                    {role.role_name}
+                  </Button>
+                ))}
+              </Td>
+              <Td>
+                <Select
+                  placeholder="Select role"
+                  value={roleSelections[user.id] || ''}
+                  onChange={e =>
+                    setRoleSelections(prev => ({
+                      ...prev,
+                      [user.id]: e.target.value as UserRole,
+                    }))
+                  }
+                  mb={2}
+                >
+                  {Object.values(UserRole).map(r => (
+                    <option key={r} value={r}>
+                      {r}
+                    </option>
+                  ))}
+                </Select>
+                <Button size="sm" onClick={() => handleAssign(user.id)}>
+                  Assign
+                </Button>
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </Box>
+  )
+}
+
+export default UserRolesPage

--- a/frontend/src/services/api/userRoles.ts
+++ b/frontend/src/services/api/userRoles.ts
@@ -1,0 +1,26 @@
+import { request } from './request';
+import { buildApiUrl, API_CONFIG } from './config';
+import { UserRole, UserRoleObject } from '@/types/user';
+
+export const assignRole = async (
+  userId: string,
+  role: UserRole,
+): Promise<UserRoleObject> => {
+  return request<UserRoleObject>(
+    buildApiUrl(API_CONFIG.ENDPOINTS.USERS, `/${userId}/roles`),
+    {
+      method: 'POST',
+      body: JSON.stringify({ role_name: role }),
+    },
+  );
+};
+
+export const removeRole = async (
+  userId: string,
+  role: UserRole,
+): Promise<void> => {
+  await request(
+    buildApiUrl(API_CONFIG.ENDPOINTS.USERS, `/${userId}/roles/${role}`),
+    { method: 'DELETE' },
+  );
+};


### PR DESCRIPTION
## Summary
- display user roles table at `/user-roles`
- allow assigning and removing roles with Chakra UI forms
- add unit tests for user roles page

## Testing
- `npm run lint`
- `npm run test:integration` *(fails: observer.observe is not a function)*
- `npx vitest run src/__tests__/integration/userRolesPages.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68416c0a3ee0832c90c71771d23f8e14