### PR TITLE
Implement handoff criteria router

### DIFF
--- a/backend/routers/rules/__init__.py
+++ b/backend/routers/rules/__init__.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter
 from .workflows.workflows import router as workflows_router
 from .violations.violations import router as violations_router
 from .templates.templates import router as templates_router
-from .roles.roles import router as roles_router
+from .roles import router as roles_router
 from .mandates.mandates import router as mandates_router
 from .logs.logs import router as logs_router
 

--- a/backend/routers/rules/roles/__init__.py
+++ b/backend/routers/rules/roles/__init__.py
@@ -1,1 +1,11 @@
-# Rules module\n
+from fastapi import APIRouter
+from .roles import router as roles_router
+from .capabilities import router as capabilities_router
+from .forbidden_actions import router as forbidden_actions_router
+from .handoff_criteria import router as handoff_criteria_router
+
+router = APIRouter()
+router.include_router(roles_router)
+router.include_router(capabilities_router)
+router.include_router(forbidden_actions_router)
+router.include_router(handoff_criteria_router)

--- a/backend/routers/rules/roles/handoff_criteria.py
+++ b/backend/routers/rules/roles/handoff_criteria.py
@@ -1,0 +1,45 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+from typing import List, Optional
+
+from ....database import get_sync_db as get_db
+from ....services.agent_handoff_service import AgentHandoffService
+from ....schemas.agent_handoff_criteria import (
+    AgentHandoffCriteria,
+    AgentHandoffCriteriaCreate,
+)
+
+router = APIRouter()
+
+
+@router.get("/", response_model=List[AgentHandoffCriteria])
+def list_handoff_criteria(
+    agent_role_id: Optional[str] = Query(None, description="Filter by agent role"),
+    db: Session = Depends(get_db),
+):
+    """List handoff criteria, optionally filtered by agent role."""
+    service = AgentHandoffService(db)
+    return service.list_criteria(agent_role_id)
+
+
+@router.post("/", response_model=AgentHandoffCriteria)
+def create_handoff_criteria(
+    criteria: AgentHandoffCriteriaCreate,
+    db: Session = Depends(get_db),
+):
+    """Create new handoff criteria."""
+    service = AgentHandoffService(db)
+    return service.create_criteria(criteria)
+
+
+@router.delete("/{criteria_id}")
+def delete_handoff_criteria(
+    criteria_id: str,
+    db: Session = Depends(get_db),
+):
+    """Delete handoff criteria by ID."""
+    service = AgentHandoffService(db)
+    success = service.delete_criteria(criteria_id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Criteria not found")
+    return {"message": "Criteria deleted successfully"}


### PR DESCRIPTION
## Summary
- add new router for handoff criteria CRUD
- aggregate role routers in `roles/__init__.py`
- update rules router to use role aggregator

## Testing
- `flake8 routers/rules/roles/handoff_criteria.py`
- `flake8 routers/rules/roles/__init__.py`
- `flake8 routers/rules/__init__.py`
- `pytest -q` *(fails: AttributeError in memory_service, openapi schema missing, project endpoints 404)*

------
https://chatgpt.com/codex/tasks/task_e_68417478f654832cb358f1b7fbe46e92