### PR TITLE
Add agent capability MCP tools

### DIFF
--- a/SYSTEM_GUIDE.md
+++ b/SYSTEM_GUIDE.md
@@ -37,6 +37,7 @@ node dev_start.js
 - **✅ Project Management**: Members, file associations, archive/unarchive
 - **✅ Task Management**: Dependencies, comments, status tracking
 - **✅ Agent System**: Rules-based agents with capabilities and constraints
+- **✅ Agent Capability Management**: Create, list, and delete role capabilities via MCP
 - **✅ Memory System**: Knowledge graph for file and content management
 - **✅ Audit Logging**: Complete action tracking and history
 

--- a/backend/mcp_tools/__init__.py
+++ b/backend/mcp_tools/__init__.py
@@ -12,5 +12,8 @@ __all__ = [
     'search_memory_tool',
     'add_project_file_tool',
     'list_project_files_tool',
-    'remove_project_file_tool'
+    'remove_project_file_tool',
+    'create_capability_tool',
+    'list_capabilities_tool',
+    'delete_capability_tool'
 ]

--- a/backend/mcp_tools/agent_capability_tools.py
+++ b/backend/mcp_tools/agent_capability_tools.py
@@ -1,0 +1,96 @@
+"""MCP Tools for managing agent capabilities."""
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from typing import Optional
+import logging
+import uuid
+
+from backend import models
+
+logger = logging.getLogger(__name__)
+
+
+async def create_capability_tool(
+    agent_role_id: str,
+    capability: str,
+    description: Optional[str],
+    db: AsyncSession,
+) -> dict:
+    """Create a capability for the given agent role."""
+    try:
+        new_cap = models.AgentCapability(
+            id=str(uuid.uuid4()).replace("-", ""),
+            agent_role_id=agent_role_id,
+            capability=capability,
+            description=description,
+            is_active=True,
+        )
+        db.add(new_cap)
+        await db.commit()
+        await db.refresh(new_cap)
+        return {
+            "success": True,
+            "capability": {
+                "id": new_cap.id,
+                "agent_role_id": new_cap.agent_role_id,
+                "capability": new_cap.capability,
+                "description": new_cap.description,
+                "is_active": new_cap.is_active,
+                "created_at": new_cap.created_at.isoformat(),
+            },
+        }
+    except Exception as exc:
+        logger.error(f"MCP create capability failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+async def list_capabilities_tool(
+    agent_role_id: Optional[str],
+    db: AsyncSession,
+) -> dict:
+    """List capabilities. Optionally filter by agent role."""
+    try:
+        query = select(models.AgentCapability)
+        if agent_role_id:
+            query = query.filter(models.AgentCapability.agent_role_id == agent_role_id)
+        result = await db.execute(query)
+        capabilities = result.scalars().all()
+        return {
+            "success": True,
+            "capabilities": [
+                {
+                    "id": c.id,
+                    "agent_role_id": c.agent_role_id,
+                    "capability": c.capability,
+                    "description": c.description,
+                    "is_active": c.is_active,
+                    "created_at": c.created_at.isoformat(),
+                }
+                for c in capabilities
+            ],
+        }
+    except Exception as exc:
+        logger.error(f"MCP list capabilities failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+async def delete_capability_tool(capability_id: str, db: AsyncSession) -> dict:
+    """Delete a capability by ID."""
+    try:
+        query = select(models.AgentCapability).filter(
+            models.AgentCapability.id == capability_id
+        )
+        result = await db.execute(query)
+        capability_obj = result.scalar_one_or_none()
+        if not capability_obj:
+            raise HTTPException(status_code=404, detail="Capability not found")
+        await db.delete(capability_obj)
+        await db.commit()
+        return {"success": True}
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"MCP delete capability failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/backend/routers/mcp/core.py
+++ b/backend/routers/mcp/core.py
@@ -25,6 +25,11 @@ from ....schemas.memory import (
     MemoryObservationCreate,
     MemoryRelationCreate
 )
+from ...mcp_tools.agent_capability_tools import (
+    create_capability_tool,
+    list_capabilities_tool,
+    delete_capability_tool,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["mcp-tools"])
@@ -657,10 +662,6 @@ async def mcp_create_mandate(
     mandate: UniversalMandateCreate,
     db: Session = Depends(get_db_session),
 ):
-async def mcp_create_mandate(
-    mandate: UniversalMandateCreate,
-    db: Session = Depends(get_db_session),
-):
     """MCP Tool: Create a new universal mandate."""
     try:
         rules_service = RulesService(db)
@@ -687,10 +688,6 @@ async def mcp_create_agent_rule(
     rule: AgentRuleCreate,
     db: Session = Depends(get_db_session),
 ):
-async def mcp_create_agent_rule(
-    rule: AgentRuleCreate,
-    db: Session = Depends(get_db_session),
-):
     """MCP Tool: Create a new agent-specific rule."""
     try:
         rules_service = RulesService(db)
@@ -706,3 +703,44 @@ async def mcp_create_agent_rule(
     except Exception as e:
         logger.error(f"MCP create agent rule failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/mcp-tools/rule/capability/create",
+    tags=["mcp-tools"],
+    operation_id="create_capability_tool",
+)
+async def mcp_create_capability(
+    agent_role_id: str,
+    capability: str,
+    description: Optional[str] = None,
+    db: Session = Depends(get_db_session),
+):
+    """MCP Tool: Create a new capability for an agent role."""
+    return await create_capability_tool(agent_role_id, capability, description, db)
+
+
+@router.get(
+    "/mcp-tools/rule/capability/list",
+    tags=["mcp-tools"],
+    operation_id="list_capabilities_tool",
+)
+async def mcp_list_capabilities(
+    agent_role_id: Optional[str] = Query(None),
+    db: Session = Depends(get_db_session),
+):
+    """MCP Tool: List capabilities, optionally by role."""
+    return await list_capabilities_tool(agent_role_id, db)
+
+
+@router.delete(
+    "/mcp-tools/rule/capability/delete",
+    tags=["mcp-tools"],
+    operation_id="delete_capability_tool",
+)
+async def mcp_delete_capability(
+    capability_id: str,
+    db: Session = Depends(get_db_session),
+):
+    """MCP Tool: Delete a capability by ID."""
+    return await delete_capability_tool(capability_id, db)


### PR DESCRIPTION
## Summary
- add tools for managing agent capabilities
- register capability tools in MCP router
- document capability management

## Testing
- `flake8 mcp_tools/agent_capability_tools.py routers/mcp/core.py`
- `pytest -q` *(fails: ModuleNotFoundError & AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_68416c08d154832c802cba0c6f9e2dea