### PR TITLE
Add user role management page

### DIFF
--- a/frontend/src/app/user-roles/page.tsx
+++ b/frontend/src/app/user-roles/page.tsx
@@ -1,0 +1,151 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Select,
+  Button,
+  Spinner,
+  useToast,
+} from '@chakra-ui/react';
+import { getUsers } from '@/services/api/users';
+import { assignRole, removeRole } from '@/services/api/user_roles';
+import { User, UserRole } from '@/types/user';
+
+const UserRolesPage: React.FC = () => {
+  const [users, setUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedRoles, setSelectedRoles] = useState<Record<string, UserRole>>(
+    {}
+  );
+  const toast = useToast();
+
+  const fetchUsers = async () => {
+    setLoading(true);
+    try {
+      const data = await getUsers(0, 100);
+      setUsers(data);
+    } catch (err: any) {
+      toast({
+        title: 'Failed to load users',
+        description: err.message || String(err),
+        status: 'error',
+        duration: 4000,
+        isClosable: true,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchUsers();
+  }, []);
+
+  const handleAssign = async (userId: string) => {
+    const role = selectedRoles[userId];
+    if (!role) return;
+    try {
+      await assignRole(userId, role);
+      toast({ title: 'Role assigned', status: 'success', duration: 2000 });
+      fetchUsers();
+    } catch (err: any) {
+      toast({
+        title: 'Failed to assign role',
+        description: err.message || String(err),
+        status: 'error',
+        duration: 4000,
+        isClosable: true,
+      });
+    }
+  };
+
+  const handleRemove = async (userId: string, role: string) => {
+    try {
+      await removeRole(userId, role);
+      toast({ title: 'Role removed', status: 'success', duration: 2000 });
+      fetchUsers();
+    } catch (err: any) {
+      toast({
+        title: 'Failed to remove role',
+        description: err.message || String(err),
+        status: 'error',
+        duration: 4000,
+        isClosable: true,
+      });
+    }
+  };
+
+  if (loading) {
+    return (
+      <Box p={8} textAlign="center">
+        <Spinner />
+      </Box>
+    );
+  }
+
+  return (
+    <Box p={4} overflowX="auto">
+      <Table variant="simple">
+        <Thead>
+          <Tr>
+            <Th>User</Th>
+            <Th>Roles</Th>
+            <Th>Assign Role</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {users.map((user) => (
+            <Tr key={user.id}>
+              <Td>{user.username}</Td>
+              <Td>
+                <Box display="flex" gap={2} flexWrap="wrap">
+                  {user.user_roles.map((r) => (
+                    <Button
+                      key={r.role_name}
+                      size="xs"
+                      onClick={() => handleRemove(user.id, r.role_name)}
+                    >
+                      {r.role_name} ✕
+                    </Button>
+                  ))}
+                </Box>
+              </Td>
+              <Td>
+                <Select
+                  placeholder="Select role"
+                  size="sm"
+                  value={selectedRoles[user.id] || ''}
+                  onChange={(e) =>
+                    setSelectedRoles({
+                      ...selectedRoles,
+                      [user.id]: e.target.value as UserRole,
+                    })
+                  }
+                  mr={2}
+                  maxW="150px"
+                >
+                  {Object.values(UserRole).map((role) => (
+                    <option key={role} value={role}>
+                      {role}
+                    </option>
+                  ))}
+                </Select>
+                <Button size="sm" onClick={() => handleAssign(user.id)}>
+                  Assign
+                </Button>
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </Box>
+  );
+};
+
+export default UserRolesPage;

--- a/frontend/src/services/api/__tests__/user_roles.test.ts
+++ b/frontend/src/services/api/__tests__/user_roles.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { assignRole, removeRole } from '../user_roles';
+import { buildApiUrl, API_CONFIG } from '../config';
+import { request } from '../request';
+
+vi.mock('../request', () => ({ request: vi.fn() }));
+const requestMock = request as unknown as vi.Mock;
+
+describe('user_roles service', () => {
+  beforeEach(() => {
+    requestMock.mockResolvedValue(undefined);
+    vi.clearAllMocks();
+  });
+
+  it('assignRole calls correct URL', async () => {
+    await assignRole('1', 'admin');
+    expect(requestMock).toHaveBeenCalledWith(
+      buildApiUrl(API_CONFIG.ENDPOINTS.USERS, '/1/roles'),
+      { method: 'POST', body: JSON.stringify({ role_name: 'admin' }) }
+    );
+  });
+
+  it('removeRole calls correct URL', async () => {
+    await removeRole('1', 'admin');
+    expect(requestMock).toHaveBeenCalledWith(
+      buildApiUrl(API_CONFIG.ENDPOINTS.USERS, '/1/roles/admin'),
+      { method: 'DELETE' }
+    );
+  });
+});

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -9,5 +9,6 @@ export * from "./comments";
 export * from "./rules";
 export * from "./mcp";
 export * from "./users";
+export * from "./user_roles";
 export * from "./audit_logs";
 export * from "./project_templates";

--- a/frontend/src/services/api/user_roles.ts
+++ b/frontend/src/services/api/user_roles.ts
@@ -1,0 +1,34 @@
+import { request } from './request';
+import { buildApiUrl, API_CONFIG } from './config';
+import { UserRoleObject } from '@/types/user';
+
+export const assignRole = async (
+  userId: string,
+  roleName: string
+): Promise<UserRoleObject> => {
+  return request<UserRoleObject>(
+    buildApiUrl(API_CONFIG.ENDPOINTS.USERS, `/${userId}/roles`),
+    {
+      method: 'POST',
+      body: JSON.stringify({ role_name: roleName }),
+    }
+  );
+};
+
+export const removeRole = async (
+  userId: string,
+  roleName: string
+): Promise<{ message: string }> => {
+  return request<{ message: string }>(
+    buildApiUrl(API_CONFIG.ENDPOINTS.USERS, `/${userId}/roles/${roleName}`),
+    { method: 'DELETE' }
+  );
+};
+
+export const getUserRoles = async (
+  userId: string
+): Promise<UserRoleObject[]> => {
+  return request<UserRoleObject[]>(
+    buildApiUrl(API_CONFIG.ENDPOINTS.USERS, `/${userId}/roles`)
+  );
+};


### PR DESCRIPTION
## Summary
- add user role API helpers
- expose role API from service index
- create user roles management page
- test user roles API calls

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68417474cd60832c9aee494a860b3b95