### PR TITLE
Add verification requirements UI

### DIFF
--- a/frontend/src/components/agents/VerificationRequirements.tsx
+++ b/frontend/src/components/agents/VerificationRequirements.tsx
@@ -1,0 +1,224 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  IconButton,
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+  useDisclosure,
+  useToast,
+  FormControl,
+  FormLabel,
+  Input,
+  Switch,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalCloseButton,
+  ModalBody,
+  ModalFooter,
+} from "@chakra-ui/react";
+import { AddIcon, EditIcon, DeleteIcon } from "@chakra-ui/icons";
+import {
+  verificationRequirementsApi,
+} from "@/services/api";
+import type {
+  VerificationRequirement,
+  VerificationRequirementCreateData,
+  VerificationRequirementUpdateData,
+} from "@/types/verificationRequirement";
+
+interface Props {
+  agentRoleId: string;
+}
+
+const VerificationRequirements: React.FC<Props> = ({ agentRoleId }) => {
+  const [requirements, setRequirements] = useState<VerificationRequirement[]>([]);
+  const [formState, setFormState] = useState<VerificationRequirementCreateData>({
+    requirement: "",
+    description: "",
+    is_mandatory: true,
+  });
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const toast = useToast();
+
+  const loadRequirements = async () => {
+    try {
+      const data = await verificationRequirementsApi.list(agentRoleId);
+      setRequirements(data);
+    } catch (err) {
+      toast({
+        title: "Failed to load requirements",
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  useEffect(() => {
+    loadRequirements();
+  }, [agentRoleId]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value, type, checked } = e.target;
+    setFormState((s) => ({
+      ...s,
+      [name]: type === "checkbox" ? checked : value,
+    }));
+  };
+
+  const openCreate = () => {
+    setFormState({ requirement: "", description: "", is_mandatory: true });
+    setEditingId(null);
+    onOpen();
+  };
+
+  const openEdit = (req: VerificationRequirement) => {
+    setFormState({
+      requirement: req.requirement,
+      description: req.description ?? "",
+      is_mandatory: req.is_mandatory,
+    });
+    setEditingId(req.id);
+    onOpen();
+  };
+
+  const handleSubmit = async () => {
+    try {
+      if (editingId) {
+        const updated = await verificationRequirementsApi.update(
+          editingId,
+          formState as VerificationRequirementUpdateData,
+        );
+        setRequirements((r) => r.map((x) => (x.id === editingId ? updated : x)));
+        toast({ title: "Requirement updated", status: "success", duration: 3000 });
+      } else {
+        const created = await verificationRequirementsApi.create(agentRoleId, formState);
+        setRequirements((r) => [...r, created]);
+        toast({ title: "Requirement added", status: "success", duration: 3000 });
+      }
+      onClose();
+    } catch (err) {
+      toast({
+        title: "Error saving requirement",
+        description: err instanceof Error ? err.message : String(err),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await verificationRequirementsApi.remove(id);
+      setRequirements((r) => r.filter((req) => req.id !== id));
+      toast({ title: "Requirement deleted", status: "success", duration: 3000 });
+    } catch (err) {
+      toast({
+        title: "Error deleting requirement",
+        description: err instanceof Error ? err.message : String(err),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  return (
+    <Box>
+      <Button leftIcon={<AddIcon />} mb={4} onClick={openCreate}>
+        Add Requirement
+      </Button>
+      <Table variant="simple">
+        <Thead>
+          <Tr>
+            <Th>Requirement</Th>
+            <Th>Description</Th>
+            <Th>Mandatory</Th>
+            <Th>Actions</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {requirements.map((req) => (
+            <Tr key={req.id} data-testid="requirement-row">
+              <Td>{req.requirement}</Td>
+              <Td>{req.description}</Td>
+              <Td>{req.is_mandatory ? "Yes" : "No"}</Td>
+              <Td>
+                <IconButton
+                  aria-label="Edit"
+                  icon={<EditIcon />}
+                  size="sm"
+                  mr={2}
+                  onClick={() => openEdit(req)}
+                />
+                <IconButton
+                  aria-label="Delete"
+                  icon={<DeleteIcon />}
+                  size="sm"
+                  colorScheme="red"
+                  onClick={() => handleDelete(req.id)}
+                />
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>
+            {editingId ? "Edit Requirement" : "Add Requirement"}
+          </ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <FormControl mb={3}>
+              <FormLabel>Requirement</FormLabel>
+              <Input
+                name="requirement"
+                value={formState.requirement}
+                onChange={handleChange}
+              />
+            </FormControl>
+            <FormControl mb={3}>
+              <FormLabel>Description</FormLabel>
+              <Input
+                name="description"
+                value={formState.description || ""}
+                onChange={handleChange}
+              />
+            </FormControl>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0">Mandatory</FormLabel>
+              <Switch
+                name="is_mandatory"
+                isChecked={formState.is_mandatory}
+                onChange={handleChange}
+              />
+            </FormControl>
+          </ModalBody>
+          <ModalFooter>
+            <Button mr={3} onClick={onClose}>
+              Cancel
+            </Button>
+            <Button colorScheme="blue" onClick={handleSubmit}>
+              {editingId ? "Update" : "Create"}
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </Box>
+  );
+};
+
+export default VerificationRequirements;

--- a/frontend/src/components/agents/__tests__/VerificationRequirements.test.tsx
+++ b/frontend/src/components/agents/__tests__/VerificationRequirements.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor } from '@/__tests__/utils/test-utils';
+import VerificationRequirements from '../VerificationRequirements';
+import { verificationRequirementsApi } from '@/services/api/verificationRequirements';
+
+vi.mock('@/services/api/verificationRequirements', () => ({
+  verificationRequirementsApi: {
+    list: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+const mockedApi = vi.mocked(verificationRequirementsApi);
+
+describe('VerificationRequirements', () => {
+  const user = userEvent.setup();
+  const roleId = 'role1';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedApi.list.mockResolvedValue([]);
+  });
+
+  it('fetches requirements on mount', async () => {
+    render(<VerificationRequirements agentRoleId={roleId} />, { wrapper: TestWrapper });
+    await waitFor(() => {
+      expect(mockedApi.list).toHaveBeenCalledWith(roleId);
+    });
+  });
+
+  it('creates requirement through API', async () => {
+    mockedApi.create.mockResolvedValue({
+      id: '1',
+      agent_role_id: roleId,
+      requirement: 'Check',
+      description: '',
+      is_mandatory: true,
+    });
+    render(<VerificationRequirements agentRoleId={roleId} />, { wrapper: TestWrapper });
+    await user.click(screen.getByText(/add requirement/i));
+    await user.type(screen.getByLabelText(/requirement/i), 'Check');
+    await user.click(screen.getByText(/create/i));
+    await waitFor(() => {
+      expect(mockedApi.create).toHaveBeenCalledWith(roleId, {
+        requirement: 'Check',
+        description: '',
+        is_mandatory: true,
+      });
+    });
+  });
+
+  it('deletes requirement through API', async () => {
+    mockedApi.list.mockResolvedValueOnce([
+      { id: '1', agent_role_id: roleId, requirement: 'Test', description: '', is_mandatory: true },
+    ]);
+    mockedApi.remove.mockResolvedValue();
+    render(<VerificationRequirements agentRoleId={roleId} />, { wrapper: TestWrapper });
+    const deleteBtn = await screen.findByRole('button', { name: /delete/i });
+    await user.click(deleteBtn);
+    await waitFor(() => {
+      expect(mockedApi.remove).toHaveBeenCalledWith('1');
+    });
+  });
+});

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -11,3 +11,4 @@ export * from "./mcp";
 export * from "./users";
 export * from "./audit_logs";
 export * from "./project_templates";
+export * from "./verificationRequirements";

--- a/frontend/src/services/api/verificationRequirements.ts
+++ b/frontend/src/services/api/verificationRequirements.ts
@@ -1,0 +1,57 @@
+import { request } from './request';
+import { buildApiUrl, API_CONFIG } from './config';
+import type {
+  VerificationRequirement,
+  VerificationRequirementCreateData,
+  VerificationRequirementUpdateData,
+} from '@/types/verificationRequirement';
+
+export const verificationRequirementsApi = {
+  async list(agentRoleId: string): Promise<VerificationRequirement[]> {
+    return request(
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.RULES,
+        `/roles/${agentRoleId}/verification-requirements`
+      )
+    );
+  },
+  async create(
+    agentRoleId: string,
+    data: VerificationRequirementCreateData
+  ): Promise<VerificationRequirement> {
+    return request(
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.RULES,
+        `/roles/${agentRoleId}/verification-requirements`
+      ),
+      {
+        method: 'POST',
+        body: JSON.stringify(data),
+      }
+    );
+  },
+  async update(
+    id: string,
+    data: VerificationRequirementUpdateData
+  ): Promise<VerificationRequirement> {
+    return request(
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.RULES,
+        `/verification-requirements/${id}`
+      ),
+      {
+        method: 'PUT',
+        body: JSON.stringify(data),
+      }
+    );
+  },
+  async remove(id: string): Promise<void> {
+    await request(
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.RULES,
+        `/verification-requirements/${id}`
+      ),
+      { method: 'DELETE' }
+    );
+  },
+};

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -9,6 +9,7 @@ export * from "./rules";
 export * from "./mcp";
 export * from "./project_template";
 export * from "./agent_prompt_template";
+export * from "./verificationRequirement";
 
 // Common types used across the application
 // Canonical shared sort direction type for all entities

--- a/frontend/src/types/verificationRequirement.ts
+++ b/frontend/src/types/verificationRequirement.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+export const verificationRequirementBaseSchema = z.object({
+  requirement: z.string().min(1, 'Requirement is required'),
+  description: z.string().optional().nullable(),
+  is_mandatory: z.boolean().default(true),
+});
+
+export const verificationRequirementCreateSchema = verificationRequirementBaseSchema;
+export type VerificationRequirementCreateData = z.infer<typeof verificationRequirementCreateSchema>;
+
+export const verificationRequirementUpdateSchema = verificationRequirementBaseSchema.partial();
+export type VerificationRequirementUpdateData = z.infer<typeof verificationRequirementUpdateSchema>;
+
+export const verificationRequirementSchema = verificationRequirementBaseSchema.extend({
+  id: z.string(),
+  agent_role_id: z.string(),
+  created_at: z.string().datetime({ message: 'Invalid ISO datetime string' }).optional(),
+});
+
+export type VerificationRequirement = z.infer<typeof verificationRequirementSchema>;


### PR DESCRIPTION
## Summary
- add VerificationRequirements component for agents
- expose verification requirements API service
- define verification requirement types
- test API interactions for the component

## Testing
- `npm run lint`
- `npm test` *(fails: TypeError due to missing environment)*

------
https://chatgpt.com/codex/tasks/task_e_68416bfb9f8c832ca8d34922bca55a34