### PR TITLE
Add universal mandates UI and e2e tests

### DIFF
--- a/frontend/src/app/universal-mandates/page.tsx
+++ b/frontend/src/app/universal-mandates/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+import React from 'react';
+import UniversalMandateManager from '@/components/rules/UniversalMandateManager';
+
+const UniversalMandatesPage: React.FC = () => {
+  return <UniversalMandateManager />;
+};
+
+export default UniversalMandatesPage;

--- a/frontend/src/components/rules/EditUniversalMandateModal.tsx
+++ b/frontend/src/components/rules/EditUniversalMandateModal.tsx
@@ -1,0 +1,126 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import {
+  FormControl,
+  FormLabel,
+  Input,
+  Textarea,
+  Switch,
+  NumberInput,
+  NumberInputField,
+  VStack,
+} from "@chakra-ui/react";
+import EditModalBase from "../common/EditModalBase";
+import type { UniversalMandate, UniversalMandateUpdateData } from "@/types/rules";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  mandate: UniversalMandate | null;
+  onSave: (data: UniversalMandateUpdateData) => Promise<void>;
+  onDelete?: () => Promise<void>;
+}
+
+const EditUniversalMandateModal: React.FC<Props> = ({
+  isOpen,
+  onClose,
+  mandate,
+  onSave,
+  onDelete,
+}) => {
+  const [formData, setFormData] = useState<UniversalMandateUpdateData>({});
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  useEffect(() => {
+    if (mandate) {
+      setFormData({
+        title: mandate.title,
+        content: mandate.content,
+        priority: mandate.priority,
+        is_active: mandate.is_active,
+        category: mandate.category ?? undefined,
+      });
+    }
+  }, [mandate]);
+
+  const handleSave = async () => {
+    if (!mandate) return;
+    setSaving(true);
+    await onSave(formData);
+    setSaving(false);
+  };
+
+  const handleDelete = async () => {
+    if (!onDelete) return;
+    setDeleting(true);
+    await onDelete();
+    setDeleting(false);
+  };
+
+  return (
+    <EditModalBase
+      isOpen={isOpen}
+      onClose={onClose}
+      entityName="Mandate"
+      entityData={mandate}
+      entityDisplayField="title"
+      onSave={handleSave}
+      onDelete={onDelete ? handleDelete : undefined}
+      isLoadingSave={saving}
+      isLoadingDelete={deleting}
+    >
+      <VStack spacing={4} align="stretch">
+        <FormControl isRequired>
+          <FormLabel>Title</FormLabel>
+          <Input
+            value={formData.title || ""}
+            onChange={(e) =>
+              setFormData({ ...formData, title: e.target.value })
+            }
+          />
+        </FormControl>
+        <FormControl isRequired>
+          <FormLabel>Content</FormLabel>
+          <Textarea
+            value={formData.content || ""}
+            onChange={(e) =>
+              setFormData({ ...formData, content: e.target.value })
+            }
+          />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Priority</FormLabel>
+          <NumberInput
+            min={1}
+            max={10}
+            value={formData.priority ?? 5}
+            onChange={(val) =>
+              setFormData({
+                ...formData,
+                priority: parseInt(val, 10) || 0,
+              })
+            }
+          >
+            <NumberInputField />
+          </NumberInput>
+        </FormControl>
+        <FormControl display="flex" alignItems="center">
+          <Switch
+            id="is_active"
+            isChecked={formData.is_active ?? true}
+            onChange={(e) =>
+              setFormData({ ...formData, is_active: e.target.checked })
+            }
+            mr={2}
+          />
+          <FormLabel htmlFor="is_active" mb="0">
+            Active
+          </FormLabel>
+        </FormControl>
+      </VStack>
+    </EditModalBase>
+  );
+};
+
+export default EditUniversalMandateModal;

