### PR TITLE
Implement forbidden action endpoints

### DIFF
--- a/backend/crud/rules.py
+++ b/backend/crud/rules.py
@@ -223,7 +223,49 @@ async def delete_capability(
 
     await db.delete(db_capability)
     await db.commit()
-    return True  # Mandate operations
+    return True
+
+# Forbidden action operations
+
+async def add_forbidden_action(
+    db: AsyncSession,
+    role_id: str,
+    action: str,
+    reason: Optional[str] = None
+) -> models.AgentForbiddenAction:
+    """Create a forbidden action for an agent role."""
+    db_action = models.AgentForbiddenAction(
+        id=str(uuid.uuid4()).replace("-", ""),
+        agent_role_id=role_id,
+        action=action,
+        reason=reason,
+        is_active=True,
+    )
+    db.add(db_action)
+    await db.commit()
+    await db.refresh(db_action)
+    return db_action
+
+
+async def get_forbidden_actions(db: AsyncSession, role_id: str) -> List[models.AgentForbiddenAction]:
+    """List forbidden actions for a role."""
+    result = await db.execute(
+        select(models.AgentForbiddenAction).filter(models.AgentForbiddenAction.agent_role_id == role_id)
+    )
+    return result.scalars().all()
+
+
+async def remove_forbidden_action(db: AsyncSession, action_id: str) -> bool:
+    """Delete a forbidden action by ID."""
+    result = await db.execute(
+        select(models.AgentForbiddenAction).filter(models.AgentForbiddenAction.id == action_id)
+    )
+    db_action = result.scalar_one_or_none()
+    if not db_action:
+        return False
+    await db.delete(db_action)
+    await db.commit()
+    return True
 
 
 async def create_mandate(

--- a/backend/routers/rules/__init__.py
+++ b/backend/routers/rules/__init__.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter
 from .workflows.workflows import router as workflows_router
 from .violations.violations import router as violations_router
 from .templates.templates import router as templates_router
-from .roles.roles import router as roles_router
+from .roles import router as roles_router
 from .mandates.mandates import router as mandates_router
 from .logs.logs import router as logs_router
 

--- a/backend/routers/rules/roles/__init__.py
+++ b/backend/routers/rules/roles/__init__.py
@@ -1,1 +1,16 @@
-# Rules module\n
+"""Aggregate routers for agent roles and related resources."""
+
+from fastapi import APIRouter
+
+from .roles import router as roles_router
+from .capabilities import router as capabilities_router
+from .forbidden_actions import router as forbidden_actions_router
+
+router = APIRouter()
+router.include_router(roles_router, prefix="/roles", tags=["agent-roles"])
+router.include_router(capabilities_router, prefix="/roles", tags=["agent-capabilities"])
+router.include_router(
+    forbidden_actions_router,
+    prefix="/roles",
+    tags=["agent-forbidden-actions"],
+)

--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -60,6 +60,11 @@ from .agent import (
     AgentRuleUpdate,
     AgentRule,
 )
+from .agent_forbidden_action import (
+    AgentForbiddenActionBase,
+    AgentForbiddenActionCreate,
+    AgentForbiddenAction,
+)
 
 # Import and export memory schemas
 from .memory import (

--- a/backend/schemas/agent_forbidden_action.py
+++ b/backend/schemas/agent_forbidden_action.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel, ConfigDict, Field
+from typing import Optional
+from datetime import datetime
+
+
+class AgentForbiddenActionBase(BaseModel):
+    """Base schema for agent forbidden action."""
+    action: str = Field(..., description="Forbidden action name.")
+    reason: Optional[str] = Field(None, description="Reason the action is forbidden.")
+    is_active: bool = Field(True, description="Whether the rule is active.")
+
+
+class AgentForbiddenActionCreate(AgentForbiddenActionBase):
+    """Schema for creating a forbidden action."""
+    pass
+
+
+class AgentForbiddenAction(AgentForbiddenActionBase):
+    """Schema returned from API."""
+    id: str = Field(..., description="Unique identifier for the forbidden action.")
+    agent_role_id: str = Field(..., description="Associated agent role ID.")
+    created_at: datetime = Field(..., description="Creation timestamp.")
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/services/agent_forbidden_action_service.py
+++ b/backend/services/agent_forbidden_action_service.py
@@ -1,0 +1,25 @@
+from sqlalchemy.orm import Session
+from typing import List, Optional
+
+from .. import models
+from ..crud import rules as crud_rules
+
+
+class AgentForbiddenActionService:
+    """Service layer for agent forbidden actions."""
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    async def create_forbidden_action(
+        self, role_id: str, action: str, reason: Optional[str] = None
+    ) -> models.AgentForbiddenAction:
+        return await crud_rules.add_forbidden_action(self.db, role_id, action, reason)
+
+    async def list_forbidden_actions(
+        self, role_id: str
+    ) -> List[models.AgentForbiddenAction]:
+        return await crud_rules.get_forbidden_actions(self.db, role_id)
+
+    async def delete_forbidden_action(self, action_id: str) -> bool:
+        return await crud_rules.remove_forbidden_action(self.db, action_id)


### PR DESCRIPTION
## Summary
- add new Pydantic schema for forbidden actions
- implement CRUD helpers for forbidden actions
- create agent forbidden action service
- expose REST API for managing forbidden actions
- register router under rules

## Testing
- `flake8 services/agent_forbidden_action_service.py ../backend/routers/rules/roles/forbidden_actions.py ../backend/schemas/agent_forbidden_action.py ../backend/routers/rules/roles/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_68416c118eb4832cb8d82c82d6ade55d