### PR TITLE
Add capability service and router

### DIFF
--- a/backend/routers/rules/roles/__init__.py
+++ b/backend/routers/rules/roles/__init__.py
@@ -1,1 +1,17 @@
-# Rules module\n
+from fastapi import APIRouter
+from .roles import router as roles_router
+from .capabilities import router as capabilities_router
+from .forbidden_actions import router as forbidden_actions_router
+
+router = APIRouter()
+router.include_router(roles_router, prefix="", tags=["agent-roles"])
+router.include_router(
+    capabilities_router,
+    prefix="",
+    tags=["agent-capabilities"],
+)
+router.include_router(
+    forbidden_actions_router,
+    prefix="",
+    tags=["agent-forbidden-actions"],
+)

--- a/backend/routers/rules/roles/capabilities.py
+++ b/backend/routers/rules/roles/capabilities.py
@@ -1,32 +1,69 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
-from typing import Optional
+from typing import List, Optional
 
-from ....database import get_db
-from ....crud import rules as crud_rules
+from ....database import get_sync_db as get_db
+from ....services.agent_capability_service import AgentCapabilityService
+from ....models import AgentCapability
 
-router = APIRouter()  # Agent Capabilities
-@router.post("/{agent_role_id}/capabilities")
+router = APIRouter()
 
 
-def add_capability(
+def get_service(db: Session = Depends(get_db)) -> AgentCapabilityService:
+    return AgentCapabilityService(db)
+
+
+@router.post("/{agent_role_id}/capabilities", response_model=AgentCapability)
+def create_capability(
     agent_role_id: str,
     capability: str,
     description: Optional[str] = None,
-    db: Session = Depends(get_db)
+    service: AgentCapabilityService = Depends(get_service),
 ):
-    """Add a capability to an agent role"""
-    return crud_rules.add_agent_capability(db, agent_role_id, capability, description)
+    """Add a capability to an agent role."""
+    return service.create_capability(agent_role_id, capability, description)
+
+
+@router.get("/{agent_role_id}/capabilities", response_model=List[AgentCapability])
+def list_capabilities(
+    agent_role_id: str,
+    active_only: bool = True,
+    service: AgentCapabilityService = Depends(get_service),
+):
+    """List capabilities for an agent role."""
+    return service.list_capabilities(
+        agent_role_id=agent_role_id,
+        active_only=active_only,
+    )
+
+
+@router.put("/capabilities/{capability_id}", response_model=AgentCapability)
+def update_capability(
+    capability_id: str,
+    capability: Optional[str] = None,
+    description: Optional[str] = None,
+    is_active: Optional[bool] = None,
+    service: AgentCapabilityService = Depends(get_service),
+):
+    """Update an existing capability."""
+    result = service.update_capability(
+        capability_id,
+        capability,
+        description,
+        is_active,
+    )
+    if not result:
+        raise HTTPException(status_code=404, detail="Capability not found")
+    return result
+
 
 @router.delete("/capabilities/{capability_id}")
-
-
-def remove_capability(
+def delete_capability(
     capability_id: str,
-    db: Session = Depends(get_db)
+    service: AgentCapabilityService = Depends(get_service),
 ):
-    """Remove an agent capability"""
-    success = crud_rules.remove_agent_capability(db, capability_id)
+    """Remove a capability from a role."""
+    success = service.delete_capability(capability_id)
     if not success:
-    raise HTTPException(status_code=404, detail="Capability not found")
+        raise HTTPException(status_code=404, detail="Capability not found")
     return {"message": "Capability removed successfully"}

--- a/backend/services/agent_capability_service.py
+++ b/backend/services/agent_capability_service.py
@@ -1,0 +1,82 @@
+from sqlalchemy.orm import Session
+from typing import List, Optional
+
+from .. import models
+
+
+class AgentCapabilityService:
+    """Service layer for managing agent capabilities."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create_capability(
+        self,
+        agent_role_id: str,
+        capability: str,
+        description: Optional[str] = None,
+    ) -> models.AgentCapability:
+        """Create and persist a new capability for an agent role."""
+        db_capability = models.AgentCapability(
+            agent_role_id=agent_role_id,
+            capability=capability,
+            description=description,
+        )
+        self.db.add(db_capability)
+        self.db.commit()
+        self.db.refresh(db_capability)
+        return db_capability
+
+    def update_capability(
+        self,
+        capability_id: str,
+        capability: Optional[str] = None,
+        description: Optional[str] = None,
+        is_active: Optional[bool] = None,
+    ) -> Optional[models.AgentCapability]:
+        """Update an existing capability by ID."""
+        db_capability = (
+            self.db.query(models.AgentCapability)
+            .filter(models.AgentCapability.id == capability_id)
+            .first()
+        )
+        if not db_capability:
+            return None
+
+        if capability is not None:
+            db_capability.capability = capability
+        if description is not None:
+            db_capability.description = description
+        if is_active is not None:
+            db_capability.is_active = is_active
+
+        self.db.commit()
+        self.db.refresh(db_capability)
+        return db_capability
+
+    def list_capabilities(
+        self,
+        agent_role_id: Optional[str] = None,
+        active_only: bool = True,
+    ) -> List[models.AgentCapability]:
+        """Retrieve capabilities, optionally filtered by role and active state."""
+        query = self.db.query(models.AgentCapability)
+        if agent_role_id:
+            query = query.filter(models.AgentCapability.agent_role_id == agent_role_id)
+        if active_only:
+            query = query.filter(models.AgentCapability.is_active.is_(True))
+        return query.all()
+
+    def delete_capability(self, capability_id: str) -> bool:
+        """Remove a capability by ID."""
+        db_capability = (
+            self.db.query(models.AgentCapability)
+            .filter(models.AgentCapability.id == capability_id)
+            .first()
+        )
+        if not db_capability:
+            return False
+
+        self.db.delete(db_capability)
+        self.db.commit()
+        return True


### PR DESCRIPTION
## Summary
- add service for agent capabilities
- expose CRUD routes for capabilities
- wire capabilities router into roles API

## Testing
- `flake8 services/agent_capability_service.py routers/rules/roles/capabilities.py routers/rules/roles/__init__.py`
- `pytest -q` *(fails: ImportError: cannot import name 'Undefined' from 'pydantic.fields')*

------
https://chatgpt.com/codex/tasks/task_e_684174759604832c8a5982cd14e164ca