### PR TITLE
Add ErrorProtocol manager UI

### DIFF
--- a/frontend/src/components/agents/ErrorProtocolManager.tsx
+++ b/frontend/src/components/agents/ErrorProtocolManager.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Flex,
+  Input,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  useToast,
+} from "@chakra-ui/react";
+import type { ErrorProtocol } from "@/types/error_protocol";
+import { errorProtocolsApi } from "@/services/api/errorProtocols";
+
+interface ErrorProtocolManagerProps {
+  agentRoleId: string;
+}
+
+const ErrorProtocolManager: React.FC<ErrorProtocolManagerProps> = ({ agentRoleId }) => {
+  const [protocols, setProtocols] = useState<ErrorProtocol[]>([]);
+  const [errorType, setErrorType] = useState("");
+  const [protocolText, setProtocolText] = useState("");
+  const toast = useToast();
+
+  const fetchProtocols = async () => {
+    try {
+      const list = await errorProtocolsApi.list(agentRoleId);
+      setProtocols(list);
+    } catch (err) {
+      toast({
+        title: "Failed to fetch protocols",
+        description: err instanceof Error ? err.message : String(err),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  useEffect(() => {
+    fetchProtocols();
+  }, [agentRoleId]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!errorType.trim() || !protocolText.trim()) return;
+    try {
+      const created = await errorProtocolsApi.create(agentRoleId, {
+        error_type: errorType,
+        protocol: protocolText,
+        priority: 5,
+        is_active: true,
+      });
+      setProtocols((prev) => [...prev, created]);
+      setErrorType("");
+      setProtocolText("");
+      toast({ title: "Protocol added", status: "success", duration: 3000, isClosable: true });
+    } catch (err) {
+      toast({
+        title: "Failed to add protocol",
+        description: err instanceof Error ? err.message : String(err),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await errorProtocolsApi.remove(id);
+      setProtocols((prev) => prev.filter((p) => p.id !== id));
+      toast({ title: "Protocol removed", status: "success", duration: 3000, isClosable: true });
+    } catch (err) {
+      toast({
+        title: "Failed to remove protocol",
+        description: err instanceof Error ? err.message : String(err),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  return (
+    <Box p={4}>
+      <Box as="form" onSubmit={handleSubmit} mb={4}>
+        <Flex gap={2} mb={2}>
+          <Input
+            placeholder="Error Type"
+            value={errorType}
+            onChange={(e) => setErrorType(e.target.value)}
+          />
+          <Input
+            placeholder="Protocol"
+            value={protocolText}
+            onChange={(e) => setProtocolText(e.target.value)}
+          />
+          <Button type="submit" colorScheme="blue">
+            Add
+          </Button>
+        </Flex>
+      </Box>
+      <Table variant="simple" size="sm">
+        <Thead>
+          <Tr>
+            <Th>Error Type</Th>
+            <Th>Protocol</Th>
+            <Th></Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {protocols.map((p) => (
+            <Tr key={p.id}>
+              <Td>{p.error_type}</Td>
+              <Td>{p.protocol}</Td>
+              <Td>
+                <Button size="xs" colorScheme="red" onClick={() => handleDelete(p.id)}>
+                  Delete
+                </Button>
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </Box>
+  );
+};
+
+export default ErrorProtocolManager;

--- a/frontend/src/services/api/errorProtocols.ts
+++ b/frontend/src/services/api/errorProtocols.ts
@@ -1,0 +1,33 @@
+import { request } from './request';
+import { buildApiUrl, API_CONFIG } from './config';
+import type { ErrorProtocol, ErrorProtocolCreateData, ErrorProtocolUpdateData } from '@/types/error_protocol';
+
+export const errorProtocolsApi = {
+  async list(agentRoleId: string): Promise<ErrorProtocol[]> {
+    return request<ErrorProtocol[]>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/roles/${agentRoleId}/error-protocols`)
+    );
+  },
+
+  async create(agentRoleId: string, data: Omit<ErrorProtocolCreateData, 'agent_role_id'>): Promise<ErrorProtocol> {
+    const response = await request<ErrorProtocol>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/roles/${agentRoleId}/error-protocols`),
+      { method: 'POST', body: JSON.stringify({ ...data, agent_role_id: agentRoleId }) }
+    );
+    return response;
+  },
+
+  async update(protocolId: string, data: ErrorProtocolUpdateData): Promise<ErrorProtocol> {
+    return request<ErrorProtocol>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/error-protocols/${protocolId}`),
+      { method: 'PUT', body: JSON.stringify(data) }
+    );
+  },
+
+  async remove(protocolId: string): Promise<void> {
+    await request(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/error-protocols/${protocolId}`),
+      { method: 'DELETE' }
+    );
+  },
+};

--- a/frontend/src/types/error_protocol.ts
+++ b/frontend/src/types/error_protocol.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+export const errorProtocolBaseSchema = z.object({
+  error_type: z.string().min(1, 'Error type is required'),
+  protocol: z.string().min(1, 'Protocol is required'),
+  priority: z.number().min(1).max(10).default(5),
+  is_active: z.boolean().default(true),
+});
+
+export const errorProtocolCreateSchema = errorProtocolBaseSchema.extend({
+  agent_role_id: z.string(),
+});
+
+export type ErrorProtocolCreateData = z.infer<typeof errorProtocolCreateSchema>;
+
+export const errorProtocolUpdateSchema = errorProtocolBaseSchema.partial();
+
+export type ErrorProtocolUpdateData = z.infer<typeof errorProtocolUpdateSchema>;
+
+export const errorProtocolSchema = errorProtocolBaseSchema.extend({
+  id: z.string(),
+  agent_role_id: z.string(),
+  created_at: z.string().datetime({ message: 'Invalid ISO datetime string' }),
+});
+
+export type ErrorProtocol = z.infer<typeof errorProtocolSchema>;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -9,6 +9,7 @@ export * from "./rules";
 export * from "./mcp";
 export * from "./project_template";
 export * from "./agent_prompt_template";
+export * from "./error_protocol";
 
 // Common types used across the application
 // Canonical shared sort direction type for all entities

--- a/frontend/tests/ErrorProtocolManager.test.tsx
+++ b/frontend/tests/ErrorProtocolManager.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@/__tests__/utils/test-utils';
+import ErrorProtocolManager from '../src/components/agents/ErrorProtocolManager';
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual('@chakra-ui/react');
+  return {
+    ...actual,
+    useToast: () => vi.fn(),
+    useColorModeValue: (light: any, dark: any) => light,
+  };
+});
+
+vi.mock('../src/services/api/errorProtocols', () => ({
+  errorProtocolsApi: {
+    list: vi.fn().mockResolvedValue([]),
+    create: vi.fn().mockResolvedValue({ id: '1', agent_role_id: '1', error_type: 't', protocol: 'p', priority: 5, is_active: true, created_at: new Date().toISOString() }),
+    update: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+describe('ErrorProtocolManager', () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders without crashing', () => {
+    render(<ErrorProtocolManager agentRoleId="1" />, { wrapper: ({ children }) => <div>{children}</div> });
+    expect(document.body).toBeInTheDocument();
+  });
+
+  it('handles form submission', async () => {
+    render(<ErrorProtocolManager agentRoleId="1" />, { wrapper: ({ children }) => <div>{children}</div> });
+    const inputs = screen.getAllByRole('textbox');
+    const button = screen.getByRole('button', { name: /add/i });
+
+    if (inputs.length >= 2) {
+      await user.type(inputs[0], 'type');
+      await user.type(inputs[1], 'protocol');
+    }
+    await user.click(button);
+
+    expect(document.body).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- implement ErrorProtocolManager component to manage error handling protocols
- provide API service for error protocol CRUD
- define `ErrorProtocol` types and export via index
- add basic rendering test for the new component

## Testing
- `npm run test:run` *(fails: Tests 10 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68416bf8955c832cb985910972e90692