### PR TITLE
Add AgentForbiddenActions component

### DIFF
--- a/frontend/src/components/__tests__/AgentForbiddenActions.test.tsx
+++ b/frontend/src/components/__tests__/AgentForbiddenActions.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@/__tests__/utils/test-utils';
+import AgentForbiddenActions from '../AgentForbiddenActions';
+import { rulesApi } from '@/services/api';
+
+vi.mock('@/services/api', () => ({
+  rulesApi: {
+    forbiddenActions: {
+      add: vi.fn().mockResolvedValue({ id: '1', action: 'test', agent_role_id: 'r1' }),
+      remove: vi.fn().mockResolvedValue({}),
+    },
+  },
+}));
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual('@chakra-ui/react');
+  return {
+    ...actual,
+    useToast: () => vi.fn(),
+    useColorModeValue: (light: any, dark: any) => light,
+  };
+});
+
+describe('AgentForbiddenActions', () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls API when adding and removing actions', async () => {
+    render(<AgentForbiddenActions roleId="r1" initialActions={[]} />);
+
+    await user.type(screen.getByLabelText(/action/i), 'test');
+    await user.click(screen.getByRole('button', { name: /add/i }));
+
+    expect(rulesApi.forbiddenActions.add).toHaveBeenCalledWith('r1', {
+      action: 'test',
+      reason: '',
+    });
+
+    const removeBtn = await screen.findByRole('button', { name: /remove/i });
+    await user.click(removeBtn);
+    expect(rulesApi.forbiddenActions.remove).toHaveBeenCalledWith('1');
+  });
+});

--- a/frontend/src/components/agents/AgentForbiddenActions.tsx
+++ b/frontend/src/components/agents/AgentForbiddenActions.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  List,
+  ListItem,
+  Flex,
+} from "@chakra-ui/react";
+import { rulesApi } from "@/services/api";
+import type { ForbiddenAction, ForbiddenActionCreateData } from "@/types";
+
+interface AgentForbiddenActionsProps {
+  roleId: string;
+  initialActions?: ForbiddenAction[];
+}
+
+const AgentForbiddenActions: React.FC<AgentForbiddenActionsProps> = ({
+  roleId,
+  initialActions = [],
+}) => {
+  const [actions, setActions] = useState<ForbiddenAction[]>(initialActions);
+  const [action, setAction] = useState("");
+  const [reason, setReason] = useState("");
+
+  const handleAdd = async () => {
+    const data: ForbiddenActionCreateData = { action, reason };
+    const newAction = await rulesApi.forbiddenActions.add(roleId, data);
+    setActions((prev) => [...prev, newAction]);
+    setAction("");
+    setReason("");
+  };
+
+  const handleRemove = async (id: string) => {
+    await rulesApi.forbiddenActions.remove(id);
+    setActions((prev) => prev.filter((a) => a.id !== id));
+  };
+
+  return (
+    <Box>
+      <Box
+        as="form"
+        onSubmit={(e) => {
+          e.preventDefault();
+          void handleAdd();
+        }}
+      >
+        <FormControl isRequired mb={2}>
+          <FormLabel>Action</FormLabel>
+          <Input value={action} onChange={(e) => setAction(e.target.value)} />
+        </FormControl>
+        <FormControl mb={2}>
+          <FormLabel>Reason</FormLabel>
+          <Input value={reason} onChange={(e) => setReason(e.target.value)} />
+        </FormControl>
+        <Button type="submit" isDisabled={!action.trim()}>
+          Add
+        </Button>
+      </Box>
+      <List mt={4} spacing={2}>
+        {actions.map((fa) => (
+          <ListItem key={fa.id} borderWidth="1px" p={2} borderRadius="md">
+            <Flex justify="space-between" align="center">
+              <span>{fa.action}</span>
+              <Button
+                size="sm"
+                colorScheme="red"
+                onClick={() => handleRemove(fa.id)}
+              >
+                Remove
+              </Button>
+            </Flex>
+          </ListItem>
+        ))}
+      </List>
+    </Box>
+  );
+};
+
+export default AgentForbiddenActions;

--- a/frontend/src/services/api/rules.ts
+++ b/frontend/src/services/api/rules.ts
@@ -156,6 +156,37 @@ export const rulesApi = {
     },
   },
 
+  // --- Forbidden Actions APIs ---
+  forbiddenActions: {
+    // Add a forbidden action to a role
+    add: async (
+      roleId: string,
+      data: { action: string; reason?: string }
+    ): Promise<{ id: string; action: string; reason?: string; agent_role_id: string }> => {
+      return await request(
+        buildApiUrl(
+          API_CONFIG.ENDPOINTS.RULES,
+          `/roles/${roleId}/forbidden-actions`
+        ),
+        {
+          method: "POST",
+          body: JSON.stringify(data),
+        }
+      );
+    },
+
+    // Remove a forbidden action
+    remove: async (actionId: string): Promise<void> => {
+      await request(
+        buildApiUrl(
+          API_CONFIG.ENDPOINTS.RULES,
+          `/roles/forbidden-actions/${actionId}`
+        ),
+        { method: "DELETE" }
+      );
+    },
+  },
+
   // --- Rule Template APIs ---
   templates: {
     // Get all rule templates

--- a/frontend/src/types/forbidden_action.ts
+++ b/frontend/src/types/forbidden_action.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+export const forbiddenActionBaseSchema = z.object({
+  action: z.string(),
+  reason: z.string().nullable().optional(),
+  is_active: z.boolean().default(true),
+});
+
+export const forbiddenActionCreateSchema = forbiddenActionBaseSchema.omit({
+  is_active: true,
+});
+export type ForbiddenActionCreateData = z.infer<typeof forbiddenActionCreateSchema>;
+
+export const forbiddenActionSchema = forbiddenActionBaseSchema.extend({
+  id: z.string(),
+  agent_role_id: z.string(),
+});
+export type ForbiddenAction = z.infer<typeof forbiddenActionSchema>;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -8,6 +8,7 @@ export * from "./comment";
 export * from "./rules";
 export * from "./mcp";
 export * from "./project_template";
+export * from "./forbidden_action";
 export * from "./agent_prompt_template";
 
 // Common types used across the application


### PR DESCRIPTION
## Summary
- add AgentForbiddenActions component for managing forbidden actions
- support adding and removing forbidden actions via API
- expose forbidden action types
- test that API calls are triggered

## Testing
- `npm run lint --prefix frontend`
- `npm run test:components --prefix frontend` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_684174825500832cbb645d288c81b7b2