### PR TITLE
Add verification requirement tools

### DIFF
--- a/backend/mcp_tools/README.md
+++ b/backend/mcp_tools/README.md
@@ -7,6 +7,7 @@ Key files:
 *   `task_tools.py`: MCP-specific tools for interacting with tasks.
 *   `memory_tools.py`: MCP-specific tools for interacting with the Memory Service.
 *   `project_tools.py`: MCP-specific tools for interacting with projects.
+*   `verification_requirement_tools.py`: Manage agent verification requirements.
 *   `__init__.py`: Initializes the mcp_tools package.
 
 ## Architecture Diagram
@@ -25,6 +26,7 @@ graph TD
 - `memory_tools.py`
 - `project_tools.py`
 - `task_tools.py`
+- `verification_requirement_tools.py`
 
 <!-- File List End -->
 

--- a/backend/mcp_tools/verification_requirement_tools.py
+++ b/backend/mcp_tools/verification_requirement_tools.py
@@ -1,0 +1,94 @@
+"""MCP tools for managing agent verification requirements."""
+
+import logging
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from backend.models import AgentVerificationRequirement
+from backend.schemas.verification_requirement import VerificationRequirementCreate
+
+logger = logging.getLogger(__name__)
+
+
+async def create_verification_requirement_tool(
+    agent_role_id: str,
+    requirement: VerificationRequirementCreate,
+    db: Session,
+) -> dict:
+    """Create a verification requirement for an agent role."""
+    try:
+        db_req = AgentVerificationRequirement(
+            agent_role_id=agent_role_id,
+            requirement=requirement.requirement,
+            description=requirement.description,
+            is_mandatory=requirement.is_mandatory,
+        )
+        db.add(db_req)
+        db.commit()
+        db.refresh(db_req)
+        return {
+            "success": True,
+            "requirement": {
+                "id": db_req.id,
+                "agent_role_id": db_req.agent_role_id,
+                "requirement": db_req.requirement,
+                "description": db_req.description,
+                "is_mandatory": db_req.is_mandatory,
+            },
+        }
+    except Exception as exc:
+        logger.error(f"MCP create verification requirement failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+async def list_verification_requirements_tool(
+    agent_role_id: str,
+    db: Session,
+) -> dict:
+    """List verification requirements for an agent role."""
+    try:
+        reqs = (
+            db.query(AgentVerificationRequirement)
+            .filter(AgentVerificationRequirement.agent_role_id == agent_role_id)
+            .all()
+        )
+        return {
+            "success": True,
+            "requirements": [
+                {
+                    "id": r.id,
+                    "agent_role_id": r.agent_role_id,
+                    "requirement": r.requirement,
+                    "description": r.description,
+                    "is_mandatory": r.is_mandatory,
+                }
+                for r in reqs
+            ],
+        }
+    except Exception as exc:
+        logger.error(f"MCP list verification requirements failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+async def delete_verification_requirement_tool(
+    requirement_id: str,
+    db: Session,
+) -> dict:
+    """Delete a verification requirement."""
+    try:
+        req = (
+            db.query(AgentVerificationRequirement)
+            .filter(AgentVerificationRequirement.id == requirement_id)
+            .first()
+        )
+        if not req:
+            raise HTTPException(status_code=404, detail="Requirement not found")
+        db.delete(req)
+        db.commit()
+        return {"success": True}
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"MCP delete verification requirement failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))
+

--- a/backend/routers/mcp/core.py
+++ b/backend/routers/mcp/core.py
@@ -25,6 +25,12 @@ from ....schemas.memory import (
     MemoryObservationCreate,
     MemoryRelationCreate
 )
+from ....schemas.verification_requirement import VerificationRequirementCreate
+from ....mcp_tools.verification_requirement_tools import (
+    create_verification_requirement_tool,
+    list_verification_requirements_tool,
+    delete_verification_requirement_tool,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["mcp-tools"])
@@ -706,3 +712,43 @@ async def mcp_create_agent_rule(
     except Exception as e:
         logger.error(f"MCP create agent rule failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/mcp-tools/rule/verification/create",
+    tags=["mcp-tools"],
+    operation_id="create_verification_requirement_tool",
+)
+async def mcp_create_verification_requirement(
+    agent_role_id: str,
+    requirement: VerificationRequirementCreate,
+    db: Session = Depends(get_db_session),
+):
+    """MCP Tool: Create a verification requirement for an agent role."""
+    return await create_verification_requirement_tool(agent_role_id, requirement, db)
+
+
+@router.get(
+    "/mcp-tools/rule/verification/list",
+    tags=["mcp-tools"],
+    operation_id="list_verification_requirements_tool",
+)
+async def mcp_list_verification_requirements(
+    agent_role_id: str,
+    db: Session = Depends(get_db_session),
+):
+    """MCP Tool: List verification requirements for a role."""
+    return await list_verification_requirements_tool(agent_role_id, db)
+
+
+@router.post(
+    "/mcp-tools/rule/verification/delete",
+    tags=["mcp-tools"],
+    operation_id="delete_verification_requirement_tool",
+)
+async def mcp_delete_verification_requirement(
+    requirement_id: str,
+    db: Session = Depends(get_db_session),
+):
+    """MCP Tool: Delete a verification requirement."""
+    return await delete_verification_requirement_tool(requirement_id, db)

--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -75,3 +75,8 @@ from .memory import (
     MemoryRelation,
 )
 from .file_ingest import FileIngestInput
+from .verification_requirement import (
+    VerificationRequirementBase,
+    VerificationRequirementCreate,
+    VerificationRequirement,
+)

--- a/backend/schemas/verification_requirement.py
+++ b/backend/schemas/verification_requirement.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel, ConfigDict, Field
+from typing import Optional
+from datetime import datetime
+
+class VerificationRequirementBase(BaseModel):
+    """Base schema for agent verification requirements."""
+    requirement: str = Field(..., description="Name of the verification action.")
+    description: Optional[str] = Field(None, description="Detailed description.")
+    is_mandatory: bool = Field(True, description="Whether the verification is mandatory.")
+
+class VerificationRequirementCreate(VerificationRequirementBase):
+    """Schema for creating a verification requirement."""
+    pass
+
+class VerificationRequirement(VerificationRequirementBase):
+    """Schema returned in API responses."""
+    id: str = Field(..., description="Unique requirement identifier.")
+    agent_role_id: str = Field(..., description="Associated agent role ID.")
+    created_at: datetime = Field(..., description="Creation timestamp.")
+
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## Summary
- add `verification_requirement_tools` with create/list/delete helpers
- expose verification requirement routes in MCP core router
- update schemas package with `VerificationRequirement` models
- document verification tools in MCP README

## Testing
- `flake8 .` *(fails: F401, W291, E501, ...)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy', AssertionError, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68416c005d00832c99479186120b3e18