### PR TITLE
Add error protocol management UI

### DIFF
--- a/frontend/src/components/agents/ErrorProtocolManager.tsx
+++ b/frontend/src/components/agents/ErrorProtocolManager.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Input,
+  Textarea,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  useToast,
+} from "@chakra-ui/react";
+import { errorProtocolsApi } from "@/services/api/error_protocols";
+import type { ErrorProtocol, ErrorProtocolCreateData } from "@/types";
+
+const ErrorProtocolManager: React.FC = () => {
+  const [protocols, setProtocols] = useState<ErrorProtocol[]>([]);
+  const [errorType, setErrorType] = useState("");
+  const [protocolText, setProtocolText] = useState("");
+  const toast = useToast();
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await errorProtocolsApi.list();
+        setProtocols(data);
+      } catch (err) {
+        toast({
+          title: "Failed to load protocols",
+          status: "error",
+          duration: 3000,
+          isClosable: true,
+        });
+      }
+    };
+    load();
+  }, [toast]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const newProtocol: ErrorProtocolCreateData = {
+      agent_role_id: "default",
+      error_type: errorType,
+      protocol: protocolText,
+      priority: 5,
+    };
+    try {
+      const created = await errorProtocolsApi.create(newProtocol);
+      setProtocols((prev) => [...prev, created]);
+      setErrorType("");
+      setProtocolText("");
+      toast({ title: "Protocol added", status: "success", duration: 3000, isClosable: true });
+    } catch (err) {
+      toast({ title: "Error adding protocol", status: "error", duration: 5000, isClosable: true });
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await errorProtocolsApi.remove(id);
+      setProtocols((prev) => prev.filter((p) => p.id !== id));
+      toast({ title: "Protocol deleted", status: "success", duration: 3000, isClosable: true });
+    } catch (err) {
+      toast({ title: "Error deleting protocol", status: "error", duration: 5000, isClosable: true });
+    }
+  };
+
+  return (
+    <Box p={4} maxW="600px" mx="auto">
+      <Box as="form" onSubmit={handleSubmit} mb={4}>
+        <Input
+          placeholder="Error Type"
+          value={errorType}
+          onChange={(e) => setErrorType(e.target.value)}
+          mb={2}
+        />
+        <Textarea
+          placeholder="Protocol"
+          value={protocolText}
+          onChange={(e) => setProtocolText(e.target.value)}
+          mb={2}
+        />
+        <Button type="submit" colorScheme="blue" isDisabled={!errorType || !protocolText}>
+          Add Protocol
+        </Button>
+      </Box>
+      <Table size="sm">
+        <Thead>
+          <Tr>
+            <Th>Error Type</Th>
+            <Th>Protocol</Th>
+            <Th></Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {protocols.map((p) => (
+            <Tr key={p.id} data-testid="protocol-row">
+              <Td>{p.error_type}</Td>
+              <Td>{p.protocol}</Td>
+              <Td>
+                <Button size="xs" onClick={() => handleDelete(p.id)}>
+                  Delete
+                </Button>
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </Box>
+  );
+};
+
+export default ErrorProtocolManager;

--- a/frontend/src/components/agents/__tests__/ErrorProtocolManager.test.tsx
+++ b/frontend/src/components/agents/__tests__/ErrorProtocolManager.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@/__tests__/utils/test-utils';
+import ErrorProtocolManager from '../ErrorProtocolManager';
+import type { ErrorProtocol } from '@/types/error_protocol';
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual('@chakra-ui/react');
+  return {
+    ...actual,
+    useToast: () => vi.fn(),
+    useColorModeValue: (l: any, d: any) => l,
+  };
+});
+
+const mockProtocols: ErrorProtocol[] = [
+  {
+    id: '1',
+    agent_role_id: 'default',
+    error_type: 'TypeError',
+    protocol: 'Handle type error',
+    priority: 5,
+    is_active: true,
+    created_at: '',
+    updated_at: '',
+  },
+];
+
+vi.mock('@/services/api/error_protocols', () => ({
+  errorProtocolsApi: {
+    list: vi.fn(async () => mockProtocols),
+    create: vi.fn(async (data) => ({ id: '2', created_at: '', updated_at: '', is_active: true, ...data })),
+    remove: vi.fn(async () => {}),
+    update: vi.fn(),
+  },
+}));
+
+describe('ErrorProtocolManager', () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders protocols and handles form submission', async () => {
+    render(<ErrorProtocolManager />, { wrapper: ({ children }) => <div>{children}</div> });
+
+    // existing row
+    expect(await screen.findByText('TypeError')).toBeInTheDocument();
+
+    const inputs = screen.getAllByRole('textbox');
+    const button = screen.getByRole('button', { name: /add protocol/i });
+
+    if (inputs.length >= 2) {
+      await user.type(inputs[0], 'ValueError');
+      await user.type(inputs[1], 'Handle value error');
+    }
+    await user.click(button);
+
+    expect(screen.getAllByTestId('protocol-row').length).toBeGreaterThan(1);
+  });
+});

