### PR TITLE
Add mandate deletion endpoint

### DIFF
--- a/backend/routers/rules/mandates/mandates.py
+++ b/backend/routers/rules/mandates/mandates.py
@@ -44,3 +44,16 @@ def update_mandate(
     if not result:
     raise HTTPException(status_code=404, detail="Mandate not found")
     return result
+
+@router.delete("/{mandate_id}")
+
+
+def delete_mandate(
+    mandate_id: str,
+    db: Session = Depends(get_db)
+):
+    """Delete a universal mandate"""
+    success = crud_rules.delete_universal_mandate(db, mandate_id)
+    if not success:
+    raise HTTPException(status_code=404, detail="Mandate not found")
+    return {"message": "Mandate deleted successfully"}

--- a/backend/services/rules_service.py
+++ b/backend/services/rules_service.py
@@ -183,10 +183,14 @@ def get_error_protocol(self, agent_name: str, error_type: str) -> Optional[str]:
 
         return None
 
-def get_universal_mandates_for_prompt(self) -> List[str]:
+    def get_universal_mandates_for_prompt(self) -> List[str]:
         """Get universal mandates formatted for agent prompts"""
         mandates = crud_rules.get_universal_mandates(self.db)
         return [f"**{mandate.title}**: {mandate.description}" for mandate in mandates]
+
+    def delete_universal_mandate(self, mandate_id: str) -> bool:
+        """Delete a universal mandate by ID."""
+        return crud_rules.delete_universal_mandate(self.db, mandate_id)
 
 def initialize_default_rules(self):
         """Initialize default rules for the system"""

--- a/backend/tests/test_mandates.py
+++ b/backend/tests/test_mandates.py
@@ -1,0 +1,12 @@
+from unittest.mock import MagicMock, patch
+
+from backend.services.rules_service import RulesService
+
+
+def test_delete_universal_mandate_calls_crud():
+    session = MagicMock()
+    service = RulesService(session)
+    with patch("backend.services.rules_service.crud_rules.delete_universal_mandate", return_value=True) as mock_delete:
+        result = service.delete_universal_mandate("m1")
+        mock_delete.assert_called_once_with(session, "m1")
+        assert result is True


### PR DESCRIPTION
## Summary
- allow deleting mandates via DELETE /{mandate_id}
- expose delete_universal_mandate on RulesService
- cover RulesService deletion with a unit test

## Testing
- `flake8` *(fails: E302, E501, etc.)*
- `pytest -q backend/tests/test_mandates.py` *(fails: ImportError: cannot import name 'field_validator')*

------
https://chatgpt.com/codex/tasks/task_e_6841748dcfe0832cbb00e4529c9b4c05