### PR TITLE
Add agent verification requirement router

### DIFF
--- a/backend/routers/rules/__init__.py
+++ b/backend/routers/rules/__init__.py
@@ -3,6 +3,9 @@ from .workflows.workflows import router as workflows_router
 from .violations.violations import router as violations_router
 from .templates.templates import router as templates_router
 from .roles.roles import router as roles_router
+from .roles.verification_requirements import (
+    router as verification_requirements_router,
+)
 from .mandates.mandates import router as mandates_router
 from .logs.logs import router as logs_router
 
@@ -11,5 +14,6 @@ router.include_router(workflows_router)
 router.include_router(violations_router)
 router.include_router(templates_router)
 router.include_router(roles_router)
+router.include_router(verification_requirements_router)
 router.include_router(mandates_router)
 router.include_router(logs_router)

--- a/backend/routers/rules/roles/verification_requirements.py
+++ b/backend/routers/rules/roles/verification_requirements.py
@@ -1,0 +1,73 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from typing import List
+
+from ....database import get_sync_db as get_db
+from ....schemas.agent_verification_requirement import (
+    AgentVerificationRequirement,
+    AgentVerificationRequirementCreate,
+    AgentVerificationRequirementUpdate,
+)
+from ....services.agent_verification_service import AgentVerificationService
+
+router = APIRouter()
+
+
+def get_service(db: Session = Depends(get_db)) -> AgentVerificationService:
+    return AgentVerificationService(db)
+
+
+@router.post(
+    "/{agent_role_id}/verification-requirements",
+    response_model=AgentVerificationRequirement,
+)
+def create_verification_requirement(
+    agent_role_id: str,
+    requirement: AgentVerificationRequirementCreate,
+    service: AgentVerificationService = Depends(get_service),
+):
+    data = requirement.model_copy(update={"agent_role_id": agent_role_id})
+    return service.create_requirement(data)
+
+
+@router.get(
+    "/{agent_role_id}/verification-requirements",
+    response_model=List[AgentVerificationRequirement],
+)
+def list_verification_requirements(
+    agent_role_id: str,
+    service: AgentVerificationService = Depends(get_service),
+):
+    return service.list_requirements(agent_role_id)
+
+
+@router.put(
+    "/verification-requirements/{requirement_id}",
+    response_model=AgentVerificationRequirement,
+)
+def update_verification_requirement(
+    requirement_id: str,
+    requirement_update: AgentVerificationRequirementUpdate,
+    service: AgentVerificationService = Depends(get_service),
+):
+    result = service.update_requirement(requirement_id, requirement_update)
+    if not result:
+        raise HTTPException(
+            status_code=404,
+            detail="Verification requirement not found",
+        )
+    return result
+
+
+@router.delete("/verification-requirements/{requirement_id}")
+def delete_verification_requirement(
+    requirement_id: str,
+    service: AgentVerificationService = Depends(get_service),
+):
+    success = service.delete_requirement(requirement_id)
+    if not success:
+        raise HTTPException(
+            status_code=404,
+            detail="Verification requirement not found",
+        )
+    return {"message": "Verification requirement removed successfully"}

--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -79,4 +79,10 @@ from .agent_handoff_criteria import (
     AgentHandoffCriteriaCreate,
     AgentHandoffCriteria,
 )
+from .agent_verification_requirement import (
+    AgentVerificationRequirementBase,
+    AgentVerificationRequirementCreate,
+    AgentVerificationRequirementUpdate,
+    AgentVerificationRequirement,
+)
 from .file_ingest import FileIngestInput

--- a/backend/schemas/agent_verification_requirement.py
+++ b/backend/schemas/agent_verification_requirement.py
@@ -1,0 +1,41 @@
+from pydantic import BaseModel, ConfigDict, Field
+from typing import Optional
+from datetime import datetime
+
+
+class AgentVerificationRequirementBase(BaseModel):
+    """Base schema for agent verification requirements."""
+
+    agent_role_id: str = Field(..., description="ID of the related agent role.")
+    requirement: str = Field(..., description="Verification requirement text.")
+    description: Optional[str] = Field(
+        None, description="Optional description of the requirement."
+    )
+    is_mandatory: bool = Field(
+        True, description="Whether this verification is mandatory."
+    )
+
+
+class AgentVerificationRequirementCreate(AgentVerificationRequirementBase):
+    """Schema for creating a verification requirement."""
+
+    pass
+
+
+class AgentVerificationRequirementUpdate(BaseModel):
+    """Schema for updating a verification requirement."""
+
+    requirement: Optional[str] = Field(None, description="Updated requirement text.")
+    description: Optional[str] = Field(None, description="Updated description.")
+    is_mandatory: Optional[bool] = Field(None, description="Updated mandatory flag.")
+
+
+class AgentVerificationRequirement(AgentVerificationRequirementBase):
+    """Schema representing a verification requirement."""
+
+    id: str = Field(..., description="Unique identifier for the requirement.")
+    created_at: datetime = Field(
+        ..., description="Timestamp the requirement was created."
+    )
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/services/agent_verification_service.py
+++ b/backend/services/agent_verification_service.py
@@ -1,0 +1,68 @@
+from sqlalchemy.orm import Session
+from typing import List, Optional
+
+from .. import models
+from ..schemas.agent_verification_requirement import (
+    AgentVerificationRequirementCreate,
+    AgentVerificationRequirementUpdate,
+)
+
+
+class AgentVerificationService:
+    """Service for managing agent verification requirements."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create_requirement(
+        self, requirement_in: AgentVerificationRequirementCreate
+    ) -> models.AgentVerificationRequirement:
+        db_req = models.AgentVerificationRequirement(
+            agent_role_id=requirement_in.agent_role_id,
+            requirement=requirement_in.requirement,
+            description=requirement_in.description,
+            is_mandatory=requirement_in.is_mandatory,
+        )
+        self.db.add(db_req)
+        self.db.commit()
+        self.db.refresh(db_req)
+        return db_req
+
+    def list_requirements(
+        self, agent_role_id: Optional[str] = None
+    ) -> List[models.AgentVerificationRequirement]:
+        query = self.db.query(models.AgentVerificationRequirement)
+        if agent_role_id:
+            query = query.filter(
+                models.AgentVerificationRequirement.agent_role_id == agent_role_id
+            )
+        return query.all()
+
+    def update_requirement(
+        self, requirement_id: str, update: AgentVerificationRequirementUpdate
+    ) -> Optional[models.AgentVerificationRequirement]:
+        db_obj = (
+            self.db.query(models.AgentVerificationRequirement)
+            .filter(models.AgentVerificationRequirement.id == requirement_id)
+            .first()
+        )
+        if not db_obj:
+            return None
+        update_data = update.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(db_obj, field, value)
+        self.db.commit()
+        self.db.refresh(db_obj)
+        return db_obj
+
+    def delete_requirement(self, requirement_id: str) -> bool:
+        db_obj = (
+            self.db.query(models.AgentVerificationRequirement)
+            .filter(models.AgentVerificationRequirement.id == requirement_id)
+            .first()
+        )
+        if not db_obj:
+            return False
+        self.db.delete(db_obj)
+        self.db.commit()
+        return True


### PR DESCRIPTION
## Summary
- implement `AgentVerificationService` with CRUD helpers
- add pydantic schema for verification requirements
- expose new verification requirement routes under rules
- wire router into rules package

## Testing
- `flake8 services/agent_verification_service.py routers/rules/roles/verification_requirements.py schemas/agent_verification_requirement.py`
- `pytest` *(fails: ModuleNotFoundError and several assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68417483e4ec832c92ed22df8c264e6f