### PR TITLE
Add workflow API utilities

### DIFF
--- a/frontend/src/services/api/__tests__/workflows.test.ts
+++ b/frontend/src/services/api/__tests__/workflows.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { workflowsApi } from '../workflows';
+import { buildApiUrl, API_CONFIG } from '../config';
+import { request } from '../request';
+
+vi.mock('../request', () => ({ request: vi.fn() }));
+const requestMock = request as unknown as vi.Mock;
+
+describe('workflowsApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requestMock.mockResolvedValue(undefined);
+  });
+
+  it('list builds correct query', async () => {
+    await workflowsApi.list({ workflow_type: 'demo', active_only: false });
+    expect(requestMock).toHaveBeenCalledWith(
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.RULES,
+        '/workflows?workflow_type=demo&active_only=false'
+      )
+    );
+  });
+
+  it('get calls correct url', async () => {
+    await workflowsApi.get('abc');
+    expect(requestMock).toHaveBeenCalledWith(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, '/workflows/abc')
+    );
+  });
+
+  it('create posts to correct url', async () => {
+    await workflowsApi.create({
+      name: 'n',
+      workflow_type: 't',
+      is_active: true,
+    });
+    expect(requestMock).toHaveBeenCalledWith(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, '/workflows'),
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('update puts to correct url', async () => {
+    await workflowsApi.update('abc', { name: 'u' });
+    expect(requestMock).toHaveBeenCalledWith(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, '/workflows/abc'),
+      expect.objectContaining({ method: 'PUT' })
+    );
+  });
+
+  it('delete sends delete request', async () => {
+    await workflowsApi.delete('abc');
+    expect(requestMock).toHaveBeenCalledWith(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, '/workflows/abc'),
+      expect.objectContaining({ method: 'DELETE' })
+    );
+  });
+});

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -11,3 +11,4 @@ export * from "./mcp";
 export * from "./users";
 export * from "./audit_logs";
 export * from "./project_templates";
+export * from "./workflows";

--- a/frontend/src/services/api/workflows.ts
+++ b/frontend/src/services/api/workflows.ts
@@ -1,0 +1,58 @@
+import { request } from './request';
+import { buildApiUrl, API_CONFIG } from './config';
+import type {
+  Workflow,
+  WorkflowCreateData,
+  WorkflowUpdateData,
+} from '@/types/workflow';
+
+export const workflowsApi = {
+  async list(filters?: {
+    workflow_type?: string;
+    active_only?: boolean;
+  }): Promise<Workflow[]> {
+    const params = new URLSearchParams();
+    if (filters?.workflow_type)
+      params.append('workflow_type', filters.workflow_type);
+    if (filters?.active_only !== undefined) {
+      params.append('active_only', String(filters.active_only));
+    }
+    const query = params.toString();
+    return request<Workflow[]>(
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.RULES,
+        `/workflows${query ? `?${query}` : ''}`
+      )
+    );
+  },
+
+  async get(id: string): Promise<Workflow> {
+    return request<Workflow>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/workflows/${id}`)
+    );
+  },
+
+  async create(data: WorkflowCreateData): Promise<Workflow> {
+    return request<Workflow>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, '/workflows'),
+      {
+        method: 'POST',
+        body: JSON.stringify(data),
+      }
+    );
+  },
+
+  async update(id: string, data: WorkflowUpdateData): Promise<Workflow> {
+    return request<Workflow>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/workflows/${id}`),
+      { method: 'PUT', body: JSON.stringify(data) }
+    );
+  },
+
+  async delete(id: string): Promise<{ message: string }> {
+    return request<{ message: string }>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/workflows/${id}`),
+      { method: 'DELETE' }
+    );
+  },
+};

--- a/frontend/src/types/README.md
+++ b/frontend/src/types/README.md
@@ -67,6 +67,15 @@ This directory centralizes all TypeScript type definitions, interfaces, enums, a
   - `TaskSortOptions`: Interface for task sorting options.
   - `TaskError`, `TaskResponse`, `TaskListResponse`: API-related types for tasks.
 
+### `workflow.ts`
+
+- **Purpose**: Defines schemas and types for **Workflows** and their steps.
+- **Key Exports**:
+  - `workflowSchema`, `Workflow`: Base workflow representation.
+  - `workflowCreateSchema`, `WorkflowCreateData`: For creating workflows.
+  - `workflowUpdateSchema`, `WorkflowUpdateData`: For updating workflows.
+  - `workflowStepSchema`, `WorkflowStep`: Represents individual workflow steps.
+
 ## Architecture Diagram
 ```mermaid
 graph TD
@@ -91,6 +100,7 @@ graph TD
 - `rules.ts`
 - `task.ts`
 - `user.ts`
+- `workflow.ts`
 
 <!-- File List End -->
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -9,6 +9,7 @@ export * from "./rules";
 export * from "./mcp";
 export * from "./project_template";
 export * from "./agent_prompt_template";
+export * from "./workflow";
 
 // Common types used across the application
 // Canonical shared sort direction type for all entities

--- a/frontend/src/types/workflow.ts
+++ b/frontend/src/types/workflow.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+
+export const workflowBaseSchema = z.object({
+  name: z.string(),
+  description: z.string().nullable().optional(),
+  workflow_type: z.string(),
+  entry_criteria: z.string().nullable().optional(),
+  success_criteria: z.string().nullable().optional(),
+  is_active: z.boolean().default(true),
+});
+
+export const workflowCreateSchema = workflowBaseSchema;
+export type WorkflowCreateData = z.infer<typeof workflowCreateSchema>;
+
+export const workflowUpdateSchema = workflowBaseSchema.partial();
+export type WorkflowUpdateData = z.infer<typeof workflowUpdateSchema>;
+
+export const workflowSchema = workflowBaseSchema.extend({
+  id: z.string(),
+  created_at: z.string().datetime({ message: 'Invalid ISO datetime string' }),
+  updated_at: z.string().datetime({ message: 'Invalid ISO datetime string' }),
+});
+export type Workflow = z.infer<typeof workflowSchema>;
+
+export const workflowStepBaseSchema = z.object({
+  workflow_id: z.string(),
+  agent_role_id: z.string(),
+  step_order: z.number(),
+  title: z.string(),
+  description: z.string().nullable().optional(),
+  prerequisites: z.string().nullable().optional(),
+  expected_outputs: z.string().nullable().optional(),
+  verification_points: z.string().nullable().optional(),
+  estimated_duration_minutes: z.number().nullable().optional(),
+  is_active: z.boolean().default(true),
+});
+
+export const workflowStepCreateSchema = workflowStepBaseSchema;
+export type WorkflowStepCreateData = z.infer<typeof workflowStepCreateSchema>;
+
+export const workflowStepUpdateSchema = workflowStepBaseSchema.partial();
+export type WorkflowStepUpdateData = z.infer<typeof workflowStepUpdateSchema>;
+
+export const workflowStepSchema = workflowStepBaseSchema.extend({
+  id: z.string(),
+  created_at: z.string().datetime({ message: 'Invalid ISO datetime string' }),
+  updated_at: z.string().datetime({ message: 'Invalid ISO datetime string' }),
+});
+export type WorkflowStep = z.infer<typeof workflowStepSchema>;


### PR DESCRIPTION
## Summary
- add workflow API client with typed CRUD calls
- define workflow and step interfaces
- expose workflow API through index exports
- document workflow types in README
- unit test workflow API helper

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test:run` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416c015820832c9eb717ab2d949fa9