### PR TITLE
Add criteria API utilities

### DIFF
--- a/frontend/src/services/api/agents.ts
+++ b/frontend/src/services/api/agents.ts
@@ -8,9 +8,12 @@ import {
   AgentUnarchiveResponse,
   AgentRuleAddResponse,
   AgentRuleRemoveResponse,
-} from "@/types";
-import { request } from "./request";
-import { buildApiUrl, API_CONFIG } from "./config";
+  Criteria,
+  CriteriaCreateData,
+  CriteriaUpdateData,
+} from '@/types';
+import { request } from './request';
+import { buildApiUrl, API_CONFIG } from './config';
 
 // Intermediate raw type for agents from backend
 interface RawAgent {
@@ -25,20 +28,27 @@ interface RawAgent {
 }
 
 // Fetch all agents
-export const getAgents = async (skip: number = 0, limit: number = 100, search?: string, status?: string, is_archived?: boolean): Promise<Agent[]> => {
+export const getAgents = async (
+  skip: number = 0,
+  limit: number = 100,
+  search?: string,
+  status?: string,
+  is_archived?: boolean
+): Promise<Agent[]> => {
   const queryParams = new URLSearchParams();
-  queryParams.append("skip", String(skip));
-  queryParams.append("limit", String(limit));
-  if (search !== undefined) queryParams.append("search", search);
-  if (status !== undefined) queryParams.append("status", status);
-  if (is_archived !== undefined) queryParams.append("is_archived", String(is_archived));
+  queryParams.append('skip', String(skip));
+  queryParams.append('limit', String(limit));
+  if (search !== undefined) queryParams.append('search', search);
+  if (status !== undefined) queryParams.append('status', status);
+  if (is_archived !== undefined)
+    queryParams.append('is_archived', String(is_archived));
   const queryString = queryParams.toString();
   const url = buildApiUrl(API_CONFIG.ENDPOINTS.AGENTS, `?${queryString}`);
   const rawAgents = await request<RawAgent[]>(url);
   return rawAgents.map((rawAgent) => ({
     ...rawAgent,
     id: String(rawAgent.id),
-    name: String(rawAgent.name || ""),
+    name: String(rawAgent.name || ''),
     created_at: String(rawAgent.created_at || new Date().toISOString()),
     is_archived: (rawAgent as any).is_archived ?? false,
     // Include new fields in the mapping
@@ -55,7 +65,7 @@ export const getAgentById = async (agent_id: string): Promise<Agent> => {
   return {
     ...rawAgent,
     id: String(rawAgent.id),
-    name: String(rawAgent.name || ""),
+    name: String(rawAgent.name || ''),
     created_at: String(rawAgent.created_at || new Date().toISOString()),
     is_archived: (rawAgent as any).is_archived ?? false,
   };
@@ -68,21 +78,23 @@ export const getAgentByName = async (agent_name: string): Promise<Agent> => {
   return {
     ...rawAgent,
     id: String(rawAgent.id),
-    name: String(rawAgent.name || ""),
+    name: String(rawAgent.name || ''),
     created_at: String(rawAgent.created_at || new Date().toISOString()),
     is_archived: (rawAgent as any).is_archived ?? false,
   };
 };
 
-export const createAgent = async (agentData: AgentCreateData): Promise<Agent> => {
+export const createAgent = async (
+  agentData: AgentCreateData
+): Promise<Agent> => {
   const rawAgent = await request<RawAgent>(
-    buildApiUrl(API_CONFIG.ENDPOINTS.AGENTS, "/"),
-    { method: "POST", body: JSON.stringify(agentData) },
+    buildApiUrl(API_CONFIG.ENDPOINTS.AGENTS, '/'),
+    { method: 'POST', body: JSON.stringify(agentData) }
   );
   return {
     ...rawAgent,
     id: String(rawAgent.id),
-    name: String(rawAgent.name || ""),
+    name: String(rawAgent.name || ''),
     created_at: String(rawAgent.created_at || new Date().toISOString()),
     is_archived: (rawAgent as any).is_archived ?? false,
   };
@@ -90,16 +102,16 @@ export const createAgent = async (agentData: AgentCreateData): Promise<Agent> =>
 
 export const updateAgentById = async (
   agent_id: string,
-  agentData: AgentUpdateDataType,
+  agentData: AgentUpdateDataType
 ): Promise<Agent> => {
   const rawAgent = await request<RawAgent>(
     buildApiUrl(API_CONFIG.ENDPOINTS.AGENTS, `/${agent_id}`),
-    { method: "PUT", body: JSON.stringify(agentData) },
+    { method: 'PUT', body: JSON.stringify(agentData) }
   );
   return {
     ...rawAgent,
     id: String(rawAgent.id),
-    name: String(rawAgent.name || ""),
+    name: String(rawAgent.name || ''),
     created_at: String(rawAgent.created_at || new Date().toISOString()),
     is_archived: (rawAgent as any).is_archived ?? false,
   };
@@ -108,41 +120,118 @@ export const updateAgentById = async (
 export const deleteAgentById = async (agent_id: string): Promise<null> => {
   await request<null>(
     buildApiUrl(API_CONFIG.ENDPOINTS.AGENTS, `/${agent_id}`),
-    { method: "DELETE" },
+    { method: 'DELETE' }
   );
   return null;
 };
 
-export const archiveAgent = async (agentId: string): Promise<AgentArchiveResponse> => {
+export const archiveAgent = async (
+  agentId: string
+): Promise<AgentArchiveResponse> => {
   return request<AgentArchiveResponse>(
-    buildApiUrl(API_CONFIG.ENDPOINTS.AGENTS, `/${agentId}/archive`), 
-    { method: "POST" }
+    buildApiUrl(API_CONFIG.ENDPOINTS.AGENTS, `/${agentId}/archive`),
+    { method: 'POST' }
   );
 };
 
-export const unarchiveAgent = async (agentId: string): Promise<AgentUnarchiveResponse> => {
+export const unarchiveAgent = async (
+  agentId: string
+): Promise<AgentUnarchiveResponse> => {
   return request<AgentUnarchiveResponse>(
-    buildApiUrl(API_CONFIG.ENDPOINTS.AGENTS, `/${agentId}/unarchive`), 
-    { method: "POST" }
+    buildApiUrl(API_CONFIG.ENDPOINTS.AGENTS, `/${agentId}/unarchive`),
+    { method: 'POST' }
   );
 };
 
-export const addRuleToAgent = async (agentId: string, ruleId: string): Promise<AgentRuleAddResponse> => {
+export const addRuleToAgent = async (
+  agentId: string,
+  ruleId: string
+): Promise<AgentRuleAddResponse> => {
   return request<AgentRuleAddResponse>(
-    buildApiUrl(API_CONFIG.ENDPOINTS.AGENTS, `/${agentId}/rules/`), 
-    { method: "POST", body: JSON.stringify({ rule_id: ruleId }) }
+    buildApiUrl(API_CONFIG.ENDPOINTS.AGENTS, `/${agentId}/rules/`),
+    { method: 'POST', body: JSON.stringify({ rule_id: ruleId }) }
   );
 };
 
-export const removeRuleFromAgent = async (agentId: string, ruleId: string): Promise<AgentRuleRemoveResponse> => {
+export const removeRuleFromAgent = async (
+  agentId: string,
+  ruleId: string
+): Promise<AgentRuleRemoveResponse> => {
   return request<AgentRuleRemoveResponse>(
-    buildApiUrl(API_CONFIG.ENDPOINTS.AGENTS, `/${agentId}/rules/${ruleId}`), 
-    { method: "DELETE" }
+    buildApiUrl(API_CONFIG.ENDPOINTS.AGENTS, `/${agentId}/rules/${ruleId}`),
+    { method: 'DELETE' }
   );
 };
 
 export const getAgentRules = async (agentId: string): Promise<AgentRule[]> => {
   return request<AgentRule[]>(
     buildApiUrl(API_CONFIG.ENDPOINTS.AGENTS, `/${agentId}/rules/`)
+  );
+};
+
+// ----- Agent Handoff Criteria API -----
+interface RawCriteria {
+  id: string | number;
+  agent_role_id: string | number;
+  criteria: string;
+  description?: string | null;
+  target_agent_role?: string | null;
+  is_active?: boolean | null;
+  created_at?: string | null;
+  [key: string]: unknown;
+}
+
+const mapCriteria = (raw: RawCriteria): Criteria => ({
+  ...raw,
+  id: String(raw.id),
+  agent_role_id: String(raw.agent_role_id),
+  criteria: String(raw.criteria),
+  description: raw.description ? String(raw.description) : null,
+  target_agent_role: raw.target_agent_role
+    ? String(raw.target_agent_role)
+    : null,
+  is_active: raw.is_active !== undefined ? Boolean(raw.is_active) : true,
+  created_at: String(raw.created_at || new Date().toISOString()),
+});
+
+export const createCriteria = async (
+  roleId: string,
+  data: CriteriaCreateData
+): Promise<Criteria> => {
+  const raw = await request<RawCriteria>(
+    buildApiUrl(
+      API_CONFIG.ENDPOINTS.AGENTS,
+      `/roles/${roleId}/handoff-criteria`
+    ),
+    { method: 'POST', body: JSON.stringify(data) }
+  );
+  return mapCriteria(raw);
+};
+
+export const listCriteria = async (roleId: string): Promise<Criteria[]> => {
+  const raw = await request<RawCriteria[]>(
+    buildApiUrl(
+      API_CONFIG.ENDPOINTS.AGENTS,
+      `/roles/${roleId}/handoff-criteria`
+    )
+  );
+  return raw.map(mapCriteria);
+};
+
+export const updateCriteria = async (
+  criteriaId: string,
+  data: CriteriaUpdateData
+): Promise<Criteria> => {
+  const raw = await request<RawCriteria>(
+    buildApiUrl(API_CONFIG.ENDPOINTS.AGENTS, `/handoff-criteria/${criteriaId}`),
+    { method: 'PUT', body: JSON.stringify(data) }
+  );
+  return mapCriteria(raw);
+};
+
+export const deleteCriteria = async (criteriaId: string): Promise<void> => {
+  await request<void>(
+    buildApiUrl(API_CONFIG.ENDPOINTS.AGENTS, `/handoff-criteria/${criteriaId}`),
+    { method: 'DELETE' }
   );
 };

--- a/frontend/src/types/agents.ts
+++ b/frontend/src/types/agents.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+export const criteriaBaseSchema = z.object({
+  agent_role_id: z.string(),
+  criteria: z.string().min(1, 'Criteria is required'),
+  description: z.string().nullable().optional(),
+  target_agent_role: z.string().nullable().optional(),
+  is_active: z.boolean().default(true),
+});
+
+export const criteriaCreateSchema = criteriaBaseSchema.omit({
+  is_active: true,
+});
+
+export type CriteriaCreateData = z.infer<typeof criteriaCreateSchema>;
+
+export const criteriaUpdateSchema = criteriaBaseSchema.partial();
+
+export type CriteriaUpdateData = z.infer<typeof criteriaUpdateSchema>;
+
+export const criteriaSchema = criteriaBaseSchema.extend({
+  id: z.string(),
+  created_at: z.string().datetime({ message: 'Invalid ISO datetime string' }),
+});
+
+export type Criteria = z.infer<typeof criteriaSchema>;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,18 +1,19 @@
-export * from "./project";
-export * from "./agent";
-export * from "./task";
-export * from "./user";
-export * from "./audit_log";
-export * from "./memory";
-export * from "./comment";
-export * from "./rules";
-export * from "./mcp";
-export * from "./project_template";
-export * from "./agent_prompt_template";
+export * from './project';
+export * from './agent';
+export * from './agents';
+export * from './task';
+export * from './user';
+export * from './audit_log';
+export * from './memory';
+export * from './comment';
+export * from './rules';
+export * from './mcp';
+export * from './project_template';
+export * from './agent_prompt_template';
 
 // Common types used across the application
 // Canonical shared sort direction type for all entities
-export type SortDirection = "asc" | "desc";
+export type SortDirection = 'asc' | 'desc';
 
 export interface PaginationParams {
   page: number;
@@ -35,10 +36,10 @@ export interface ApiListResponse<T> extends ApiResponse<T[]> {
 }
 
 // Theme types
-export type ThemeMode = "light" | "dark" | "system";
+export type ThemeMode = 'light' | 'dark' | 'system';
 
 // Toast types
-export type ToastType = "success" | "error" | "warning" | "info";
+export type ToastType = 'success' | 'error' | 'warning' | 'info';
 
 export interface ToastMessage {
   id: string;
@@ -48,7 +49,13 @@ export interface ToastMessage {
 }
 
 // Canonical task sort field type (should match all UI/usage fields)
-export type TaskSortField = "created_at" | "title" | "status" | "agent" | "project_id" | "updated_at";
+export type TaskSortField =
+  | 'created_at'
+  | 'title'
+  | 'status'
+  | 'agent'
+  | 'project_id'
+  | 'updated_at';
 
 // Canonical task sort options type
 export interface TaskSortOptions {
@@ -57,5 +64,5 @@ export interface TaskSortOptions {
 }
 
 // Add shared types for group by and view mode
-export type GroupByType = "status" | "project" | "agent" | "parent";
-export type ViewMode = "list" | "kanban";
+export type GroupByType = 'status' | 'project' | 'agent' | 'parent';
+export type ViewMode = 'list' | 'kanban';


### PR DESCRIPTION
## Summary
- add Handoff Criteria interfaces for agents
- expose new type exports
- implement `createCriteria`, `listCriteria`, `updateCriteria`, `deleteCriteria` API functions

## Testing
- `npx prettier -w frontend/src/types/agents.ts frontend/src/types/index.ts frontend/src/services/api/agents.ts`
- `npm --prefix frontend run type-check` *(fails: Module errors)*
- `npm --prefix frontend test` *(fails: observer.observe is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68416c04e2f0832caca26b19963abb83