### PR TITLE
Add forbidden action MCP tools

### DIFF
--- a/backend/mcp_tools/README.md
+++ b/backend/mcp_tools/README.md
@@ -10,6 +10,7 @@ Key files:
 *   `project_file_tools.py`: Associate memory files with projects.
 *   `rule_tools.py`: Tools for managing agent rules and mandates.
 *   `agent_handoff_tools.py`: Tools for managing agent handoff criteria.
+*   `forbidden_action_tools.py`: Tools for creating and listing forbidden actions for agent roles.
 *   `__init__.py`: Initializes the mcp_tools package.
 
 ## Architecture Diagram
@@ -19,6 +20,29 @@ graph TD
     frontend -->|API requests| backend(Backend)
     backend -->|persists| database[(Database)]
     backend -->|integrates| mcp(MCP Server)
+```
+
+## Usage Examples
+
+### Create a Forbidden Action
+
+```python
+from backend.mcp_tools.forbidden_action_tools import create_forbidden_action_tool
+
+result = await create_forbidden_action_tool(
+    agent_role_id="manager",
+    action="deploy_production",
+    reason="Only ops may deploy",
+    db=session,
+)
+```
+
+### List Forbidden Actions
+
+```python
+from backend.mcp_tools.forbidden_action_tools import list_forbidden_actions_tool
+
+actions = await list_forbidden_actions_tool(agent_role_id="manager", db=session)
 ```
 
 <!-- File List Start -->
@@ -31,6 +55,7 @@ graph TD
 - `project_file_tools.py`
 - `rule_tools.py`
 - `agent_handoff_tools.py`
+- `forbidden_action_tools.py`
 
 <!-- File List End -->
 

--- a/backend/mcp_tools/__init__.py
+++ b/backend/mcp_tools/__init__.py
@@ -18,5 +18,7 @@ __all__ = [
     'delete_handoff_criteria_tool',
     'create_project_template_tool',
     'list_project_templates_tool',
-    'delete_project_template_tool'
+    'delete_project_template_tool',
+    'create_forbidden_action_tool',
+    'list_forbidden_actions_tool'
 ]

--- a/backend/mcp_tools/forbidden_action_tools.py
+++ b/backend/mcp_tools/forbidden_action_tools.py
@@ -1,0 +1,77 @@
+"""MCP Tools for managing forbidden actions for agent roles."""
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+from typing import Optional
+import logging
+
+from backend.models.agent_forbidden_action import AgentForbiddenAction
+from backend.services.audit_log_service import AuditLogService
+
+logger = logging.getLogger(__name__)
+
+
+async def create_forbidden_action_tool(
+    agent_role_id: str,
+    action: str,
+    reason: Optional[str],
+    db: Session,
+) -> dict:
+    """MCP Tool: Create a forbidden action for an agent role."""
+    try:
+        forbidden = AgentForbiddenAction(
+            agent_role_id=agent_role_id,
+            action=action,
+            reason=reason,
+            is_active=True,
+        )
+        db.add(forbidden)
+        db.commit()
+        db.refresh(forbidden)
+        AuditLogService(db).log_action(
+            action="forbidden_action_created",
+            entity_type="agent_forbidden_action",
+            entity_id=forbidden.id,
+            changes={"action": action, "reason": reason},
+        )
+        return {
+            "success": True,
+            "forbidden_action": {
+                "id": forbidden.id,
+                "agent_role_id": forbidden.agent_role_id,
+                "action": forbidden.action,
+                "reason": forbidden.reason,
+                "is_active": forbidden.is_active,
+            },
+        }
+    except Exception as exc:
+        logger.error(f"MCP create forbidden action failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+async def list_forbidden_actions_tool(
+    agent_role_id: Optional[str],
+    db: Session,
+) -> dict:
+    """MCP Tool: List forbidden actions for agent roles."""
+    try:
+        query = db.query(AgentForbiddenAction)
+        if agent_role_id:
+            query = query.filter(AgentForbiddenAction.agent_role_id == agent_role_id)
+        actions = query.all()
+        return {
+            "success": True,
+            "forbidden_actions": [
+                {
+                    "id": fa.id,
+                    "agent_role_id": fa.agent_role_id,
+                    "action": fa.action,
+                    "reason": fa.reason,
+                    "is_active": fa.is_active,
+                }
+                for fa in actions
+            ],
+        }
+    except Exception as exc:
+        logger.error(f"MCP list forbidden actions failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/backend/routers/mcp/core.py
+++ b/backend/routers/mcp/core.py
@@ -878,3 +878,48 @@ async def mcp_delete_handoff_criteria(
     except Exception as e:
         logger.error(f"MCP delete handoff criteria failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/mcp-tools/forbidden-action/create",
+    tags=["mcp-tools"],
+    operation_id="create_forbidden_action_tool",
+)
+async def mcp_create_forbidden_action(
+    agent_role_id: str,
+    action: str,
+    reason: Optional[str] = None,
+    db: Session = Depends(get_db_session),
+):
+    """MCP Tool: Create a forbidden action for an agent role."""
+    try:
+        from ...mcp_tools.forbidden_action_tools import create_forbidden_action_tool
+
+        return await create_forbidden_action_tool(
+            agent_role_id=agent_role_id,
+            action=action,
+            reason=reason,
+            db=db,
+        )
+    except Exception as e:
+        logger.error(f"MCP create forbidden action failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get(
+    "/mcp-tools/forbidden-action/list",
+    tags=["mcp-tools"],
+    operation_id="list_forbidden_actions_tool",
+)
+async def mcp_list_forbidden_actions(
+    agent_role_id: Optional[str] = Query(None),
+    db: Session = Depends(get_db_session),
+):
+    """MCP Tool: List forbidden actions for agent roles."""
+    try:
+        from ...mcp_tools.forbidden_action_tools import list_forbidden_actions_tool
+
+        return await list_forbidden_actions_tool(agent_role_id, db)
+    except Exception as e:
+        logger.error(f"MCP list forbidden actions failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
## Summary
- add `forbidden_action_tools` with create and list functions
- expose the new tools in `__init__.py`
- mount endpoints for them in the MCP core router
- document usage examples in the MCP tools README

## Testing
- `flake8 mcp_tools/forbidden_action_tools.py routers/mcp/core.py`
- `pytest` *(fails: tests/test_memory_ingestion.py::test_ingest_file_and_retrieve, tests/test_openapi.py::test_openapi_contains_key_paths, tests/test_project_task_endpoints.py::test_list_projects_includes_fixture, tests/test_project_task_endpoints.py::test_get_project_by_id, tests/test_project_task_endpoints.py::test_create_project_via_api, tests/test_project_task_endpoints.py::test_task_crud_flow, tests/test_project_task_endpoints.py::test_create_task_requires_project)*

------
https://chatgpt.com/codex/tasks/task_e_6841747ef2c8832c8c762b37aa01495d