### PR TITLE
Add agent error protocol service and router

### DIFF
--- a/backend/routers/rules/__init__.py
+++ b/backend/routers/rules/__init__.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 from .workflows.workflows import router as workflows_router
 from .violations.violations import router as violations_router
+from .violations.error_protocols import router as error_protocols_router
 from .templates.templates import router as templates_router
 from .roles.roles import router as roles_router
 from .mandates.mandates import router as mandates_router
@@ -9,6 +10,7 @@ from .logs.logs import router as logs_router
 router = APIRouter()
 router.include_router(workflows_router)
 router.include_router(violations_router)
+router.include_router(error_protocols_router)
 router.include_router(templates_router)
 router.include_router(roles_router)
 router.include_router(mandates_router)

--- a/backend/routers/rules/violations/error_protocols.py
+++ b/backend/routers/rules/violations/error_protocols.py
@@ -1,0 +1,50 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from typing import List
+
+from ....database import get_db
+from ....crud import rules as crud_rules
+from ....schemas import rules as schemas
+
+router = APIRouter()
+
+
+@router.get('/roles/{role_id}', response_model=List[schemas.ErrorProtocol])
+async def get_error_protocols(role_id: str, db: AsyncSession = Depends(get_db)):
+    """Retrieve all error protocols for a specific agent role."""
+    role = await crud_rules.get_agent_role(db, role_id)
+    if not role:
+        raise HTTPException(status_code=404, detail='Agent role not found')
+    return role.error_protocols
+
+
+@router.post('/roles/{role_id}', response_model=schemas.ErrorProtocol)
+async def create_error_protocol(
+    role_id: str,
+    error_protocol: schemas.ErrorProtocolCreate,
+    db: AsyncSession = Depends(get_db),
+):
+    """Create a new error protocol for the given role."""
+    return await crud_rules.create_error_protocol(db, role_id, error_protocol)
+
+
+@router.put('/{protocol_id}', response_model=schemas.ErrorProtocol)
+async def update_error_protocol(
+    protocol_id: str,
+    protocol_update: schemas.ErrorProtocolUpdate,
+    db: AsyncSession = Depends(get_db),
+):
+    """Update an existing error protocol."""
+    result = await crud_rules.update_error_protocol(db, protocol_id, protocol_update)
+    if not result:
+        raise HTTPException(status_code=404, detail='Error protocol not found')
+    return result
+
+
+@router.delete('/{protocol_id}')
+async def delete_error_protocol(protocol_id: str, db: AsyncSession = Depends(get_db)):
+    """Delete an error protocol by ID."""
+    success = await crud_rules.delete_error_protocol(db, protocol_id)
+    if not success:
+        raise HTTPException(status_code=404, detail='Error protocol not found')
+    return {'detail': 'Error protocol deleted'}

--- a/backend/services/agent_error_protocol_service.py
+++ b/backend/services/agent_error_protocol_service.py
@@ -1,0 +1,40 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from typing import List, Optional
+
+from .. import models
+from ..crud import rules as crud_rules
+from ..schemas import rules as schemas
+
+
+class AgentErrorProtocolService:
+    """Service for managing agent error handling protocols."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def create_error_protocol(
+        self, role_id: str, error_protocol: schemas.ErrorProtocolCreate
+    ) -> models.AgentErrorProtocol:
+        """Create a new error protocol for the given agent role."""
+        return await crud_rules.create_error_protocol(
+            self.db, role_id, error_protocol
+        )
+
+    async def update_error_protocol(
+        self, protocol_id: str, protocol_update: schemas.ErrorProtocolUpdate
+    ) -> Optional[models.AgentErrorProtocol]:
+        """Update an existing error protocol."""
+        return await crud_rules.update_error_protocol(
+            self.db, protocol_id, protocol_update
+        )
+
+    async def delete_error_protocol(self, protocol_id: str) -> bool:
+        """Delete an error protocol by ID."""
+        return await crud_rules.delete_error_protocol(self.db, protocol_id)
+
+    async def get_error_protocols_for_role(
+        self, role_id: str
+    ) -> List[models.AgentErrorProtocol]:
+        """Retrieve all error protocols for a specific agent role."""
+        role = await crud_rules.get_agent_role(self.db, role_id)
+        return role.error_protocols if role else []


### PR DESCRIPTION
## Summary
- add a service for agent error protocol CRUD operations
- expose new `/rules/violations/error_protocols` API routes
- register the router in the rules package

## Testing
- `pytest -k rules_service -q`

------
https://chatgpt.com/codex/tasks/task_e_68416bfb32e0832c8a6bb972b848b178