### PR TITLE
Add AgentCapabilities component

### DIFF
--- a/frontend/src/components/README.md
+++ b/frontend/src/components/README.md
@@ -159,6 +159,7 @@ graph TD
 ## File List
 
 - `AgentList.tsx`
+- `agents/AgentCapabilities.tsx`
 - `BulkActionsBar.tsx`
 - `ClientOnly.tsx`
 - `Dashboard.tsx`

--- a/frontend/src/components/agents/AgentCapabilities.tsx
+++ b/frontend/src/components/agents/AgentCapabilities.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import {
+  Box,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  TableContainer,
+  Button,
+  HStack,
+  Input,
+} from "@chakra-ui/react";
+import { agentRolesApi } from "@/services/api/agent_roles";
+import type { AgentCapability } from "@/types/agent";
+
+interface AgentCapabilitiesProps {
+  roleName: string;
+  roleId: string;
+}
+
+const AgentCapabilities: React.FC<AgentCapabilitiesProps> = ({ roleName, roleId }) => {
+  const [capabilities, setCapabilities] = useState<AgentCapability[]>([]);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+
+  const fetchCapabilities = async () => {
+    try {
+      const caps = await agentRolesApi.getCapabilities(roleName);
+      setCapabilities(caps);
+    } catch (err) {
+      console.error("Failed to load capabilities", err);
+    }
+  };
+
+  useEffect(() => {
+    fetchCapabilities();
+  }, [roleName]);
+
+  const handleAdd = async () => {
+    if (!name) return;
+    try {
+      await agentRolesApi.addCapability(roleId, name, description);
+      setName("");
+      setDescription("");
+      fetchCapabilities();
+    } catch (err) {
+      console.error("Failed to add capability", err);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await agentRolesApi.deleteCapability(id);
+      fetchCapabilities();
+    } catch (err) {
+      console.error("Failed to delete capability", err);
+    }
+  };
+
+  return (
+    <Box p={4}>
+      <HStack mb={4} spacing={2}>
+        <Input
+          placeholder="Capability"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          size="sm"
+        />
+        <Input
+          placeholder="Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          size="sm"
+        />
+        <Button onClick={handleAdd} size="sm" data-testid="add-capability">
+          Add
+        </Button>
+      </HStack>
+      <TableContainer>
+        <Table size="sm">
+          <Thead>
+            <Tr>
+              <Th>Name</Th>
+              <Th>Description</Th>
+              <Th></Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {capabilities.map((cap: any) => (
+              <Tr key={cap.id ?? cap.name} data-testid="capability-row">
+                <Td>{cap.name ?? cap.capability}</Td>
+                <Td>{cap.description}</Td>
+                <Td>
+                  {cap.id && (
+                    <Button
+                      size="xs"
+                      colorScheme="red"
+                      onClick={() => handleDelete(cap.id)}
+                    >
+                      Remove
+                    </Button>
+                  )}
+                </Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+};
+
+export default AgentCapabilities;
+

--- a/frontend/src/components/agents/__tests__/AgentCapabilities.test.tsx
+++ b/frontend/src/components/agents/__tests__/AgentCapabilities.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@/__tests__/utils/test-utils';
+import AgentCapabilities from '../AgentCapabilities';
+
+vi.mock('@/services/api/agent_roles', () => ({
+  agentRolesApi: {
+    getCapabilities: vi.fn().mockResolvedValue([]),
+    addCapability: vi.fn().mockResolvedValue({}),
+    deleteCapability: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+describe('AgentCapabilities', () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render without crashing', async () => {
+    render(
+      <AgentCapabilities roleName="BuilderAgent" roleId="1" />,
+      { wrapper: ({ children }) => <div>{children}</div> }
+    );
+    expect(screen.getByText('Name')).toBeInTheDocument();
+  });
+
+  it('should handle user interactions', async () => {
+    render(
+      <AgentCapabilities roleName="BuilderAgent" roleId="1" />,
+      { wrapper: ({ children }) => <div>{children}</div> }
+    );
+
+    const buttons = screen.queryAllByRole('button');
+    const inputs = screen.queryAllByRole('textbox');
+
+    if (buttons.length > 0) {
+      await user.click(buttons[0]);
+    }
+
+    if (inputs.length > 0) {
+      await user.type(inputs[0], 'test');
+    }
+
+    expect(document.body).toBeInTheDocument();
+  });
+});

--- a/frontend/src/services/api/agent_roles.ts
+++ b/frontend/src/services/api/agent_roles.ts
@@ -1,0 +1,34 @@
+import { request } from "./request";
+import { buildApiUrl, API_CONFIG } from "./config";
+import type { AgentCapability } from "@/types/agent";
+
+export const agentRolesApi = {
+  getCapabilities: async (roleName: string): Promise<AgentCapability[]> => {
+    const role = await request<any>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/${roleName}`)
+    );
+    return role.capabilities || [];
+  },
+
+  addCapability: async (
+    roleId: string,
+    capability: string,
+    description?: string
+  ): Promise<AgentCapability> => {
+    return request(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/${roleId}/capabilities`),
+      {
+        method: "POST",
+        body: JSON.stringify({ capability, description }),
+      }
+    );
+  },
+
+  deleteCapability: async (capabilityId: string): Promise<void> => {
+    await request(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/capabilities/${capabilityId}`),
+      { method: "DELETE" }
+    );
+  },
+};
+

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -11,3 +11,4 @@ export * from "./mcp";
 export * from "./users";
 export * from "./audit_logs";
 export * from "./project_templates";
+export * from "./agent_roles";


### PR DESCRIPTION
## Summary
- list and modify capabilities for a role
- expose agent role API methods
- document component in README
- test new AgentCapabilities component

## Testing
- `npm run lint`
- `npm test` *(fails: observer.observe is not a function)*
- `npm run test:coverage` *(fails: observer.observe is not a function)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68416c0ec700832c9b4395162a4c7c1b