### PR TITLE
Add verification requirement management

### DIFF
--- a/frontend/src/components/agents/VerificationRequirements.tsx
+++ b/frontend/src/components/agents/VerificationRequirements.tsx
@@ -1,0 +1,130 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Flex,
+  Input,
+  List,
+  ListItem,
+  Spinner,
+  Text,
+  useToast,
+} from "@chakra-ui/react";
+import { verificationRequirementsApi } from "@/services/api";
+import type { VerificationRequirement } from "@/types";
+
+interface VerificationRequirementsProps {
+  agentRoleId: string;
+}
+
+const VerificationRequirements: React.FC<VerificationRequirementsProps> = ({ agentRoleId }) => {
+  const toast = useToast();
+  const [requirements, setRequirements] = useState<VerificationRequirement[] | null>(null);
+  const [newReq, setNewReq] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const loadRequirements = async () => {
+    try {
+      const data = await verificationRequirementsApi.list(agentRoleId);
+      setRequirements(data);
+    } catch (err) {
+      toast({
+        title: "Failed to load requirements",
+        description: err instanceof Error ? err.message : String(err),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  useEffect(() => {
+    loadRequirements();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agentRoleId]);
+
+  const handleCreate = async () => {
+    if (!newReq.trim()) return;
+    setLoading(true);
+    try {
+      await verificationRequirementsApi.create({
+        agent_role_id: agentRoleId,
+        requirement: newReq,
+      });
+      setNewReq("");
+      await loadRequirements();
+      toast({ title: "Requirement added", status: "success", duration: 3000, isClosable: true });
+    } catch (err) {
+      toast({
+        title: "Failed to add requirement",
+        description: err instanceof Error ? err.message : String(err),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    setLoading(true);
+    try {
+      await verificationRequirementsApi.delete(id);
+      await loadRequirements();
+      toast({ title: "Requirement removed", status: "success", duration: 3000, isClosable: true });
+    } catch (err) {
+      toast({
+        title: "Failed to remove requirement",
+        description: err instanceof Error ? err.message : String(err),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!requirements) {
+    return (
+      <Flex justify="center" align="center" p="4" minH="100px">
+        <Spinner />
+      </Flex>
+    );
+  }
+
+  return (
+    <Box>
+      <Flex mb={2} gap={2}>
+        <Input
+          placeholder="New requirement"
+          value={newReq}
+          onChange={(e) => setNewReq(e.target.value)}
+        />
+        <Button onClick={handleCreate} isLoading={loading} disabled={!newReq.trim()}>
+          Add
+        </Button>
+      </Flex>
+      {requirements.length === 0 ? (
+        <Text>No verification requirements.</Text>
+      ) : (
+        <List spacing={2}>
+          {requirements.map((req) => (
+            <ListItem key={req.id} borderWidth="1px" borderRadius="md" p={2}>
+              <Flex justify="space-between" align="center">
+                <Text>{req.requirement}</Text>
+                <Button size="sm" colorScheme="red" onClick={() => handleDelete(req.id)}>
+                  Delete
+                </Button>
+              </Flex>
+            </ListItem>
+          ))}
+        </List>
+      )}
+    </Box>
+  );
+};
+
+export default VerificationRequirements;

--- a/frontend/src/services/api/__tests__/verification_requirements.test.ts
+++ b/frontend/src/services/api/__tests__/verification_requirements.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { verificationRequirementsApi } from '../verification_requirements';
+import { request } from '../request';
+import { buildApiUrl } from '../config';
+
+vi.mock('../request');
+vi.mock('../config');
+
+const mockRequest = vi.mocked(request);
+const mockBuildApiUrl = vi.mocked(buildApiUrl);
+
+describe('Verification Requirements API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBuildApiUrl.mockReturnValue('http://localhost:8000/api/test');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('creates a verification requirement', async () => {
+    const mockResponse = { data: { id: '1', agent_role_id: 'role1', requirement: 'req', is_mandatory: true, created_at: '2024-01-01T00:00:00Z' } };
+    mockRequest.mockResolvedValue(mockResponse);
+
+    const result = await verificationRequirementsApi.create({ agent_role_id: 'role1', requirement: 'req' });
+
+    expect(mockBuildApiUrl).toHaveBeenCalled();
+    expect(mockRequest).toHaveBeenCalledWith('http://localhost:8000/api/test', expect.objectContaining({ method: 'POST' }));
+    expect(result).toEqual(mockResponse.data);
+  });
+
+  it('deletes a verification requirement', async () => {
+    mockRequest.mockResolvedValue(null);
+
+    await verificationRequirementsApi.delete('1');
+
+    expect(mockBuildApiUrl).toHaveBeenCalled();
+    expect(mockRequest).toHaveBeenCalledWith('http://localhost:8000/api/test', { method: 'DELETE' });
+  });
+});

--- a/frontend/src/services/api/config.ts
+++ b/frontend/src/services/api/config.ts
@@ -18,6 +18,7 @@ export const API_CONFIG = {
     MEMORY: "/memory",
     RULES: "/rules",
     MCP_TOOLS: "/mcp-tools",
+    VERIFICATION_REQUIREMENTS: "/verification-requirements",
   },
 } as const;
 

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -11,3 +11,4 @@ export * from "./mcp";
 export * from "./users";
 export * from "./audit_logs";
 export * from "./project_templates";
+export * from "./verification_requirements";

--- a/frontend/src/services/api/verification_requirements.ts
+++ b/frontend/src/services/api/verification_requirements.ts
@@ -1,0 +1,35 @@
+import { request } from './request';
+import { buildApiUrl, API_CONFIG } from './config';
+import type {
+  VerificationRequirement,
+  VerificationRequirementCreateData,
+  VerificationRequirementListResponse,
+  VerificationRequirementResponse,
+} from '@/types/verification_requirement';
+
+export const verificationRequirementsApi = {
+  async list(agentRoleId: string): Promise<VerificationRequirement[]> {
+    const response = await request<VerificationRequirementListResponse>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.VERIFICATION_REQUIREMENTS, `?agent_role_id=${agentRoleId}`)
+    );
+    return response.data;
+  },
+
+  async create(data: VerificationRequirementCreateData): Promise<VerificationRequirement> {
+    const response = await request<VerificationRequirementResponse>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.VERIFICATION_REQUIREMENTS),
+      {
+        method: 'POST',
+        body: JSON.stringify(data),
+      }
+    );
+    return response.data;
+  },
+
+  async delete(id: string): Promise<void> {
+    await request(
+      buildApiUrl(API_CONFIG.ENDPOINTS.VERIFICATION_REQUIREMENTS, `/${id}`),
+      { method: 'DELETE' }
+    );
+  },
+};

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -9,6 +9,7 @@ export * from "./rules";
 export * from "./mcp";
 export * from "./project_template";
 export * from "./agent_prompt_template";
+export * from "./verification_requirement";
 
 // Common types used across the application
 // Canonical shared sort direction type for all entities

--- a/frontend/src/types/verification_requirement.ts
+++ b/frontend/src/types/verification_requirement.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+export const verificationRequirementBaseSchema = z.object({
+  agent_role_id: z.string(),
+  requirement: z.string().min(1, 'Requirement is required'),
+  description: z.string().nullable().optional(),
+  is_mandatory: z.boolean().default(true),
+});
+
+export const verificationRequirementCreateSchema = verificationRequirementBaseSchema.omit({
+  agent_role_id: false,
+});
+
+export type VerificationRequirementCreateData = z.infer<typeof verificationRequirementCreateSchema> & { agent_role_id: string };
+
+export const verificationRequirementSchema = verificationRequirementBaseSchema.extend({
+  id: z.string(),
+  created_at: z.string().datetime({ message: 'Invalid ISO datetime string' }),
+});
+
+export type VerificationRequirement = z.infer<typeof verificationRequirementSchema>;
+
+export interface VerificationRequirementResponse {
+  data: VerificationRequirement;
+  error?: { code: string; message: string; field?: string };
+}
+
+export interface VerificationRequirementListResponse {
+  data: VerificationRequirement[];
+  total: number;
+  page: number;
+  pageSize: number;
+  error?: { code: string; message: string; field?: string };
+}


### PR DESCRIPTION
## Summary
- implement `VerificationRequirements` component for agent roles
- add API service for verification requirement CRUD
- export verification requirement types
- create tests for verification requirement service

## Testing
- `npm run lint`
- `npx vitest run src/services/api/__tests__/verification_requirements.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68417487bee4832c9997b7a809db1f49