### PR TITLE
Add user role management endpoints

### DIFF
--- a/backend/app_factory.py
+++ b/backend/app_factory.py
@@ -68,6 +68,17 @@ def include_app_routers(application: FastAPI) -> None:
         logger.warning(f"Could not import users router: {e}")
 
     try:
+        from .routers.users.roles import router as user_roles_router
+        application.include_router(
+            user_roles_router,
+            prefix="/api/v1/users",
+            tags=["user-roles"],
+        )
+        logger.info("User roles router included successfully")
+    except ImportError as e:
+        logger.warning(f"Could not import user roles router: {e}")
+
+    try:
         from .routers.admin import router as admin_router
         application.include_router(admin_router, prefix="/api/v1", tags=["admin"])
         logger.info("Admin router included successfully")

--- a/backend/routers/users/__init__.py
+++ b/backend/routers/users/__init__.py
@@ -1,7 +1,9 @@
 from fastapi import APIRouter
 from .core.core import router as core_router
 from .auth.auth import router as auth_router
+from .roles import router as roles_router
 
 router = APIRouter()
 router.include_router(core_router)
 router.include_router(auth_router)
+router.include_router(roles_router)

--- a/backend/routers/users/roles.py
+++ b/backend/routers/users/roles.py
@@ -1,0 +1,87 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ...database import get_db
+from ...services.user_role_service import UserRoleService
+from ...services.audit_log_service import AuditLogService
+from ...auth import get_current_active_user
+from ...models import User as UserModel
+from ...schemas.user import UserRole, UserRoleCreate
+from ...schemas.api_responses import DataResponse, ListResponse
+
+router = APIRouter(prefix="/{user_id}/roles", tags=["User Roles"])
+
+
+def get_user_role_service(db: AsyncSession = Depends(get_db)) -> UserRoleService:
+    return UserRoleService(db)
+
+
+def get_audit_log_service(db: AsyncSession = Depends(get_db)) -> AuditLogService:
+    return AuditLogService(db)
+
+
+@router.post(
+    "/",
+    response_model=DataResponse[UserRole],
+    status_code=status.HTTP_201_CREATED,
+)
+async def assign_role(
+    user_id: str,
+    role: UserRoleCreate,
+    user_role_service: UserRoleService = Depends(get_user_role_service),
+    audit_log_service: AuditLogService = Depends(get_audit_log_service),
+    current_user: UserModel = Depends(get_current_active_user),
+):
+    """Assign a role to a user."""
+    if role.user_id and role.user_id != user_id:
+        raise HTTPException(status_code=400, detail="user_id mismatch")
+
+    db_role = await user_role_service.assign_role_to_user(user_id, role.role_name)
+    await audit_log_service.create_log(
+        action="assign_role",
+        user_id=current_user.id,
+        details={"target_user_id": user_id, "role": role.role_name.value},
+    )
+    return DataResponse[UserRole](
+        data=UserRole.model_validate(db_role),
+        message="Role assigned",
+    )
+
+
+@router.get("/", response_model=ListResponse[UserRole])
+async def list_roles(
+    user_id: str,
+    user_role_service: UserRoleService = Depends(get_user_role_service),
+):
+    """List roles for a user."""
+    roles = await user_role_service.get_user_roles(user_id)
+    pydantic_roles = [UserRole.model_validate(r) for r in roles]
+    return ListResponse[UserRole](
+        data=pydantic_roles,
+        total=len(pydantic_roles),
+        page=1,
+        page_size=len(pydantic_roles),
+        has_more=False,
+        message=f"Retrieved {len(pydantic_roles)} roles",
+    )
+
+
+@router.delete("/{role_name}", response_model=DataResponse[bool])
+async def remove_role(
+    user_id: str,
+    role_name: str,
+    user_role_service: UserRoleService = Depends(get_user_role_service),
+    audit_log_service: AuditLogService = Depends(get_audit_log_service),
+    current_user: UserModel = Depends(get_current_active_user),
+):
+    """Remove a role from a user."""
+    success = await user_role_service.remove_role_from_user(user_id, role_name)
+    if not success:
+        raise HTTPException(status_code=404, detail="Role not found")
+
+    await audit_log_service.create_log(
+        action="remove_role",
+        user_id=current_user.id,
+        details={"target_user_id": user_id, "role": role_name},
+    )
+    return DataResponse[bool](data=True, message="Role removed")

--- a/backend/services/user_role_service.py
+++ b/backend/services/user_role_service.py
@@ -1,43 +1,65 @@
-from sqlalchemy.orm import Session
-from .. import models, schemas
-from typing import List, Optional
+from typing import List
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import models
+from ..enums import UserRoleEnum
 
 
 class UserRoleService:
-def __init__(self, db: Session):
-    self.db = db
+    """Async service for managing user roles."""
 
