### PR TITLE
feat: add agent handoff criteria api

### DIFF
--- a/frontend/src/services/api/agent_handoff_criteria.ts
+++ b/frontend/src/services/api/agent_handoff_criteria.ts
@@ -1,0 +1,47 @@
+import {
+  AgentHandoffCriteria,
+  AgentHandoffCriteriaCreateData,
+} from '@/types/agents';
+import { request } from './request';
+import { buildApiUrl, API_CONFIG } from './config';
+
+// Create new handoff criteria
+export const createAgentHandoffCriteria = async (
+  data: AgentHandoffCriteriaCreateData
+): Promise<AgentHandoffCriteria> => {
+  const response = await request<{
+    success: boolean;
+    criteria: AgentHandoffCriteria;
+  }>(buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/handoff/create'), {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+  return response.criteria;
+};
+
+// List handoff criteria optionally filtered by agent role
+export const listAgentHandoffCriteria = async (
+  agentRoleId?: string
+): Promise<AgentHandoffCriteria[]> => {
+  const query = agentRoleId
+    ? `?agent_role_id=${encodeURIComponent(agentRoleId)}`
+    : '';
+  const response = await request<{
+    success: boolean;
+    criteria: AgentHandoffCriteria[];
+  }>(buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, `/handoff/list${query}`));
+  return response.criteria;
+};
+
+// Delete handoff criteria by ID
+export const deleteAgentHandoffCriteria = async (
+  criteriaId: string
+): Promise<void> => {
+  await request<{ success: boolean }>(
+    buildApiUrl(
+      API_CONFIG.ENDPOINTS.MCP_TOOLS,
+      `/handoff/delete?criteria_id=${encodeURIComponent(criteriaId)}`
+    ),
+    { method: 'DELETE' }
+  );
+};

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -11,3 +11,4 @@ export * from "./mcp";
 export * from "./users";
 export * from "./audit_logs";
 export * from "./project_templates";
+export * from "./agent_handoff_criteria";

--- a/frontend/src/types/agents.ts
+++ b/frontend/src/types/agents.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+// --- Agent Handoff Criteria Schemas ---
+export const agentHandoffCriteriaBaseSchema = z.object({
+  agent_role_id: z.string(),
+  criteria: z.string(),
+  description: z.string().nullable().optional(),
+  target_agent_role: z.string().nullable().optional(),
+  is_active: z.boolean().default(true),
+});
+
+export const agentHandoffCriteriaCreateSchema = agentHandoffCriteriaBaseSchema;
+export type AgentHandoffCriteriaCreateData = z.infer<
+  typeof agentHandoffCriteriaCreateSchema
+>;
+
+export const agentHandoffCriteriaSchema = agentHandoffCriteriaBaseSchema.extend(
+  {
+    id: z.string(),
+    created_at: z.string().datetime({ message: 'Invalid ISO datetime string' }),
+  }
+);
+
+export type AgentHandoffCriteria = z.infer<typeof agentHandoffCriteriaSchema>;
+
+export interface AgentHandoffCriteriaResponse {
+  success: boolean;
+  criteria: AgentHandoffCriteria;
+}
+
+export interface AgentHandoffCriteriaListResponse {
+  success: boolean;
+  criteria: AgentHandoffCriteria[];
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -9,6 +9,7 @@ export * from "./rules";
 export * from "./mcp";
 export * from "./project_template";
 export * from "./agent_prompt_template";
+export * from "./agents";
 
 // Common types used across the application
 // Canonical shared sort direction type for all entities


### PR DESCRIPTION
## Summary
- add `agent_handoff_criteria` API service with create/list/delete
- define `AgentHandoffCriteria` types
- export new APIs and types

## Testing
- `npm run lint`
- `npm run test:coverage` *(fails: observer.observe is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6841747be464832c9c5fc47b16322522