### PR TITLE
Add AgentForbiddenActions component

### DIFF
--- a/frontend/src/components/agents/AgentForbiddenActions.tsx
+++ b/frontend/src/components/agents/AgentForbiddenActions.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import React, { useState } from 'react';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  IconButton,
+  Input,
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from '@chakra-ui/react';
+import { DeleteIcon } from '@chakra-ui/icons';
+
+const AgentForbiddenActions: React.FC = () => {
+  const [action, setAction] = useState('');
+  const [actions, setActions] = useState<string[]>([]);
+
+  const handleAdd = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = action.trim();
+    if (!trimmed) return;
+    setActions((prev) => [...prev, trimmed]);
+    setAction('');
+  };
+
+  const handleRemove = (index: number) => {
+    setActions((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  return (
+    <Box p={4}>
+      <Box as="form" onSubmit={handleAdd} mb={4}>
+        <FormControl>
+          <FormLabel htmlFor="forbidden-action">Forbidden Action</FormLabel>
+          <Input
+            id="forbidden-action"
+            value={action}
+            onChange={(e) => setAction(e.target.value)}
+            placeholder="Enter action"
+          />
+        </FormControl>
+        <Button mt={2} type="submit" colorScheme="blue">
+          Add Action
+        </Button>
+      </Box>
+      <Table variant="simple">
+        <Thead>
+          <Tr>
+            <Th>Action</Th>
+            <Th>Remove</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {actions.map((act, idx) => (
+            <Tr key={idx} data-testid="forbidden-action-row">
+              <Td>{act}</Td>
+              <Td>
+                <IconButton
+                  aria-label="Remove"
+                  icon={<DeleteIcon />}
+                  size="sm"
+                  onClick={() => handleRemove(idx)}
+                />
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </Box>
+  );
+};
+
+export default AgentForbiddenActions;

--- a/frontend/src/components/agents/__tests__/AgentForbiddenActions.test.tsx
+++ b/frontend/src/components/agents/__tests__/AgentForbiddenActions.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@/__tests__/utils/test-utils';
+import AgentForbiddenActions from '../AgentForbiddenActions';
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual('@chakra-ui/react');
+  return {
+    ...actual,
+    useToast: () => vi.fn(),
+    useColorModeValue: (light: any, dark: any) => light,
+  };
+});
+
+describe('AgentForbiddenActions', () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render without crashing', () => {
+    render(<AgentForbiddenActions />, {
+      wrapper: ({ children }) => <div>{children}</div>,
+    });
+    expect(document.body).toBeInTheDocument();
+  });
+
+  it('should allow adding and removing actions', async () => {
+    render(<AgentForbiddenActions />, {
+      wrapper: ({ children }) => <div>{children}</div>,
+    });
+
+    const input = screen.getByPlaceholderText('Enter action');
+    await user.type(input, 'test-action');
+    await user.click(screen.getByRole('button', { name: /add action/i }));
+
+    expect(screen.getAllByTestId('forbidden-action-row')).toHaveLength(1);
+
+    await user.click(screen.getByRole('button', { name: /remove/i }));
+    expect(screen.queryAllByTestId('forbidden-action-row')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `AgentForbiddenActions` React component
- allow adding/removing forbidden actions in a table
- add unit test for the component

## Testing
- `npm run lint`
- `npx vitest run src/components/agents/__tests__/AgentForbiddenActions.test.tsx --passWithNoTests` *(no tests found for this pattern)*
- `pytest tests/test_simple.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68416bfdb544832ca183e848826f4285