-def assign_role_to_user(self, user_id: str, role_name: str) -> Optional[models.UserRole]:  # Check if the user and role exist (optional, depending on schema constraints)  # user = self.db.query(models.User).filter(models.User.id == user_id).first()  # role = self.db.query(models.Role).filter(models.Role.name == role_name).first()  # Assuming a separate Role model if roles are predefined  # if not user or not role:  # return None  # Check if the role is already assigned
-    existing_role = self.db.query(models.UserRole).filter(
-    models.UserRole.user_id == user_id,
-    models.UserRole.role_name == role_name
-    ).first()
+    def __init__(self, db: AsyncSession) -> None:
+        self.db = db
 
-    if existing_role:
-    return existing_role  # Role already assigned
+    async def assign_role_to_user(
+        self, user_id: str, role_name: str
+    ) -> models.UserRole:
+        role_enum = UserRoleEnum(role_name)
+        result = await self.db.execute(
+            select(models.UserRole).filter(
+                models.UserRole.user_id == user_id,
+                models.UserRole.role_name == role_enum,
+            )
+        )
+        existing = result.scalar_one_or_none()
+        if existing:
+            return existing
 
-    db_user_role = models.UserRole(user_id=user_id, role_name=role_name)
-    self.db.add(db_user_role)
-    self.db.commit()
-    self.db.refresh(db_user_role)
-    return db_user_role
+        db_user_role = models.UserRole(user_id=user_id, role_name=role_enum)
+        self.db.add(db_user_role)
+        await self.db.commit()
+        await self.db.refresh(db_user_role)
+        return db_user_role
 
-def remove_role_from_user(self, user_id: str, role_name: str) -> bool:
-    db_user_role = self.db.query(models.UserRole).filter(
-    models.UserRole.user_id == user_id,
-    models.UserRole.role_name == role_name
-    ).first()
+    async def remove_role_from_user(self, user_id: str, role_name: str) -> bool:
+        role_enum = UserRoleEnum(role_name)
+        result = await self.db.execute(
+            select(models.UserRole).filter(
+                models.UserRole.user_id == user_id,
+                models.UserRole.role_name == role_enum,
+            )
+        )
+        db_user_role = result.scalar_one_or_none()
+        if db_user_role:
+            await self.db.delete(db_user_role)
+            await self.db.commit()
+            return True
+        return False
 
-    if db_user_role:
-    self.db.delete(db_user_role)
-    self.db.commit()
-    return True
-    return False  # Role not found or not assigned
+    async def get_user_roles(self, user_id: str) -> List[models.UserRole]:
+        result = await self.db.execute(
+            select(models.UserRole).filter(models.UserRole.user_id == user_id)
+        )
+        return result.scalars().all()
 
-def get_user_roles(self, user_id: str) -> List[models.UserRole]:
-    return self.db.query(models.UserRole).filter(models.UserRole.user_id == user_id).all()  # You might add other methods like checking if a user has a specific role
-def has_role(self, user_id: str, role_name: str) -> bool:
-    return self.db.query(models.UserRole).filter(
-    models.UserRole.user_id == user_id,
-    models.UserRole.role_name == role_name
-    ).first() is not None
+    async def has_role(self, user_id: str, role_name: str) -> bool:
+        role_enum = UserRoleEnum(role_name)
+        result = await self.db.execute(
+            select(models.UserRole).filter(
+                models.UserRole.user_id == user_id,
+                models.UserRole.role_name == role_enum,
+            )
+        )
+        return result.scalar_one_or_none() is not None

--- a/backend/tests/test_user_roles.py
+++ b/backend/tests/test_user_roles.py
@@ -1,0 +1,31 @@
+import pytest
+from backend.enums import UserRoleEnum
+
+
+@pytest.mark.asyncio
+async def test_user_role_crud(authenticated_client, test_user):
+    # Assign a role
+    resp = await authenticated_client.post(
+        f"/api/v1/users/{test_user.id}/roles/",
+        json={"user_id": test_user.id, "role_name": UserRoleEnum.VIEWER.value},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["data"]["role_name"] == UserRoleEnum.VIEWER.value
+
+    # List roles
+    resp = await authenticated_client.get(f"/api/v1/users/{test_user.id}/roles/")
+    assert resp.status_code == 200
+    names = [r["role_name"] for r in resp.json()["data"]]
+    assert UserRoleEnum.VIEWER.value in names
+
+    # Remove role
+    resp = await authenticated_client.delete(
+        f"/api/v1/users/{test_user.id}/roles/{UserRoleEnum.VIEWER.value}"
+    )
+    assert resp.status_code == 200
+    assert resp.json()["data"] is True
+
+    resp = await authenticated_client.get(f"/api/v1/users/{test_user.id}/roles/")
+    assert resp.status_code == 200
+    names = [r["role_name"] for r in resp.json()["data"]]
+    assert UserRoleEnum.VIEWER.value not in names


### PR DESCRIPTION
## Summary
- add async `UserRoleService` for role CRUD
- implement `/api/v1/users/{user_id}/roles` endpoints
- register roles router with app
- test role assignment flow

## Testing
- `flake8 services/user_role_service.py routers/users/roles.py tests/test_user_roles.py`
- `pytest -q tests/test_user_roles.py`

------
https://chatgpt.com/codex/tasks/task_e_6841746c754c832c82b17b57f68a591a