--- a/frontend/src/components/rules/UniversalMandateManager.tsx
+++ b/frontend/src/components/rules/UniversalMandateManager.tsx
@@ -1,0 +1,174 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import {
+  Box,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  TableContainer,
+  IconButton,
+  Spinner,
+  useDisclosure,
+  useToast,
+} from "@chakra-ui/react";
+import { EditIcon, DeleteIcon } from "@chakra-ui/icons";
+import { rulesApi } from "@/services/api";
+import type { UniversalMandate, UniversalMandateUpdateData } from "@/types/rules";
+import EditUniversalMandateModal from "./EditUniversalMandateModal";
+import ConfirmationModal from "../common/ConfirmationModal";
+
+const UniversalMandateManager: React.FC = () => {
+  const [mandates, setMandates] = useState<UniversalMandate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selected, setSelected] = useState<UniversalMandate | null>(null);
+  const [deleteId, setDeleteId] = useState<string | null>(null);
+
+  const editDisc = useDisclosure();
+  const deleteDisc = useDisclosure();
+  const toast = useToast();
+
+  const fetchMandates = async () => {
+    setLoading(true);
+    try {
+      const result = await rulesApi.mandates.list();
+      setMandates(result.data);
+    } catch (err) {
+      toast({
+        title: "Failed to load mandates",
+        description: err instanceof Error ? err.message : String(err),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchMandates();
+  }, []);
+
+  const handleUpdate = async (data: UniversalMandateUpdateData) => {
+    if (!selected) return;
+    try {
+      await rulesApi.mandates.update(selected.id, data);
+      toast({ title: "Mandate updated", status: "success", duration: 3000, isClosable: true });
+      editDisc.onClose();
+      await fetchMandates();
+    } catch (err) {
+      toast({
+        title: "Update failed",
+        description: err instanceof Error ? err.message : String(err),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  const confirmDelete = (id: string) => {
+    setDeleteId(id);
+    deleteDisc.onOpen();
+  };
+
+  const handleDelete = async () => {
+    if (!deleteId) return;
+    try {
+      await rulesApi.mandates.delete(deleteId);
+      toast({ title: "Mandate deleted", status: "info", duration: 3000, isClosable: true });
+      setDeleteId(null);
+      deleteDisc.onClose();
+      await fetchMandates();
+    } catch (err) {
+      toast({
+        title: "Delete failed",
+        description: err instanceof Error ? err.message : String(err),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  if (loading) {
+    return (
+      <Box p={6} textAlign="center">
+        <Spinner />
+      </Box>
+    );
+  }
+
+  return (
+    <Box p={4}>
+      <TableContainer>
+        <Table size="sm">
+          <Thead>
+            <Tr>
+              <Th>Title</Th>
+              <Th>Priority</Th>
+              <Th>Active</Th>
+              <Th>Actions</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {mandates.map((m) => (
+              <Tr key={m.id}>
+                <Td>{m.title}</Td>
+                <Td>{m.priority}</Td>
+                <Td>{m.is_active ? "Yes" : "No"}</Td>
+                <Td>
+                  <IconButton
+                    aria-label="Edit"
+                    icon={<EditIcon />}
+                    size="sm"
+                    mr={2}
+                    onClick={() => {
+                      setSelected(m);
+                      editDisc.onOpen();
+                    }}
+                  />
+                  <IconButton
+                    aria-label="Delete"
+                    icon={<DeleteIcon />}
+                    size="sm"
+                    colorScheme="red"
+                    onClick={() => confirmDelete(m.id)}
+                  />
+                </Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      </TableContainer>
+
+      <EditUniversalMandateModal
+        isOpen={editDisc.isOpen}
+        onClose={() => {
+          setSelected(null);
+          editDisc.onClose();
+        }}
+        mandate={selected}
+        onSave={handleUpdate}
+        onDelete={selected ? () => confirmDelete(selected.id) : undefined}
+      />
+
+      <ConfirmationModal
+        isOpen={deleteDisc.isOpen}
+        onClose={() => {
+          setDeleteId(null);
+          deleteDisc.onClose();
+        }}
+        onConfirm={handleDelete}
+        title="Delete Mandate"
+        confirmButtonColorScheme="red"
+        confirmButtonText="Delete"
+      />
+    </Box>
+  );
+};
+
+export default UniversalMandateManager;

--- a/frontend/tests-e2e/mandates.e2e.spec.ts
+++ b/frontend/tests-e2e/mandates.e2e.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+
+test.describe('Universal Mandate CRUD API', () => {
+  test('should create, read, update and delete a mandate', async ({ request }) => {
+    const createRes = await request.post(`${API_BASE_URL}/api/rules/mandates`, {
+      data: { title: 'E2E Mandate', content: 'Created via test', priority: 5 },
+    });
+    expect(createRes.ok()).toBeTruthy();
+    const created = await createRes.json();
+    const id = created.id || created.data?.id;
+    expect(id).toBeTruthy();
+
+    const listRes = await request.get(`${API_BASE_URL}/api/rules/mandates`);
+    expect(listRes.ok()).toBeTruthy();
+
+    const updateRes = await request.put(`${API_BASE_URL}/api/rules/mandates/${id}`, {
+      data: { title: 'Updated E2E Mandate' },
+    });
+    expect(updateRes.ok()).toBeTruthy();
+
+    const deleteRes = await request.delete(`${API_BASE_URL}/api/rules/mandates/${id}`);
+    expect(deleteRes.status()).toBe(204);
+  });
+});


### PR DESCRIPTION
## Summary
- list universal mandates with edit/delete capability
- use Chakra modal and table components for mandate management
- add Playwright e2e test for mandate CRUD API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841748f95d4832c99284f0615a90294