### PR TITLE
Implement error protocol MCP tools

### DIFF
--- a/backend/docs/fastapi_mcp/README.md
+++ b/backend/docs/fastapi_mcp/README.md
@@ -96,6 +96,9 @@ FastAPI-MCP automatically exposes selected API endpoints as tools under the `/mc
 - `/mcp-tools/handoff/create` (POST)
 - `/mcp-tools/handoff/list` (GET)
 - `/mcp-tools/handoff/delete` (DELETE)
+- `/mcp-tools/error-protocol/add` (POST)
+- `/mcp-tools/error-protocol/list` (GET)
+- `/mcp-tools/error-protocol/remove` (DELETE)
 
 ## Development and Contributing
 

--- a/backend/mcp_tools/README.md
+++ b/backend/mcp_tools/README.md
@@ -31,6 +31,7 @@ graph TD
 - `project_file_tools.py`
 - `rule_tools.py`
 - `agent_handoff_tools.py`
+- `error_protocol_tools.py`
 
 <!-- File List End -->
 

--- a/backend/mcp_tools/__init__.py
+++ b/backend/mcp_tools/__init__.py
@@ -18,5 +18,8 @@ __all__ = [
     'delete_handoff_criteria_tool',
     'create_project_template_tool',
     'list_project_templates_tool',
-    'delete_project_template_tool'
+    'delete_project_template_tool',
+    'add_error_protocol_tool',
+    'list_error_protocols_tool',
+    'remove_error_protocol_tool'
 ]

--- a/backend/mcp_tools/error_protocol_tools.py
+++ b/backend/mcp_tools/error_protocol_tools.py
@@ -1,0 +1,84 @@
+"""MCP Tools for managing error protocols."""
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+from typing import Optional
+import logging
+
+from backend.services.error_protocol_service import ErrorProtocolService
+from backend.schemas.error_protocol import ErrorProtocolCreate
+
+logger = logging.getLogger(__name__)
+
+
+def _get_service(db: Session) -> ErrorProtocolService:
+    return ErrorProtocolService(db)
+
+
+async def add_error_protocol_tool(
+    role_id: str,
+    protocol_data: ErrorProtocolCreate,
+    db: Session,
+) -> dict:
+    """MCP Tool: Add an error protocol to an agent role."""
+    try:
+        service = _get_service(db)
+        protocol = service.add_protocol(role_id, protocol_data)
+        return {
+            "success": True,
+            "protocol": {
+                "id": protocol.id,
+                "agent_role_id": protocol.agent_role_id,
+                "error_type": protocol.error_type,
+                "protocol": protocol.protocol,
+                "priority": protocol.priority,
+                "is_active": protocol.is_active,
+                "created_at": protocol.created_at.isoformat(),
+            },
+        }
+    except Exception as exc:
+        logger.error(f"MCP add error protocol failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+async def list_error_protocols_tool(
+    role_id: Optional[str],
+    db: Session,
+) -> dict:
+    """MCP Tool: List error protocols."""
+    try:
+        service = _get_service(db)
+        protocols = service.list_protocols(role_id)
+        return {
+            "success": True,
+            "protocols": [
+                {
+                    "id": p.id,
+                    "agent_role_id": p.agent_role_id,
+                    "error_type": p.error_type,
+                    "protocol": p.protocol,
+                    "priority": p.priority,
+                    "is_active": p.is_active,
+                    "created_at": p.created_at.isoformat(),
+                }
+                for p in protocols
+            ],
+        }
+    except Exception as exc:
+        logger.error(f"MCP list error protocols failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+async def remove_error_protocol_tool(protocol_id: str, db: Session) -> dict:
+    """MCP Tool: Remove an error protocol."""
+    try:
+        service = _get_service(db)
+        success = service.remove_protocol(protocol_id)
+        if not success:
+            raise HTTPException(status_code=404, detail="Error protocol not found")
+        return {"success": True}
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"MCP remove error protocol failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/backend/routers/mcp/core.py
+++ b/backend/routers/mcp/core.py
@@ -19,6 +19,7 @@ from ....services.project_template_service import ProjectTemplateService
 from ....schemas.project_template import ProjectTemplateCreate
 from ....services.rules_service import RulesService
 from ....services.agent_handoff_service import AgentHandoffService
+from ....services.error_protocol_service import ErrorProtocolService
 from ....schemas.project import ProjectCreate
 from ....schemas.task import TaskCreate, TaskUpdate
 from ....schemas import AgentRuleCreate
@@ -30,6 +31,7 @@ from ....schemas.memory import (
     MemoryRelationCreate
 )
 from ....schemas.agent_handoff_criteria import AgentHandoffCriteriaCreate
+from ....schemas.error_protocol import ErrorProtocolCreate
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["mcp-tools"])
@@ -58,6 +60,12 @@ def get_agent_handoff_service(
     db: Session = Depends(get_db_session),
 ) -> AgentHandoffService:
     return AgentHandoffService(db)
+
+
+def get_error_protocol_service(
+    db: Session = Depends(get_db_session),
+) -> ErrorProtocolService:
+    return ErrorProtocolService(db)
 
 
 @router.post(
@@ -877,4 +885,88 @@ async def mcp_delete_handoff_criteria(
         raise
     except Exception as e:
         logger.error(f"MCP delete handoff criteria failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/mcp-tools/error-protocol/add",
+    tags=["mcp-tools"],
+    operation_id="add_error_protocol_tool",
+)
+async def mcp_add_error_protocol(
+    role_id: str,
+    protocol: ErrorProtocolCreate,
+    service: ErrorProtocolService = Depends(get_error_protocol_service),
+):
+    """MCP Tool: Add an error protocol to an agent role."""
+    try:
+        created = service.add_protocol(role_id, protocol)
+        return {
+            "success": True,
+            "protocol": {
+                "id": created.id,
+                "agent_role_id": created.agent_role_id,
+                "error_type": created.error_type,
+                "protocol": created.protocol,
+                "priority": created.priority,
+                "is_active": created.is_active,
+                "created_at": created.created_at.isoformat(),
+            },
+        }
+    except Exception as e:
+        logger.error(f"MCP add error protocol failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get(
+    "/mcp-tools/error-protocol/list",
+    tags=["mcp-tools"],
+    operation_id="list_error_protocols_tool",
+)
+async def mcp_list_error_protocols(
+    role_id: Optional[str] = Query(None),
+    service: ErrorProtocolService = Depends(get_error_protocol_service),
+):
+    """MCP Tool: List error protocols."""
+    try:
+        items = service.list_protocols(role_id)
+        return {
+            "success": True,
+            "protocols": [
+                {
+                    "id": p.id,
+                    "agent_role_id": p.agent_role_id,
+                    "error_type": p.error_type,
+                    "protocol": p.protocol,
+                    "priority": p.priority,
+                    "is_active": p.is_active,
+                    "created_at": p.created_at.isoformat(),
+                }
+                for p in items
+            ],
+        }
+    except Exception as e:
+        logger.error(f"MCP list error protocols failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.delete(
+    "/mcp-tools/error-protocol/remove",
+    tags=["mcp-tools"],
+    operation_id="remove_error_protocol_tool",
+)
+async def mcp_remove_error_protocol(
+    protocol_id: str,
+    service: ErrorProtocolService = Depends(get_error_protocol_service),
+):
+    """MCP Tool: Remove an error protocol."""
+    try:
+        success = service.remove_protocol(protocol_id)
+        if not success:
+            raise HTTPException(status_code=404, detail="Error protocol not found")
+        return {"success": True}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"MCP remove error protocol failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -80,3 +80,11 @@ from .agent_handoff_criteria import (
     AgentHandoffCriteria,
 )
 from .file_ingest import FileIngestInput
+
+from .error_protocol import (
+    ErrorProtocolBase,
+    ErrorProtocolCreate,
+    ErrorProtocolUpdate,
+    ErrorProtocol,
+)
+

--- a/backend/schemas/error_protocol.py
+++ b/backend/schemas/error_protocol.py
@@ -1,0 +1,45 @@
+from pydantic import BaseModel, Field, ConfigDict
+from typing import Optional, Dict, Any
+from datetime import datetime
+
+
+class ErrorProtocolBase(BaseModel):
+    """Base schema for error handling protocols."""
+
+    error_type: str = Field(..., description="Type of error this protocol handles")
+    handling_strategy: str = Field(..., description="How the error should be handled")
+    retry_config: Optional[Dict[str, Any]] = Field(
+        None, description="Optional retry configuration details"
+    )
+    escalation_path: Optional[str] = Field(
+        None, description="Escalation path if the error cannot be resolved"
+    )
+    priority: int = Field(5, description="Protocol priority (lower is higher)")
+    is_active: bool = Field(True, description="Whether the protocol is active")
+
+
+class ErrorProtocolCreate(ErrorProtocolBase):
+    """Schema for creating an error protocol."""
+
+    pass
+
+
+class ErrorProtocolUpdate(BaseModel):
+    """Schema for updating an error protocol."""
+
+    error_type: Optional[str] = None
+    handling_strategy: Optional[str] = None
+    retry_config: Optional[Dict[str, Any]] = None
+    escalation_path: Optional[str] = None
+    priority: Optional[int] = None
+    is_active: Optional[bool] = None
+
+
+class ErrorProtocol(ErrorProtocolBase):
+    """Schema for representing an error protocol."""
+
+    id: str = Field(..., description="Unique identifier of the protocol")
+    agent_role_id: str = Field(..., description="ID of the related agent role")
+    created_at: datetime = Field(..., description="Timestamp the protocol was created")
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/services/README.md
+++ b/backend/services/README.md
@@ -43,6 +43,7 @@ graph TD
 - `project_service.py`
 - `project_template_service.py`
 - `rules_service.py`
+- `error_protocol_service.py`
 - `task_dependency_service.py`
 - `task_file_association_service.py`
 - `task_service.py`

--- a/backend/services/error_protocol_service.py
+++ b/backend/services/error_protocol_service.py
@@ -1,0 +1,50 @@
+"""Service layer for agent error protocols."""
+
+from typing import List, Optional
+from sqlalchemy.orm import Session
+
+from .. import models
+from ..schemas.error_protocol import ErrorProtocolCreate
+
+
+class ErrorProtocolService:
+    """Manage agent error protocols."""
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def add_protocol(
+        self, role_id: str, protocol_in: ErrorProtocolCreate
+    ) -> models.AgentErrorProtocol:
+        """Create a new error protocol for an agent role."""
+        protocol = models.AgentErrorProtocol(
+            agent_role_id=role_id,
+            error_type=protocol_in.error_type,
+            protocol=protocol_in.handling_strategy,
+            priority=protocol_in.priority,
+            is_active=protocol_in.is_active,
+        )
+        self.db.add(protocol)
+        self.db.commit()
+        self.db.refresh(protocol)
+        return protocol
+
+    def list_protocols(
+        self, role_id: Optional[str] = None
+    ) -> List[models.AgentErrorProtocol]:
+        query = self.db.query(models.AgentErrorProtocol)
+        if role_id:
+            query = query.filter(models.AgentErrorProtocol.agent_role_id == role_id)
+        return query.all()
+
+    def remove_protocol(self, protocol_id: str) -> bool:
+        protocol = (
+            self.db.query(models.AgentErrorProtocol)
+            .filter(models.AgentErrorProtocol.id == protocol_id)
+            .first()
+        )
+        if not protocol:
+            return False
+        self.db.delete(protocol)
+        self.db.commit()
+        return True


### PR DESCRIPTION
## Summary
- add service and MCP tools for error protocol management
- expose error protocol routes via MCP router
- document new endpoints

## Testing
- `flake8 mcp_tools/error_protocol_tools.py services/error_protocol_service.py schemas/error_protocol.py routers/mcp/core.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68417489a3a8832c85230b5098ed4df8