### PR TITLE
Add agent capability MCP tools

### DIFF
--- a/SYSTEM_GUIDE.md
+++ b/SYSTEM_GUIDE.md
@@ -78,6 +78,11 @@ alembic revision --autogenerate -m "description"
 alembic upgrade head
 ```
 
+### MCP Tools
+- `add_agent_capability_tool` – add a capability to an agent role.
+- `list_agent_capabilities_tool` – list capabilities for a role.
+- `remove_agent_capability_tool` – remove a capability by ID.
+
 ## 📊 System Status
 
 ### ✅ **COMPLETED ALIGNMENTS**

--- a/backend/mcp_tools/__init__.py
+++ b/backend/mcp_tools/__init__.py
@@ -16,6 +16,9 @@ __all__ = [
     'create_handoff_criteria_tool',
     'list_handoff_criteria_tool',
     'delete_handoff_criteria_tool',
+    'add_agent_capability_tool',
+    'list_agent_capabilities_tool',
+    'remove_agent_capability_tool',
     'create_project_template_tool',
     'list_project_templates_tool',
     'delete_project_template_tool'

--- a/backend/mcp_tools/agent_capability_tools.py
+++ b/backend/mcp_tools/agent_capability_tools.py
@@ -1,0 +1,88 @@
+import logging
+from typing import Optional
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from backend.models.agent_capability import AgentCapability
+
+logger = logging.getLogger(__name__)
+
+
+async def add_agent_capability_tool(
+    agent_role_id: str,
+    capability: str,
+    description: Optional[str],
+    db: Session,
+) -> dict:
+    """MCP Tool: Add a capability to an agent role."""
+    try:
+        new_cap = AgentCapability(
+            agent_role_id=agent_role_id,
+            capability=capability,
+            description=description,
+        )
+        db.add(new_cap)
+        db.commit()
+        db.refresh(new_cap)
+        return {
+            "success": True,
+            "capability": {
+                "id": new_cap.id,
+                "agent_role_id": new_cap.agent_role_id,
+                "capability": new_cap.capability,
+                "description": new_cap.description,
+                "is_active": new_cap.is_active,
+            },
+        }
+    except Exception as exc:
+        logger.error(f"MCP add capability failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+async def list_agent_capabilities_tool(
+    agent_role_id: Optional[str],
+    db: Session,
+) -> dict:
+    """MCP Tool: List capabilities for an agent role."""
+    try:
+        query = db.query(AgentCapability)
+        if agent_role_id:
+            query = query.filter(AgentCapability.agent_role_id == agent_role_id)
+        caps = query.all()
+        return {
+            "success": True,
+            "capabilities": [
+                {
+                    "id": cap.id,
+                    "agent_role_id": cap.agent_role_id,
+                    "capability": cap.capability,
+                    "description": cap.description,
+                    "is_active": cap.is_active,
+                }
+                for cap in caps
+            ],
+        }
+    except Exception as exc:
+        logger.error(f"MCP list capabilities failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+async def remove_agent_capability_tool(capability_id: str, db: Session) -> dict:
+    """MCP Tool: Remove a capability from an agent role."""
+    try:
+        cap = (
+            db.query(AgentCapability)
+            .filter(AgentCapability.id == capability_id)
+            .first()
+        )
+        if not cap:
+            raise HTTPException(status_code=404, detail="Capability not found")
+        db.delete(cap)
+        db.commit()
+        return {"success": True}
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"MCP remove capability failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))


### PR DESCRIPTION
## Summary
- implement add/list/remove capability functions for MCP
- expose capability tools via MCP router
- document new tools in the system guide

## Testing
- `flake8 backend/mcp_tools/agent_capability_tools.py backend/routers/mcp/core.py backend/mcp_tools/__init__.py`
- `pytest backend/tests` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68417475b2e4832c8b52b39faeb84082