### PR TITLE
Add verification requirement service and router

### DIFF
--- a/backend/routers/rules/__init__.py
+++ b/backend/routers/rules/__init__.py
@@ -5,11 +5,15 @@ from .templates.templates import router as templates_router
 from .roles.roles import router as roles_router
 from .mandates.mandates import router as mandates_router
 from .logs.logs import router as logs_router
+from .roles.verification_requirements import (
+    router as verification_requirements_router,
+)
 
 router = APIRouter()
 router.include_router(workflows_router)
 router.include_router(violations_router)
 router.include_router(templates_router)
 router.include_router(roles_router)
+router.include_router(verification_requirements_router)
 router.include_router(mandates_router)
 router.include_router(logs_router)

--- a/backend/routers/rules/roles/verification_requirements.py
+++ b/backend/routers/rules/roles/verification_requirements.py
@@ -1,0 +1,76 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from typing import Optional
+
+from ....database import get_sync_db as get_db
+from ....services.agent_verification_service import AgentVerificationService
+
+router = APIRouter()
+
+
+def get_service(db: Session = Depends(get_db)) -> AgentVerificationService:
+    return AgentVerificationService(db)
+
+
+@router.get("/{agent_role_id}/verification-requirements")
+def list_requirements(
+    agent_role_id: str,
+    service: AgentVerificationService = Depends(get_service),
+):
+    """Return verification requirements for a role."""
+    return service.get_requirements(agent_role_id)
+
+
+@router.post("/{agent_role_id}/verification-requirements")
+def add_requirement(
+    agent_role_id: str,
+    requirement: str,
+    description: Optional[str] = None,
+    is_mandatory: bool = True,
+    service: AgentVerificationService = Depends(get_service),
+):
+    """Create a verification requirement for an agent role."""
+    return service.create_requirement(
+        agent_role_id,
+        requirement,
+        description,
+        is_mandatory,
+    )
+
+
+@router.put("/verification-requirements/{requirement_id}")
+def update_requirement(
+    requirement_id: str,
+    requirement: Optional[str] = None,
+    description: Optional[str] = None,
+    is_mandatory: Optional[bool] = None,
+    service: AgentVerificationService = Depends(get_service),
+):
+    """Update an existing verification requirement."""
+    result = service.update_requirement(
+        requirement_id,
+        requirement,
+        description,
+        is_mandatory,
+    )
+    if not result:
+        raise HTTPException(
+            status_code=404,
+            detail="Verification requirement not found",
+        )
+    return result
+
+
+@router.delete("/verification-requirements/{requirement_id}")
+def remove_requirement(
+    requirement_id: str,
+    service: AgentVerificationService = Depends(get_service),
+):
+    """Remove a verification requirement."""
+    success = service.delete_requirement(requirement_id)
+    if not success:
+        raise HTTPException(
+            status_code=404,
+            detail="Verification requirement not found",
+        )
+    return {"message": "Verification requirement removed successfully"}

--- a/backend/services/agent_verification_service.py
+++ b/backend/services/agent_verification_service.py
@@ -1,0 +1,74 @@
+from sqlalchemy.orm import Session
+from typing import List, Optional
+
+from .. import models
+
+
+class AgentVerificationService:
+    """Service for CRUD operations on AgentVerificationRequirement."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def get_requirements(
+        self, role_id: str
+    ) -> List[models.AgentVerificationRequirement]:
+        query = (
+            self.db.query(models.AgentVerificationRequirement)
+            .filter(models.AgentVerificationRequirement.agent_role_id == role_id)
+        )
+        return query.all()
+
+    def create_requirement(
+        self,
+        role_id: str,
+        requirement: str,
+        description: Optional[str] = None,
+        is_mandatory: bool = True,
+    ) -> models.AgentVerificationRequirement:
+        new_req = models.AgentVerificationRequirement(
+            agent_role_id=role_id,
+            requirement=requirement,
+            description=description,
+            is_mandatory=is_mandatory,
+        )
+        self.db.add(new_req)
+        self.db.commit()
+        self.db.refresh(new_req)
+        return new_req
+
+    def update_requirement(
+        self,
+        requirement_id: str,
+        requirement: Optional[str] = None,
+        description: Optional[str] = None,
+        is_mandatory: Optional[bool] = None,
+    ) -> Optional[models.AgentVerificationRequirement]:
+        req = (
+            self.db.query(models.AgentVerificationRequirement)
+            .filter(models.AgentVerificationRequirement.id == requirement_id)
+            .first()
+        )
+        if not req:
+            return None
+        if requirement is not None:
+            req.requirement = requirement
+        if description is not None:
+            req.description = description
+        if is_mandatory is not None:
+            req.is_mandatory = is_mandatory
+        self.db.commit()
+        self.db.refresh(req)
+        return req
+
+    def delete_requirement(self, requirement_id: str) -> bool:
+        req = (
+            self.db.query(models.AgentVerificationRequirement)
+            .filter(models.AgentVerificationRequirement.id == requirement_id)
+            .first()
+        )
+        if not req:
+            return False
+        self.db.delete(req)
+        self.db.commit()
+        return True


### PR DESCRIPTION
## Summary
- add `AgentVerificationService` for verification requirement CRUD operations
- implement `verification_requirements` router under rules/roles
- register new router in rules package

## Testing
- `flake8 backend/services/agent_verification_service.py backend/routers/rules/roles/verification_requirements.py backend/routers/rules/__init__.py`
- `pytest -q tests/test_simple.py`

------
https://chatgpt.com/codex/tasks/task_e_68416bfd409c832c9fbd11052f19b0d6