### PR TITLE
Add user role API module

### DIFF
--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -11,3 +11,4 @@ export * from "./mcp";
 export * from "./users";
 export * from "./audit_logs";
 export * from "./project_templates";
+export * from "./user_roles";

--- a/frontend/src/services/api/user_roles.ts
+++ b/frontend/src/services/api/user_roles.ts
@@ -1,0 +1,38 @@
+import { request } from './request';
+import { buildApiUrl, API_CONFIG } from './config';
+import { UserRole, UserRoleObject, UserRoleAssignData } from '@/types/user';
+
+/**
+ * Assign a role to a user
+ */
+export const assignRole = async (
+  userId: string,
+  data: UserRoleAssignData
+): Promise<UserRoleObject> => {
+  return request<UserRoleObject>(
+    buildApiUrl(API_CONFIG.ENDPOINTS.USERS, `/${userId}/roles`),
+    { method: 'POST', body: JSON.stringify(data) }
+  );
+};
+
+/**
+ * List roles for a user
+ */
+export const listRoles = async (userId: string): Promise<UserRoleObject[]> => {
+  return request<UserRoleObject[]>(
+    buildApiUrl(API_CONFIG.ENDPOINTS.USERS, `/${userId}/roles`)
+  );
+};
+
+/**
+ * Remove a role from a user
+ */
+export const removeRole = async (
+  userId: string,
+  roleName: UserRole | string
+): Promise<void> => {
+  await request<void>(
+    buildApiUrl(API_CONFIG.ENDPOINTS.USERS, `/${userId}/roles/${roleName}`),
+    { method: 'DELETE' }
+  );
+};

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -18,6 +18,13 @@ export const userRoleObjectSchema = z.object({
 
 export type UserRoleObject = z.infer<typeof userRoleObjectSchema>;
 
+// Schema used when assigning a role to a user
+export const userRoleAssignSchema = z.object({
+  role_name: z.nativeEnum(UserRole),
+});
+
+export type UserRoleAssignData = z.infer<typeof userRoleAssignSchema>;
+
 // --- User Schemas ---
 export const userBaseSchema = z.object({
   username: z.string(),


### PR DESCRIPTION
## Summary
- add user role service wrappers
- update type definitions for user roles
- expose user role API from the index

## Testing
- `npm run lint`
- `npm run test:run` *(fails: observer.observe is not a function)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68416c0cfc18832cbd91370d54558938