### PR TITLE
Add agent error protocol service and router

### DIFF
--- a/backend/routers/rules/__init__.py
+++ b/backend/routers/rules/__init__.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 from .workflows.workflows import router as workflows_router
 from .violations.violations import router as violations_router
+from .violations.error_protocols import router as error_protocols_router
 from .templates.templates import router as templates_router
 from .roles.roles import router as roles_router
 from .mandates.mandates import router as mandates_router
@@ -9,6 +10,7 @@ from .logs.logs import router as logs_router
 router = APIRouter()
 router.include_router(workflows_router)
 router.include_router(violations_router)
+router.include_router(error_protocols_router)
 router.include_router(templates_router)
 router.include_router(roles_router)
 router.include_router(mandates_router)

--- a/backend/routers/rules/violations/error_protocols.py
+++ b/backend/routers/rules/violations/error_protocols.py
@@ -1,0 +1,60 @@
+from typing import List
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ....database import get_db
+from ....services.agent_error_protocol_service import AgentErrorProtocolService
+from ....schemas.agent_error_protocol import (
+    AgentErrorProtocol,
+    AgentErrorProtocolCreate,
+    AgentErrorProtocolUpdate,
+)
+
+router = APIRouter()
+
+
+async def get_service(db: AsyncSession = Depends(get_db)) -> AgentErrorProtocolService:
+    return AgentErrorProtocolService(db)
+
+
+@router.get("/error-protocols/{protocol_id}", response_model=AgentErrorProtocol)
+async def read_error_protocol(protocol_id: str, service: AgentErrorProtocolService = Depends(get_service)):
+    protocol = await service.get_protocol(protocol_id)
+    if not protocol:
+        raise HTTPException(status_code=404, detail="Error protocol not found")
+    return protocol
+
+
+@router.get("/{role_id}/error-protocols", response_model=List[AgentErrorProtocol])
+async def list_error_protocols(role_id: str, service: AgentErrorProtocolService = Depends(get_service)):
+    return await service.list_protocols(agent_role_id=role_id)
+
+
+@router.post("/{role_id}/error-protocols", response_model=AgentErrorProtocol)
+async def create_error_protocol(
+    role_id: str,
+    protocol_in: AgentErrorProtocolCreate,
+    service: AgentErrorProtocolService = Depends(get_service),
+):
+    protocol_data = protocol_in.copy(update={"agent_role_id": role_id})
+    return await service.create_protocol(protocol_data)
+
+
+@router.put("/error-protocols/{protocol_id}", response_model=AgentErrorProtocol)
+async def update_error_protocol(
+    protocol_id: str,
+    protocol_update: AgentErrorProtocolUpdate,
+    service: AgentErrorProtocolService = Depends(get_service),
+):
+    updated = await service.update_protocol(protocol_id, protocol_update)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Error protocol not found")
+    return updated
+
+
+@router.delete("/error-protocols/{protocol_id}")
+async def delete_error_protocol(protocol_id: str, service: AgentErrorProtocolService = Depends(get_service)):
+    success = await service.delete_protocol(protocol_id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Error protocol not found")
+    return {"message": "Error protocol deleted successfully"}

--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -79,4 +79,10 @@ from .agent_handoff_criteria import (
     AgentHandoffCriteriaCreate,
     AgentHandoffCriteria,
 )
+from .agent_error_protocol import (
+    AgentErrorProtocolBase,
+    AgentErrorProtocolCreate,
+    AgentErrorProtocolUpdate,
+    AgentErrorProtocol,
+)
 from .file_ingest import FileIngestInput

--- a/backend/schemas/agent_error_protocol.py
+++ b/backend/schemas/agent_error_protocol.py
@@ -1,0 +1,37 @@
+from pydantic import BaseModel, ConfigDict, Field
+from typing import Optional
+from datetime import datetime
+
+
+class AgentErrorProtocolBase(BaseModel):
+    """Base schema for agent error protocols."""
+
+    agent_role_id: str = Field(..., description="ID of the related agent role.")
+    error_type: str = Field(..., description="Type of error this protocol handles.")
+    protocol: str = Field(..., description="Instructions for handling the error.")
+    priority: int = Field(5, description="Priority of the protocol.")
+    is_active: bool = Field(True, description="Whether the protocol is active.")
+
+
+class AgentErrorProtocolCreate(AgentErrorProtocolBase):
+    """Schema for creating an error protocol."""
+
+    pass
+
+
+class AgentErrorProtocolUpdate(BaseModel):
+    """Schema for updating an error protocol."""
+
+    error_type: Optional[str] = Field(None, description="Updated error type.")
+    protocol: Optional[str] = Field(None, description="Updated protocol text.")
+    priority: Optional[int] = Field(None, description="Updated priority.")
+    is_active: Optional[bool] = Field(None, description="Updated active state.")
+
+
+class AgentErrorProtocol(AgentErrorProtocolBase):
+    """Schema representing an error protocol."""
+
+    id: str = Field(..., description="Unique identifier of the protocol.")
+    created_at: datetime = Field(..., description="Creation timestamp.")
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/services/agent_error_protocol_service.py
+++ b/backend/services/agent_error_protocol_service.py
@@ -1,0 +1,68 @@
+from typing import List, Optional
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import models
+from ..schemas.agent_error_protocol import (
+    AgentErrorProtocol,
+    AgentErrorProtocolCreate,
+    AgentErrorProtocolUpdate,
+)
+
+
+class AgentErrorProtocolService:
+    """Service providing CRUD operations for AgentErrorProtocol."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def get_protocol(self, protocol_id: str) -> Optional[models.AgentErrorProtocol]:
+        result = await self.db.execute(
+            select(models.AgentErrorProtocol).filter(models.AgentErrorProtocol.id == protocol_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def list_protocols(
+        self, agent_role_id: Optional[str] = None
+    ) -> List[models.AgentErrorProtocol]:
+        query = select(models.AgentErrorProtocol)
+        if agent_role_id:
+            query = query.filter(models.AgentErrorProtocol.agent_role_id == agent_role_id)
+        result = await self.db.execute(query)
+        return list(result.scalars().all())
+
+    async def create_protocol(
+        self, protocol_in: AgentErrorProtocolCreate
+    ) -> models.AgentErrorProtocol:
+        db_protocol = models.AgentErrorProtocol(
+            agent_role_id=protocol_in.agent_role_id,
+            error_type=protocol_in.error_type,
+            protocol=protocol_in.protocol,
+            priority=protocol_in.priority,
+            is_active=protocol_in.is_active,
+        )
+        self.db.add(db_protocol)
+        await self.db.commit()
+        await self.db.refresh(db_protocol)
+        return db_protocol
+
+    async def update_protocol(
+        self, protocol_id: str, protocol_update: AgentErrorProtocolUpdate
+    ) -> Optional[models.AgentErrorProtocol]:
+        db_protocol = await self.get_protocol(protocol_id)
+        if not db_protocol:
+            return None
+        update_data = protocol_update.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(db_protocol, field, value)
+        await self.db.commit()
+        await self.db.refresh(db_protocol)
+        return db_protocol
+
+    async def delete_protocol(self, protocol_id: str) -> bool:
+        db_protocol = await self.get_protocol(protocol_id)
+        if not db_protocol:
+            return False
+        await self.db.delete(db_protocol)
+        await self.db.commit()
+        return True


### PR DESCRIPTION
## Summary
- implement `AgentErrorProtocolService` for CRUD operations
- create schemas for agent error protocols
- add error protocol API router under rules violations
- register the router in rules package

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError and endpoint tests)*

------
https://chatgpt.com/codex/tasks/task_e_684174891508832c924b05fb43597272