### PR TITLE
Implement agent handoff criteria service and router

### DIFF
--- a/backend/routers/rules/__init__.py
+++ b/backend/routers/rules/__init__.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter
 from .workflows.workflows import router as workflows_router
 from .violations.violations import router as violations_router
 from .templates.templates import router as templates_router
-from .roles.roles import router as roles_router
+from .roles import router as roles_router
 from .mandates.mandates import router as mandates_router
 from .logs.logs import router as logs_router
 

--- a/backend/routers/rules/roles/__init__.py
+++ b/backend/routers/rules/roles/__init__.py
@@ -1,1 +1,12 @@
-# Rules module\n
+from fastapi import APIRouter
+
+from .roles import router as roles_router
+from .capabilities import router as capabilities_router
+from .forbidden_actions import router as forbidden_actions_router
+from .handoff_criteria import router as handoff_criteria_router
+
+router = APIRouter()
+router.include_router(roles_router)
+router.include_router(capabilities_router)
+router.include_router(forbidden_actions_router)
+router.include_router(handoff_criteria_router, prefix="/handoff-criteria")

--- a/backend/routers/rules/roles/handoff_criteria.py
+++ b/backend/routers/rules/roles/handoff_criteria.py
@@ -1,0 +1,51 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from typing import List, Optional
+
+from ....database import get_sync_db as get_db
+from ....schemas.agent_handoff_criteria import (
+    AgentHandoffCriteria,
+    AgentHandoffCriteriaCreate,
+    AgentHandoffCriteriaUpdate,
+)
+from ....services.agent_handoff_service import AgentHandoffService
+
+router = APIRouter()
+
+
+@router.post("/", response_model=AgentHandoffCriteria)
+def create_handoff_criteria(
+    criteria: AgentHandoffCriteriaCreate, db: Session = Depends(get_db)
+):
+    service = AgentHandoffService(db)
+    return service.create_criteria(criteria)
+
+
+@router.get("/", response_model=List[AgentHandoffCriteria])
+def list_handoff_criteria(
+    agent_role_id: Optional[str] = None, db: Session = Depends(get_db)
+):
+    service = AgentHandoffService(db)
+    return service.get_criteria_list(agent_role_id)
+
+
+@router.put("/{criteria_id}", response_model=AgentHandoffCriteria)
+def update_handoff_criteria(
+    criteria_id: str,
+    criteria_update: AgentHandoffCriteriaUpdate,
+    db: Session = Depends(get_db),
+):
+    service = AgentHandoffService(db)
+    updated = service.update_criteria(criteria_id, criteria_update)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Handoff criteria not found")
+    return updated
+
+
+@router.delete("/{criteria_id}")
+def delete_handoff_criteria(criteria_id: str, db: Session = Depends(get_db)):
+    service = AgentHandoffService(db)
+    success = service.delete_criteria(criteria_id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Handoff criteria not found")
+    return {"message": "Handoff criteria deleted"}

--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -75,3 +75,8 @@ from .memory import (
     MemoryRelation,
 )
 from .file_ingest import FileIngestInput
+from .agent_handoff_criteria import (
+    AgentHandoffCriteria,
+    AgentHandoffCriteriaCreate,
+    AgentHandoffCriteriaUpdate,
+)

--- a/backend/schemas/agent_handoff_criteria.py
+++ b/backend/schemas/agent_handoff_criteria.py
@@ -1,0 +1,35 @@
+from pydantic import BaseModel, ConfigDict, Field
+from typing import Optional
+from datetime import datetime
+
+
+class AgentHandoffCriteriaBase(BaseModel):
+    """Base attributes for agent handoff criteria."""
+    criteria: str = Field(..., description="Condition that triggers a handoff.")
+    description: Optional[str] = Field(None, description="Details about the criteria.")
+    target_agent_role: Optional[str] = Field(
+        None, description="Agent role that should take over when criteria match."
+    )
+    is_active: bool = Field(True, description="Whether the criteria is active.")
+
+
+class AgentHandoffCriteriaCreate(AgentHandoffCriteriaBase):
+    """Schema for creating a handoff criteria."""
+    agent_role_id: str = Field(..., description="ID of the owning agent role.")
+
+
+class AgentHandoffCriteriaUpdate(BaseModel):
+    """Schema for updating a handoff criteria."""
+    criteria: Optional[str] = Field(None, description="Updated criteria.")
+    description: Optional[str] = Field(None, description="Updated description.")
+    target_agent_role: Optional[str] = Field(None, description="Updated target role.")
+    is_active: Optional[bool] = Field(None, description="Updated active status.")
+
+
+class AgentHandoffCriteria(AgentHandoffCriteriaBase):
+    """Representation of handoff criteria."""
+    id: str = Field(..., description="Unique identifier.")
+    agent_role_id: str = Field(..., description="ID of the owning agent role.")
+    created_at: datetime = Field(..., description="Creation timestamp.")
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/services/agent_handoff_service.py
+++ b/backend/services/agent_handoff_service.py
@@ -1,0 +1,68 @@
+from sqlalchemy.orm import Session
+from typing import List, Optional
+
+from .. import models
+from ..schemas.agent_handoff_criteria import (
+    AgentHandoffCriteriaCreate,
+    AgentHandoffCriteriaUpdate,
+)
+
+
+class AgentHandoffService:
+    """Service for CRUD operations on AgentHandoffCriteria."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create_criteria(
+        self, criteria_in: AgentHandoffCriteriaCreate
+    ) -> models.AgentHandoffCriteria:
+        db_obj = models.AgentHandoffCriteria(
+            agent_role_id=criteria_in.agent_role_id,
+            criteria=criteria_in.criteria,
+            description=criteria_in.description,
+            target_agent_role=criteria_in.target_agent_role,
+            is_active=criteria_in.is_active,
+        )
+        self.db.add(db_obj)
+        self.db.commit()
+        self.db.refresh(db_obj)
+        return db_obj
+
+    def get_criteria(self, criteria_id: str) -> Optional[models.AgentHandoffCriteria]:
+        return (
+            self.db.query(models.AgentHandoffCriteria)
+            .filter(models.AgentHandoffCriteria.id == criteria_id)
+            .first()
+        )
+
+    def get_criteria_list(
+        self, agent_role_id: Optional[str] = None
+    ) -> List[models.AgentHandoffCriteria]:
+        query = self.db.query(models.AgentHandoffCriteria)
+        if agent_role_id:
+            query = query.filter(
+                models.AgentHandoffCriteria.agent_role_id == agent_role_id
+            )
+        return query.all()
+
+    def update_criteria(
+        self, criteria_id: str, criteria_update: AgentHandoffCriteriaUpdate
+    ) -> Optional[models.AgentHandoffCriteria]:
+        db_obj = self.get_criteria(criteria_id)
+        if not db_obj:
+            return None
+        update_data = criteria_update.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(db_obj, field, value)
+        self.db.commit()
+        self.db.refresh(db_obj)
+        return db_obj
+
+    def delete_criteria(self, criteria_id: str) -> bool:
+        db_obj = self.get_criteria(criteria_id)
+        if not db_obj:
+            return False
+        self.db.delete(db_obj)
+        self.db.commit()
+        return True


### PR DESCRIPTION
## Summary
- add schemas for handoff criteria
- implement AgentHandoffService with CRUD helpers
- expose /handoff-criteria endpoints
- register router with rule routes

## Testing
- `flake8 services/agent_handoff_service.py routers/rules/roles/handoff_criteria.py schemas/agent_handoff_criteria.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_68416c064108832cbefa330ee15c65b0