### PR TITLE
Add error protocols service

### DIFF
--- a/frontend/src/services/api/error_protocols.ts
+++ b/frontend/src/services/api/error_protocols.ts
@@ -1,0 +1,62 @@
+import { request } from "./request";
+import { buildApiUrl } from "./config";
+import type {
+  ErrorProtocol,
+  ErrorProtocolCreateData,
+  ErrorProtocolUpdateData,
+} from "@/types/agents";
+
+/**
+ * CRUD wrapper for /error-protocols endpoints
+ */
+export const errorProtocolsApi = {
+  /** List error protocols optionally filtered by role */
+  async list(
+    agentRoleId?: string,
+    skip = 0,
+    limit = 100,
+  ): Promise<ErrorProtocol[]> {
+    const params = new URLSearchParams({ skip: String(skip), limit: String(limit) });
+    if (agentRoleId) params.append("agent_role_id", agentRoleId);
+    return request<ErrorProtocol[]>(
+      buildApiUrl("/error-protocols", `?${params.toString()}`),
+    );
+  },
+
+  /** Retrieve a single error protocol */
+  async get(protocolId: string): Promise<ErrorProtocol> {
+    return request<ErrorProtocol>(
+      buildApiUrl("/error-protocols", `/${protocolId}`),
+    );
+  },
+
+  /** Create a new error protocol */
+  async create(data: ErrorProtocolCreateData): Promise<ErrorProtocol> {
+    return request<ErrorProtocol>(buildApiUrl("/error-protocols"), {
+      method: "POST",
+      body: JSON.stringify(data),
+    });
+  },
+
+  /** Update an existing error protocol */
+  async update(
+    protocolId: string,
+    data: ErrorProtocolUpdateData,
+  ): Promise<ErrorProtocol> {
+    return request<ErrorProtocol>(
+      buildApiUrl("/error-protocols", `/${protocolId}`),
+      {
+        method: "PUT",
+        body: JSON.stringify(data),
+      },
+    );
+  },
+
+  /** Delete an error protocol */
+  async delete(protocolId: string): Promise<{ message: string }> {
+    return request<{ message: string }>(
+      buildApiUrl("/error-protocols", `/${protocolId}`),
+      { method: "DELETE" },
+    );
+  },
+};

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -11,3 +11,4 @@ export * from "./mcp";
 export * from "./users";
 export * from "./audit_logs";
 export * from "./project_templates";
+export * from "./error_protocols";

--- a/frontend/src/types/agents.ts
+++ b/frontend/src/types/agents.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+// --- Error Protocol Schemas ---
+export const errorProtocolBaseSchema = z.object({
+  agent_role_id: z.string(),
+  error_type: z.string(),
+  protocol: z.string(),
+  priority: z.number().optional(),
+  is_active: z.boolean().default(true),
+});
+
+export const errorProtocolCreateSchema = errorProtocolBaseSchema;
+export type ErrorProtocolCreateData = z.infer<typeof errorProtocolCreateSchema>;
+
+export const errorProtocolUpdateSchema = errorProtocolBaseSchema.partial();
+export type ErrorProtocolUpdateData = z.infer<typeof errorProtocolUpdateSchema>;
+
+export const errorProtocolSchema = errorProtocolBaseSchema.extend({
+  id: z.string(),
+  created_at: z.string().datetime({ message: 'Invalid ISO datetime string' }),
+});
+export type ErrorProtocol = z.infer<typeof errorProtocolSchema>;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,5 +1,6 @@
 export * from "./project";
 export * from "./agent";
+export * from "./agents";
 export * from "./task";
 export * from "./user";
 export * from "./audit_log";


### PR DESCRIPTION
## Summary
- implement CRUD api in frontend for error protocols
- add ErrorProtocol types and export them
- expose new api module

## Testing
- `npm run lint`
- `npm test` *(fails: 5 test files failed)*

------
https://chatgpt.com/codex/tasks/task_e_6841748b9fac832ca3aef5ef6437038b