### PR TITLE
Add verification requirement tools

### DIFF
--- a/SYSTEM_GUIDE.md
+++ b/SYSTEM_GUIDE.md
@@ -39,6 +39,7 @@ node dev_start.js
 - **✅ Agent System**: Rules-based agents with capabilities and constraints
 - **✅ Memory System**: Knowledge graph for file and content management
 - **✅ Audit Logging**: Complete action tracking and history
+- **✅ Verification Requirement Tools**: Manage agent verification checks via MCP
 
 ## 🌐 System Endpoints
 

--- a/backend/mcp_tools/__init__.py
+++ b/backend/mcp_tools/__init__.py
@@ -16,6 +16,9 @@ __all__ = [
     'create_handoff_criteria_tool',
     'list_handoff_criteria_tool',
     'delete_handoff_criteria_tool',
+    'create_verification_requirement_tool',
+    'list_verification_requirements_tool',
+    'delete_verification_requirement_tool',
     'create_project_template_tool',
     'list_project_templates_tool',
     'delete_project_template_tool'

--- a/backend/mcp_tools/verification_requirement_tools.py
+++ b/backend/mcp_tools/verification_requirement_tools.py
@@ -1,0 +1,86 @@
+"""MCP tools for agent verification requirements."""
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+from typing import Optional
+import logging
+
+from backend.services.agent_verification_requirement_service import (
+    AgentVerificationRequirementService,
+)
+from backend.schemas.agent_verification_requirement import (
+    AgentVerificationRequirementCreate,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _get_service(db: Session) -> AgentVerificationRequirementService:
+    return AgentVerificationRequirementService(db)
+
+
+async def create_verification_requirement_tool(
+    requirement_data: AgentVerificationRequirementCreate,
+    db: Session,
+) -> dict:
+    """Create a new verification requirement."""
+    try:
+        service = _get_service(db)
+        req = service.create_requirement(requirement_data)
+        return {
+            "success": True,
+            "requirement": {
+                "id": req.id,
+                "agent_role_id": req.agent_role_id,
+                "requirement": req.requirement,
+                "description": req.description,
+                "is_mandatory": req.is_mandatory,
+            },
+        }
+    except Exception as exc:
+        logger.error(f"MCP create verification requirement failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+async def list_verification_requirements_tool(
+    agent_role_id: Optional[str],
+    db: Session,
+) -> dict:
+    """List verification requirements."""
+    try:
+        service = _get_service(db)
+        items = service.list_requirements(agent_role_id)
+        return {
+            "success": True,
+            "requirements": [
+                {
+                    "id": r.id,
+                    "agent_role_id": r.agent_role_id,
+                    "requirement": r.requirement,
+                    "description": r.description,
+                    "is_mandatory": r.is_mandatory,
+                }
+                for r in items
+            ],
+        }
+    except Exception as exc:
+        logger.error(f"MCP list verification requirements failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+async def delete_verification_requirement_tool(
+    requirement_id: str,
+    db: Session,
+) -> dict:
+    """Delete a verification requirement."""
+    try:
+        service = _get_service(db)
+        success = service.delete_requirement(requirement_id)
+        if not success:
+            raise HTTPException(status_code=404, detail="Requirement not found")
+        return {"success": True}
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"MCP delete verification requirement failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -79,4 +79,9 @@ from .agent_handoff_criteria import (
     AgentHandoffCriteriaCreate,
     AgentHandoffCriteria,
 )
+from .agent_verification_requirement import (
+    AgentVerificationRequirementBase,
+    AgentVerificationRequirementCreate,
+    AgentVerificationRequirement,
+)
 from .file_ingest import FileIngestInput

--- a/backend/schemas/agent_verification_requirement.py
+++ b/backend/schemas/agent_verification_requirement.py
@@ -1,0 +1,29 @@
+from pydantic import BaseModel, ConfigDict, Field
+from typing import Optional
+from datetime import datetime
+
+
+class AgentVerificationRequirementBase(BaseModel):
+    """Base schema for verification requirements."""
+
+    agent_role_id: str = Field(..., description="Related agent role ID")
+    requirement: str = Field(..., description="Verification requirement text")
+    description: Optional[str] = Field(
+        None, description="Optional description of the requirement."
+    )
+    is_mandatory: bool = Field(True, description="Whether this requirement is mandatory")
+
+
+class AgentVerificationRequirementCreate(AgentVerificationRequirementBase):
+    """Schema for creating a verification requirement."""
+
+    pass
+
+
+class AgentVerificationRequirement(AgentVerificationRequirementBase):
+    """Schema representing a verification requirement."""
+
+    id: str = Field(..., description="Unique identifier")
+    created_at: datetime = Field(..., description="Time requirement was created")
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/services/agent_verification_requirement_service.py
+++ b/backend/services/agent_verification_requirement_service.py
@@ -1,0 +1,48 @@
+from sqlalchemy.orm import Session
+from typing import List, Optional
+
+from .. import models
+from ..schemas.agent_verification_requirement import (
+    AgentVerificationRequirementCreate,
+)
+
+
+class AgentVerificationRequirementService:
+    """Service for managing agent verification requirements."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create_requirement(
+        self, requirement_in: AgentVerificationRequirementCreate
+    ) -> models.AgentVerificationRequirement:
+        db_req = models.AgentVerificationRequirement(
+            agent_role_id=requirement_in.agent_role_id,
+            requirement=requirement_in.requirement,
+            description=requirement_in.description,
+            is_mandatory=requirement_in.is_mandatory,
+        )
+        self.db.add(db_req)
+        self.db.commit()
+        self.db.refresh(db_req)
+        return db_req
+
+    def list_requirements(
+        self, agent_role_id: Optional[str] = None
+    ) -> List[models.AgentVerificationRequirement]:
+        query = self.db.query(models.AgentVerificationRequirement)
+        if agent_role_id:
+            query = query.filter(models.AgentVerificationRequirement.agent_role_id == agent_role_id)
+        return query.all()
+
+    def delete_requirement(self, requirement_id: str) -> bool:
+        db_obj = (
+            self.db.query(models.AgentVerificationRequirement)
+            .filter(models.AgentVerificationRequirement.id == requirement_id)
+            .first()
+        )
+        if not db_obj:
+            return False
+        self.db.delete(db_obj)
+        self.db.commit()
+        return True


### PR DESCRIPTION
## Summary
- implement `AgentVerificationRequirement` schema
- add service for verification requirements
- expose new tools through MCP
- register tools in package and router
- document capability in guide

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684174843100832cad8051c6922960ec