### PR TITLE
Add agent capabilities management

### DIFF
--- a/frontend/src/components/agents/AgentCapabilities.tsx
+++ b/frontend/src/components/agents/AgentCapabilities.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Flex,
+  Input,
+  List,
+  ListItem,
+  Text,
+  useToast,
+} from "@chakra-ui/react";
+import { AddIcon, DeleteIcon } from "@chakra-ui/icons";
+import { capabilityApi, Capability } from "@/services/api/capabilities";
+
+interface AgentCapabilitiesProps {
+  roleId: string;
+}
+
+const AgentCapabilities: React.FC<AgentCapabilitiesProps> = ({ roleId }) => {
+  const [capabilities, setCapabilities] = useState<Capability[]>([]);
+  const [capName, setCapName] = useState("");
+  const [capDescription, setCapDescription] = useState("");
+  const toast = useToast();
+
+  const loadCapabilities = async () => {
+    try {
+      const data = await capabilityApi.list(roleId);
+      setCapabilities(data);
+    } catch (err) {
+      toast({
+        title: "Failed to load capabilities",
+        description: err instanceof Error ? err.message : String(err),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  useEffect(() => {
+    loadCapabilities();
+  }, [roleId]);
+
+  const handleAdd = async () => {
+    if (!capName.trim()) return;
+    try {
+      const newCap = await capabilityApi.add(roleId, capName.trim(), capDescription.trim() || undefined);
+      setCapabilities((prev) => [...prev, newCap]);
+      setCapName("");
+      setCapDescription("");
+    } catch (err) {
+      toast({
+        title: "Failed to add capability",
+        description: err instanceof Error ? err.message : String(err),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  const handleDelete = async (capabilityId: string) => {
+    try {
+      await capabilityApi.remove(capabilityId);
+      setCapabilities((prev) => prev.filter((cap) => cap.id !== capabilityId));
+    } catch (err) {
+      toast({
+        title: "Failed to remove capability",
+        description: err instanceof Error ? err.message : String(err),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  return (
+    <Box p={4} maxW="600px" mx="auto">
+      <Flex mb={4} gap={2} align="center">
+        <Input
+          placeholder="Capability"
+          value={capName}
+          onChange={(e) => setCapName(e.target.value)}
+        />
+        <Input
+          placeholder="Description"
+          value={capDescription}
+          onChange={(e) => setCapDescription(e.target.value)}
+        />
+        <Button leftIcon={<AddIcon />} onClick={handleAdd} size="sm">
+          Add
+        </Button>
+      </Flex>
+      <List spacing={3}>
+        {capabilities.map((cap) => (
+          <ListItem key={cap.id} borderWidth="1px" borderRadius="md" p={2}>
+            <Flex justify="space-between" align="center">
+              <Box>
+                <Text fontWeight="bold">{cap.capability}</Text>
+                {cap.description && (
+                  <Text fontSize="sm" color="gray.500">
+                    {cap.description}
+                  </Text>
+                )}
+              </Box>
+              <Button
+                size="sm"
+                colorScheme="red"
+                leftIcon={<DeleteIcon />}
+                onClick={() => handleDelete(cap.id)}
+              >
+                Delete
+              </Button>
+            </Flex>
+          </ListItem>
+        ))}
+      </List>
+    </Box>
+  );
+};
+
+export default AgentCapabilities;

--- a/frontend/src/components/agents/__tests__/AgentCapabilities.test.tsx
+++ b/frontend/src/components/agents/__tests__/AgentCapabilities.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@/__tests__/utils/test-utils';
+import AgentCapabilities from '../AgentCapabilities';
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual('@chakra-ui/react');
+  return {
+    ...actual,
+    useToast: () => vi.fn(),
+    useColorModeValue: (l: any) => l,
+  };
+});
+
+vi.mock('@/services/api/capabilities', () => ({
+  capabilityApi: {
+    list: vi.fn().mockResolvedValue([]),
+    add: vi.fn().mockResolvedValue({ id: '1', agent_role_id: 'r', capability: 'cap' }),
+    remove: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+describe('AgentCapabilities', () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders component', async () => {
+    render(<AgentCapabilities roleId="role-1" />, { wrapper: ({ children }) => <div>{children}</div> });
+    expect(document.body).toBeInTheDocument();
+  });
+
+  it('handles interactions', async () => {
+    render(<AgentCapabilities roleId="role-1" />, { wrapper: ({ children }) => <div>{children}</div> });
+    const input = screen.getAllByRole('textbox');
+    if (input.length > 0) {
+      await user.type(input[0], 'test');
+    }
+    const button = screen.getByRole('button', { name: /add/i });
+    await user.click(button);
+    expect(button).toBeInTheDocument();
+  });
+});

--- a/frontend/src/services/api/capabilities.ts
+++ b/frontend/src/services/api/capabilities.ts
@@ -1,0 +1,40 @@
+import { request } from './request';
+import { buildApiUrl, API_CONFIG } from './config';
+
+export interface Capability {
+  id: string;
+  agent_role_id: string;
+  capability: string;
+  description?: string | null;
+  is_active?: boolean;
+}
+
+export const capabilityApi = {
+  list: async (agentRoleId: string): Promise<Capability[]> => {
+    const role = await request<{ capabilities: Capability[] }>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/roles/${agentRoleId}`)
+    );
+    return role.capabilities || [];
+  },
+
+  add: async (
+    agentRoleId: string,
+    capability: string,
+    description?: string
+  ): Promise<Capability> => {
+    return request<Capability>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/roles/${agentRoleId}/capabilities`),
+      {
+        method: 'POST',
+        body: JSON.stringify({ capability, description }),
+      }
+    );
+  },
+
+  remove: async (capabilityId: string): Promise<void> => {
+    await request(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/roles/capabilities/${capabilityId}`),
+      { method: 'DELETE' }
+    );
+  },
+};

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -11,3 +11,4 @@ export * from "./mcp";
 export * from "./users";
 export * from "./audit_logs";
 export * from "./project_templates";
+export * from "./capabilities";


### PR DESCRIPTION
## Summary
- implement AgentCapabilities component for editing role capabilities
- integrate new capability API client
- expose capability API via index exports
- provide unit tests for AgentCapabilities

## Testing
- `npm run lint`
- `npm test` *(fails: observer.observe is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_684174774ce0832c94827f4ad6407c9b