### PR TITLE
Add API for agent verification requirements

### DIFF
--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -11,3 +11,4 @@ export * from "./mcp";
 export * from "./users";
 export * from "./audit_logs";
 export * from "./project_templates";
+export * from "./verification_requirements";

--- a/frontend/src/services/api/verification_requirements.ts
+++ b/frontend/src/services/api/verification_requirements.ts
@@ -1,0 +1,69 @@
+import { request } from "./request";
+import { buildApiUrl, API_CONFIG } from "./config";
+import type {
+  VerificationRequirement,
+  VerificationRequirementCreateData,
+  VerificationRequirementUpdateData,
+} from "@/types/agents";
+
+/**
+ * Typed API client for agent verification requirements.
+ */
+export const verificationRequirementsApi = {
+  /**
+   * List verification requirements for a specific agent role.
+   */
+  async list(agentRoleId: string): Promise<VerificationRequirement[]> {
+    return request<VerificationRequirement[]>(
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.RULES,
+        `/roles/${agentRoleId}/verification-requirements`
+      )
+    );
+  },
+
+  /**
+   * Create a new verification requirement under an agent role.
+   */
+  async create(
+    agentRoleId: string,
+    data: VerificationRequirementCreateData
+  ): Promise<VerificationRequirement> {
+    return request<VerificationRequirement>(
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.RULES,
+        `/roles/${agentRoleId}/verification-requirements`
+      ),
+      { method: "POST", body: JSON.stringify(data) }
+    );
+  },
+
+  /**
+   * Update an existing verification requirement.
+   */
+  async update(
+    requirementId: string,
+    data: VerificationRequirementUpdateData
+  ): Promise<VerificationRequirement> {
+    return request<VerificationRequirement>(
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.RULES,
+        `/roles/verification-requirements/${requirementId}`
+      ),
+      { method: "PUT", body: JSON.stringify(data) }
+    );
+  },
+
+  /**
+   * Delete a verification requirement by ID.
+   */
+  async delete(requirementId: string): Promise<void> {
+    await request<void>(
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.RULES,
+        `/roles/verification-requirements/${requirementId}`
+      ),
+      { method: "DELETE" }
+    );
+  },
+};

--- a/frontend/src/types/agents.ts
+++ b/frontend/src/types/agents.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+// --- Verification Requirement Schemas ---
+export const verificationRequirementBaseSchema = z.object({
+  agent_role_id: z.string(),
+  requirement: z.string(),
+  description: z.string().nullable().optional(),
+  is_mandatory: z.boolean().default(true),
+});
+
+export const verificationRequirementCreateSchema = verificationRequirementBaseSchema.omit({
+  agent_role_id: true,
+});
+export type VerificationRequirementCreateData = z.infer<typeof verificationRequirementCreateSchema>;
+
+export const verificationRequirementUpdateSchema = verificationRequirementBaseSchema.partial().omit({
+  agent_role_id: true,
+});
+export type VerificationRequirementUpdateData = z.infer<typeof verificationRequirementUpdateSchema>;
+
+export const verificationRequirementSchema = verificationRequirementBaseSchema.extend({
+  id: z.string(),
+  created_at: z.string().datetime({ message: 'Invalid ISO datetime string' }),
+});
+export type VerificationRequirement = z.infer<typeof verificationRequirementSchema>;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -9,6 +9,7 @@ export * from "./rules";
 export * from "./mcp";
 export * from "./project_template";
 export * from "./agent_prompt_template";
+export * from "./agents";
 
 // Common types used across the application
 // Canonical shared sort direction type for all entities


### PR DESCRIPTION
## Summary
- implement verification requirements CRUD API
- define related types
- export new utilities through index files

## Testing
- `npx next lint` *(fails: Need to install next)*
- `npm test` *(fails: vitest not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684174861924832c94aa26fcf5171ac3