### PR TITLE
Add mandate management tools

### DIFF
--- a/SYSTEM_GUIDE.md
+++ b/SYSTEM_GUIDE.md
@@ -39,6 +39,7 @@ node dev_start.js
 - **✅ Agent System**: Rules-based agents with capabilities and constraints
 - **✅ Memory System**: Knowledge graph for file and content management
 - **✅ Audit Logging**: Complete action tracking and history
+- **✅ Mandate Tools**: Manage universal mandates via MCP
 
 ## 🌐 System Endpoints
 
@@ -52,6 +53,12 @@ node dev_start.js
 - **Main Application**: `/` (React/Next.js app)
 - **Project Management**: `/projects`
 - **Task Dashboard**: `/tasks`
+
+### Mandate MCP Tools
+Manage universal mandates used by all agents:
+- `POST /mcp-tools/rule/mandate/create` – create a mandate
+- `GET /mcp-tools/rule/mandate/list` – list mandates (filter with `active_only`)
+- `DELETE /mcp-tools/rule/mandate/delete` – delete by id
 
 ## 🔧 Development Tools
 

--- a/backend/mcp_tools/__init__.py
+++ b/backend/mcp_tools/__init__.py
@@ -18,5 +18,8 @@ __all__ = [
     'delete_handoff_criteria_tool',
     'create_project_template_tool',
     'list_project_templates_tool',
-    'delete_project_template_tool'
+    'delete_project_template_tool',
+    'create_mandate_tool',
+    'list_mandates_tool',
+    'delete_mandate_tool'
 ]

--- a/backend/mcp_tools/mandate_tools.py
+++ b/backend/mcp_tools/mandate_tools.py
@@ -1,0 +1,86 @@
+"""MCP Tools for Universal Mandates."""
+
+import logging
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from backend import models
+from backend.schemas.universal_mandate import UniversalMandateCreate
+
+logger = logging.getLogger(__name__)
+
+
+async def create_mandate_tool(
+    mandate_data: UniversalMandateCreate,
+    db: Session,
+) -> dict:
+    """MCP Tool: Create a new universal mandate."""
+    try:
+        mandate = models.UniversalMandate(**mandate_data.model_dump())
+        db.add(mandate)
+        db.commit()
+        db.refresh(mandate)
+        return {
+            "success": True,
+            "mandate": {
+                "id": mandate.id,
+                "title": mandate.title,
+                "description": mandate.description,
+                "priority": mandate.priority,
+                "is_active": mandate.is_active,
+            },
+        }
+    except Exception as exc:
+        logger.error(f"MCP create mandate failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+async def list_mandates_tool(
+    active_only: bool = True,
+    db: Session | None = None,
+) -> dict:
+    """MCP Tool: List universal mandates."""
+    try:
+        query = db.query(models.UniversalMandate)
+        if active_only:
+            query = query.filter(models.UniversalMandate.is_active.is_(True))
+        mandates = query.order_by(models.UniversalMandate.priority.desc()).all()
+        return {
+            "success": True,
+            "mandates": [
+                {
+                    "id": m.id,
+                    "title": m.title,
+                    "description": m.description,
+                    "priority": m.priority,
+                    "is_active": m.is_active,
+                }
+                for m in mandates
+            ],
+        }
+    except Exception as exc:
+        logger.error(f"MCP list mandates failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+async def delete_mandate_tool(
+    mandate_id: str,
+    db: Session,
+) -> dict:
+    """MCP Tool: Delete a universal mandate."""
+    try:
+        mandate = (
+            db.query(models.UniversalMandate)
+            .filter(models.UniversalMandate.id == mandate_id)
+            .first()
+        )
+        if not mandate:
+            raise HTTPException(status_code=404, detail="Mandate not found")
+        db.delete(mandate)
+        db.commit()
+        return {"success": True}
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"MCP delete mandate failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))


### PR DESCRIPTION
## Summary
- implement MCP mandate tools for create/list/delete
- expose mandate routes in MCP core router
- document mandate tools in System Guide

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6841748ff798832cbe59840c5b05e0e3