### PR TITLE
Add universal mandate API

### DIFF
--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -7,6 +7,7 @@ export * from "./config";
 export * from "./memory";
 export * from "./comments";
 export * from "./rules";
+export * from "./universal_mandates";
 export * from "./mcp";
 export * from "./users";
 export * from "./audit_logs";

--- a/frontend/src/services/api/universal_mandates.ts
+++ b/frontend/src/services/api/universal_mandates.ts
@@ -1,0 +1,76 @@
+import { request } from './request';
+import { buildApiUrl, API_CONFIG } from './config';
+import type {
+  UniversalMandate,
+  UniversalMandateCreateData,
+  UniversalMandateUpdateData,
+  UniversalMandateFilters,
+  RuleListResponse,
+  RuleResponse,
+} from '@/types/rules';
+
+export const getUniversalMandates = async (
+  filters?: UniversalMandateFilters & { skip?: number; limit?: number }
+): Promise<RuleListResponse<UniversalMandate>> => {
+  const params = new URLSearchParams();
+  if (filters) {
+    Object.entries(filters).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        params.append(key, String(value));
+      }
+    });
+  }
+  return await request<RuleListResponse<UniversalMandate>>(
+    buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/mandates?${params.toString()}`)
+  );
+};
+
+export const createUniversalMandate = async (
+  data: UniversalMandateCreateData
+): Promise<UniversalMandate> => {
+  const response = await request<RuleResponse<UniversalMandate>>(
+    buildApiUrl(API_CONFIG.ENDPOINTS.RULES, '/mandates'),
+    {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }
+  );
+  return response.data;
+};
+
+export const updateUniversalMandate = async (
+  mandateId: string,
+  data: UniversalMandateUpdateData
+): Promise<UniversalMandate> => {
+  const response = await request<RuleResponse<UniversalMandate>>(
+    buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/mandates/${mandateId}`),
+    {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    }
+  );
+  return response.data;
+};
+
+export const deleteUniversalMandate = async (
+  mandateId: string
+): Promise<void> => {
+  await request(
+    buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/mandates/${mandateId}`),
+    {
+      method: 'DELETE',
+    }
+  );
+};
+
+export const toggleUniversalMandate = async (
+  mandateId: string
+): Promise<UniversalMandate> => {
+  const response = await request<RuleResponse<UniversalMandate>>(
+    buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/mandates/${mandateId}/toggle`),
+    {
+      method: 'PUT',
+    }
+  );
+  return response.data;
+};

--- a/frontend/src/types/rules.ts
+++ b/frontend/src/types/rules.ts
@@ -33,6 +33,19 @@ export const universalMandateSchema = universalMandateBaseSchema.extend({
 
 export type UniversalMandate = z.infer<typeof universalMandateSchema>;
 
+export interface UniversalMandateResponse {
+  data: UniversalMandate;
+  error?: { code: string; message: string; field?: string };
+}
+
+export interface UniversalMandateListResponse {
+  data: UniversalMandate[];
+  total: number;
+  page: number;
+  pageSize: number;
+  error?: { code: string; message: string; field?: string };
+}
+
 // --- Agent Rule Schemas ---
 export const ruleAgentRuleBaseSchema = z.object({
   agent_id: z.string(),


### PR DESCRIPTION
## Summary
- implement API functions for universal mandates
- expose the new API via services index
- define universal mandate response interfaces

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Argument type errors)*
- `npm run test:coverage` *(fails: TypeError in use-media-query)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6841748f070c832ca761295381f5d489