### PR TITLE
Add agent capability management

### DIFF
--- a/backend/routers/rules/roles/__init__.py
+++ b/backend/routers/rules/roles/__init__.py
@@ -1,1 +1,10 @@
-# Rules module\n
+from fastapi import APIRouter
+
+from .roles import router as roles_router
+from .capabilities import router as capabilities_router
+from .forbidden_actions import router as forbidden_actions_router
+
+router = APIRouter(prefix="/roles")
+router.include_router(roles_router)
+router.include_router(capabilities_router)
+router.include_router(forbidden_actions_router)

--- a/backend/routers/rules/roles/capabilities.py
+++ b/backend/routers/rules/roles/capabilities.py
@@ -1,32 +1,112 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 from typing import Optional
+from datetime import datetime
 
-from ....database import get_db
-from ....crud import rules as crud_rules
+from pydantic import BaseModel, ConfigDict
 
-router = APIRouter()  # Agent Capabilities
-@router.post("/{agent_role_id}/capabilities")
+from ....database import get_sync_db as get_db
+from ....services.agent_capability_service import AgentCapabilityService
+from ....schemas.api_responses import DataResponse, ListResponse
 
 
-def add_capability(
-    agent_role_id: str,
-    capability: str,
-    description: Optional[str] = None,
-    db: Session = Depends(get_db)
+class CapabilityCreate(BaseModel):
+    capability: str
+    description: Optional[str] = None
+    is_active: bool = True
+
+
+class CapabilityUpdate(BaseModel):
+    capability: Optional[str] = None
+    description: Optional[str] = None
+    is_active: Optional[bool] = None
+
+
+class Capability(BaseModel):
+    id: str
+    agent_role_id: str
+    capability: str
+    description: Optional[str] = None
+    is_active: bool
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+router = APIRouter(prefix="/capabilities", tags=["Agent Capabilities"])
+
+
+def get_service(db: Session = Depends(get_db)) -> AgentCapabilityService:
+    return AgentCapabilityService(db)
+
+
+@router.post(
+    "/{role_id}",
+    response_model=DataResponse[Capability],
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_capability_endpoint(
+    role_id: str,
+    capability: CapabilityCreate,
+    service: AgentCapabilityService = Depends(get_service),
 ):
-    """Add a capability to an agent role"""
-    return crud_rules.add_agent_capability(db, agent_role_id, capability, description)
+    created = service.create(
+        role_id=role_id,
+        capability=capability.capability,
+        description=capability.description,
+        is_active=capability.is_active,
+    )
+    return DataResponse[Capability](
+        data=Capability.model_validate(created),
+        message="Capability created",
+    )
 
-@router.delete("/capabilities/{capability_id}")
+
+@router.get("/{role_id}", response_model=ListResponse[Capability])
+async def list_capabilities_endpoint(
+    role_id: str,
+    service: AgentCapabilityService = Depends(get_service),
+):
+    caps = service.list(role_id)
+    data = [Capability.model_validate(c) for c in caps]
+    return ListResponse[Capability](
+        data=data,
+        total=len(data),
+        page=1,
+        page_size=len(data),
+        has_more=False,
+    )
 
 
-def remove_capability(
+@router.put(
+    "/{capability_id}",
+    response_model=DataResponse[Capability],
+)
+async def update_capability_endpoint(
     capability_id: str,
-    db: Session = Depends(get_db)
+    capability_update: CapabilityUpdate,
+    service: AgentCapabilityService = Depends(get_service),
 ):
-    """Remove an agent capability"""
-    success = crud_rules.remove_agent_capability(db, capability_id)
+    updated = service.update(
+        capability_id,
+        capability=capability_update.capability,
+        description=capability_update.description,
+        is_active=capability_update.is_active,
+    )
+    if not updated:
+        raise HTTPException(status_code=404, detail="Capability not found")
+    return DataResponse[Capability](
+        data=Capability.model_validate(updated),
+        message="Capability updated",
+    )
+
+
+@router.delete("/{capability_id}", response_model=DataResponse[bool])
+async def delete_capability_endpoint(
+    capability_id: str,
+    service: AgentCapabilityService = Depends(get_service),
+):
+    success = service.delete(capability_id)
     if not success:
-    raise HTTPException(status_code=404, detail="Capability not found")
-    return {"message": "Capability removed successfully"}
+        raise HTTPException(status_code=404, detail="Capability not found")
+    return DataResponse[bool](data=True, message="Capability deleted")

--- a/backend/services/agent_capability_service.py
+++ b/backend/services/agent_capability_service.py
@@ -1,0 +1,75 @@
+from sqlalchemy.orm import Session
+from typing import List, Optional
+from .. import models
+import uuid
+
+
+class AgentCapabilityService:
+    """Service for agent capability CRUD operations."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create(
+        self,
+        role_id: str,
+        capability: str,
+        description: Optional[str] = None,
+        is_active: bool = True,
+    ) -> models.AgentCapability:
+        new_capability = models.AgentCapability(
+            id=str(uuid.uuid4()).replace("-", ""),
+            agent_role_id=role_id,
+            capability=capability,
+            description=description,
+            is_active=is_active,
+        )
+        self.db.add(new_capability)
+        self.db.commit()
+        self.db.refresh(new_capability)
+        return new_capability
+
+    def list(self, role_id: Optional[str] = None) -> List[models.AgentCapability]:
+        query = self.db.query(models.AgentCapability)
+        if role_id is not None:
+            query = query.filter(models.AgentCapability.agent_role_id == role_id)
+        return query.all()
+
+    def update(
+        self,
+        capability_id: str,
+        capability: Optional[str] = None,
+        description: Optional[str] = None,
+        is_active: Optional[bool] = None,
+    ) -> Optional[models.AgentCapability]:
+        db_cap = (
+            self.db.query(models.AgentCapability)
+            .filter(models.AgentCapability.id == capability_id)
+            .first()
+        )
+        if not db_cap:
+            return None
+
+        if capability is not None:
+            db_cap.capability = capability
+        if description is not None:
+            db_cap.description = description
+        if is_active is not None:
+            db_cap.is_active = is_active
+
+        self.db.commit()
+        self.db.refresh(db_cap)
+        return db_cap
+
+    def delete(self, capability_id: str) -> bool:
+        db_cap = (
+            self.db.query(models.AgentCapability)
+            .filter(models.AgentCapability.id == capability_id)
+            .first()
+        )
+        if not db_cap:
+            return False
+
+        self.db.delete(db_cap)
+        self.db.commit()
+        return True


### PR DESCRIPTION
## Summary
- implement `AgentCapabilityService` with CRUD helpers
- add capability router for agent roles
- include the capability router in the rules roles module

## Testing
- `flake8 backend/services/agent_capability_service.py backend/routers/rules/roles/capabilities.py backend/routers/rules/roles/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68416c08d880832c952f8f5d52c1fb22