### PR TITLE
Add user role API helper

### DIFF
--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -11,3 +11,4 @@ export * from "./mcp";
 export * from "./users";
 export * from "./audit_logs";
 export * from "./project_templates";
+export * from "./user_roles";

--- a/frontend/src/services/api/user_roles.ts
+++ b/frontend/src/services/api/user_roles.ts
@@ -1,0 +1,40 @@
+import { request } from './request';
+import { buildApiUrl, API_CONFIG } from './config';
+import { UserRoleAssociation } from '@/types/user_role';
+
+/**
+ * Assign a role to a user
+ */
+export const assignRole = async (
+  userId: string,
+  roleName: string,
+): Promise<UserRoleAssociation> => {
+  return request<UserRoleAssociation>(
+    buildApiUrl(API_CONFIG.ENDPOINTS.USERS, `/${userId}/roles/`),
+    { method: 'POST', body: JSON.stringify({ role_name: roleName }) },
+  );
+};
+
+/**
+ * List roles assigned to a user
+ */
+export const listRoles = async (
+  userId: string,
+): Promise<UserRoleAssociation[]> => {
+  return request<UserRoleAssociation[]>(
+    buildApiUrl(API_CONFIG.ENDPOINTS.USERS, `/${userId}/roles/`),
+  );
+};
+
+/**
+ * Remove a role from a user
+ */
+export const removeRole = async (
+  userId: string,
+  roleName: string,
+): Promise<void> => {
+  await request<void>(
+    buildApiUrl(API_CONFIG.ENDPOINTS.USERS, `/${userId}/roles/${roleName}`),
+    { method: 'DELETE' },
+  );
+};

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -2,6 +2,7 @@ export * from "./project";
 export * from "./agent";
 export * from "./task";
 export * from "./user";
+export * from "./user_role";
 export * from "./audit_log";
 export * from "./memory";
 export * from "./comment";

--- a/frontend/src/types/user_role.ts
+++ b/frontend/src/types/user_role.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+import { UserRole } from './user';
+
+// --- User Role Schemas ---
+export const userRoleBaseSchema = z.object({
+  user_id: z.string(),
+  role_name: z.nativeEnum(UserRole),
+});
+
+export type UserRoleAssociation = z.infer<typeof userRoleBaseSchema>;
+
+export const userRoleCreateSchema = userRoleBaseSchema;
+
+export type UserRoleCreateData = z.infer<typeof userRoleCreateSchema>;


### PR DESCRIPTION
## Summary
- add `user_roles.ts` for role management
- create user role types and export them
- re-export user role utilities in API and type indexes

## Testing
- `npm run lint` *(fails: Bus error)*
- `npm test` *(fails: TypeError: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68417473926c832c94d0a415be62fd6d