### PR TITLE
Add forbidden action MCP tools

### DIFF
--- a/backend/docs/fastapi_mcp/README.md
+++ b/backend/docs/fastapi_mcp/README.md
@@ -93,6 +93,8 @@ FastAPI-MCP automatically exposes selected API endpoints as tools under the `/mc
 - `/mcp-tools/memory/add-observation` (POST)
 - `/mcp-tools/memory/add-relation` (POST)
 - `/mcp-tools/memory/search` (GET)
+- `/mcp-tools/rule/forbidden/add` (POST)
+- `/mcp-tools/rule/forbidden/list` (GET)
 
 ## Development and Contributing
 

--- a/backend/mcp_tools/__init__.py
+++ b/backend/mcp_tools/__init__.py
@@ -12,5 +12,7 @@ __all__ = [
     'search_memory_tool',
     'add_project_file_tool',
     'list_project_files_tool',
-    'remove_project_file_tool'
+    'remove_project_file_tool',
+    'add_forbidden_action_tool',
+    'list_forbidden_actions_tool'
 ]

--- a/backend/mcp_tools/forbidden_action_tools.py
+++ b/backend/mcp_tools/forbidden_action_tools.py
@@ -1,0 +1,72 @@
+"""MCP Tools for managing forbidden actions."""
+
+import logging
+from typing import Optional, List
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from backend.models.agent_forbidden_action import AgentForbiddenAction
+
+logger = logging.getLogger(__name__)
+
+
+async def add_forbidden_action_tool(
+    agent_role_id: str,
+    action: str,
+    reason: Optional[str],
+    db: Session,
+) -> dict:
+    """Add a forbidden action to an agent role."""
+    try:
+        forbidden_action = AgentForbiddenAction(
+            agent_role_id=agent_role_id,
+            action=action,
+            reason=reason,
+        )
+        db.add(forbidden_action)
+        db.commit()
+        db.refresh(forbidden_action)
+        return {
+            "success": True,
+            "forbidden_action": {
+                "id": forbidden_action.id,
+                "agent_role_id": forbidden_action.agent_role_id,
+                "action": forbidden_action.action,
+                "reason": forbidden_action.reason,
+                "is_active": forbidden_action.is_active,
+            },
+        }
+    except Exception as exc:  # pragma: no cover - unexpected DB failure
+        logger.error(f"MCP add forbidden action failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+async def list_forbidden_actions_tool(
+    agent_role_id: Optional[str],
+    skip: int,
+    limit: int,
+    db: Session,
+) -> dict:
+    """List forbidden actions for an agent role."""
+    try:
+        query = db.query(AgentForbiddenAction)
+        if agent_role_id:
+            query = query.filter(AgentForbiddenAction.agent_role_id == agent_role_id)
+        actions: List[AgentForbiddenAction] = query.offset(skip).limit(limit).all()
+        return {
+            "success": True,
+            "forbidden_actions": [
+                {
+                    "id": a.id,
+                    "agent_role_id": a.agent_role_id,
+                    "action": a.action,
+                    "reason": a.reason,
+                    "is_active": a.is_active,
+                }
+                for a in actions
+            ],
+        }
+    except Exception as exc:  # pragma: no cover - unexpected DB failure
+        logger.error(f"MCP list forbidden actions failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/backend/routers/mcp/core.py
+++ b/backend/routers/mcp/core.py
@@ -19,6 +19,10 @@ from ....schemas.project import ProjectCreate
 from ....schemas.task import TaskCreate
 from ....schemas import AgentRuleCreate
 from ....schemas.universal_mandate import UniversalMandateCreate
+from ....mcp_tools.forbidden_action_tools import (
+    add_forbidden_action_tool,
+    list_forbidden_actions_tool,
+)
 from ....schemas.memory import (
     MemoryEntityCreate,
     MemoryEntityUpdate,
@@ -706,3 +710,33 @@ async def mcp_create_agent_rule(
     except Exception as e:
         logger.error(f"MCP create agent rule failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/mcp-tools/rule/forbidden/add",
+    tags=["mcp-tools"],
+    operation_id="add_forbidden_action_tool",
+)
+async def mcp_add_forbidden_action(
+    agent_role_id: str,
+    action: str,
+    reason: Optional[str] = None,
+    db: Session = Depends(get_db_session),
+):
+    """MCP Tool: Add a forbidden action to an agent role."""
+    return await add_forbidden_action_tool(agent_role_id, action, reason, db)
+
+
+@router.get(
+    "/mcp-tools/rule/forbidden/list",
+    tags=["mcp-tools"],
+    operation_id="list_forbidden_actions_tool",
+)
+async def mcp_list_forbidden_actions(
+    agent_role_id: Optional[str] = None,
+    skip: int = 0,
+    limit: int = 100,
+    db: Session = Depends(get_db_session),
+):
+    """MCP Tool: List forbidden actions for an agent role."""
+    return await list_forbidden_actions_tool(agent_role_id, skip, limit, db)


### PR DESCRIPTION
## Summary
- provide forbidden action tools for MCP
- expose forbidden action tools via router
- document new tool routes in fastapi-mcp docs

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68416bffaed4832caf582408745c6fc0