--- a/frontend/src/services/api/error_protocols.ts
+++ b/frontend/src/services/api/error_protocols.ts
@@ -1,0 +1,36 @@
+import { request } from './request';
+import { buildApiUrl, API_CONFIG } from './config';
+import type {
+  ErrorProtocol,
+  ErrorProtocolCreateData,
+  ErrorProtocolUpdateData,
+} from '@/types/error_protocol';
+
+export const errorProtocolsApi = {
+  list: async (): Promise<ErrorProtocol[]> => {
+    return await request<ErrorProtocol[]>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, '/error-protocols')
+    );
+  },
+  create: async (data: ErrorProtocolCreateData): Promise<ErrorProtocol> => {
+    return await request<ErrorProtocol>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, '/error-protocols'),
+      { method: 'POST', body: JSON.stringify(data) }
+    );
+  },
+  update: async (
+    id: string,
+    data: ErrorProtocolUpdateData
+  ): Promise<ErrorProtocol> => {
+    return await request<ErrorProtocol>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/error-protocols/${id}`),
+      { method: 'PUT', body: JSON.stringify(data) }
+    );
+  },
+  remove: async (id: string): Promise<void> => {
+    await request(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/error-protocols/${id}`),
+      { method: 'DELETE' }
+    );
+  },
+};

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -11,3 +11,4 @@ export * from "./mcp";
 export * from "./users";
 export * from "./audit_logs";
 export * from "./project_templates";
+export * from "./error_protocols";

--- a/frontend/src/types/error_protocol.ts
+++ b/frontend/src/types/error_protocol.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+export const errorProtocolBaseSchema = z.object({
+  agent_role_id: z.string(),
+  error_type: z.string().min(1, 'Error type is required'),
+  protocol: z.string().min(1, 'Protocol is required'),
+  priority: z.number().min(1).max(10).default(5),
+  is_active: z.boolean().default(true),
+});
+
+export const errorProtocolCreateSchema = errorProtocolBaseSchema.omit({
+  is_active: true,
+});
+export type ErrorProtocolCreateData = z.infer<typeof errorProtocolCreateSchema>;
+
+export const errorProtocolUpdateSchema = errorProtocolBaseSchema.partial();
+export type ErrorProtocolUpdateData = z.infer<typeof errorProtocolUpdateSchema>;
+
+export const errorProtocolSchema = errorProtocolBaseSchema.extend({
+  id: z.string(),
+  created_at: z
+    .string()
+    .datetime({ message: 'Invalid ISO datetime string' })
+    .optional(),
+  updated_at: z
+    .string()
+    .datetime({ message: 'Invalid ISO datetime string' })
+    .optional(),
+});
+
+export type ErrorProtocol = z.infer<typeof errorProtocolSchema>;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -6,6 +6,7 @@ export * from "./audit_log";
 export * from "./memory";
 export * from "./comment";
 export * from "./rules";
+export * from "./error_protocol";
 export * from "./mcp";
 export * from "./project_template";
 export * from "./agent_prompt_template";


### PR DESCRIPTION
## Summary
- add ErrorProtocolManager component with form and table
- create API service for error protocol endpoints
- define error protocol types
- expose new service through API index
- add tests for form submission and table updates

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend run test` *(fails: observer.observe is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6841748ba898832c8347621f627faa6b