### PR TITLE
Add forbidden action management endpoints

### DIFF
--- a/backend/routers/rules/__init__.py
+++ b/backend/routers/rules/__init__.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter
 from .workflows.workflows import router as workflows_router
 from .violations.violations import router as violations_router
 from .templates.templates import router as templates_router
-from .roles.roles import router as roles_router
+from .roles import router as roles_router
 from .mandates.mandates import router as mandates_router
 from .logs.logs import router as logs_router
 

--- a/backend/routers/rules/roles/__init__.py
+++ b/backend/routers/rules/roles/__init__.py
@@ -1,1 +1,10 @@
-# Rules module\n
+from fastapi import APIRouter
+
+from .roles import router as roles_router
+from .capabilities import router as capabilities_router
+from .forbidden_actions import router as forbidden_actions_router
+
+router = APIRouter()
+router.include_router(roles_router)
+router.include_router(capabilities_router)
+router.include_router(forbidden_actions_router)

--- a/backend/routers/rules/roles/forbidden_actions.py
+++ b/backend/routers/rules/roles/forbidden_actions.py
@@ -1,32 +1,46 @@
+from typing import List, Optional
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
-from typing import Optional
 
-from ....database import get_db
-from ....crud import rules as crud_rules
+from ....database import get_sync_db as get_db
+from ....services.agent_forbidden_action_service import AgentForbiddenActionService
+from ....models import AgentForbiddenAction
 
-router = APIRouter()  # Agent Forbidden Actions
-@router.post("/{agent_role_id}/forbidden-actions")
+router = APIRouter()
 
 
-def add_forbidden_action(
+def get_service(db: Session = Depends(get_db)) -> AgentForbiddenActionService:
+    return AgentForbiddenActionService(db)
+
+
+@router.post("/{agent_role_id}/forbidden-actions", response_model=AgentForbiddenAction)
+def create_forbidden_action(
     agent_role_id: str,
     action: str,
     reason: Optional[str] = None,
-    db: Session = Depends(get_db)
-):
-    """Add a forbidden action to an agent role"""
-    return crud_rules.add_forbidden_action(db, agent_role_id, action, reason)
+    service: AgentForbiddenActionService = Depends(get_service),
+) -> AgentForbiddenAction:
+    """Add a forbidden action to an agent role."""
+    return service.create(agent_role_id, action, reason)
+
+
+@router.get("/{agent_role_id}/forbidden-actions", response_model=List[AgentForbiddenAction])
+def list_forbidden_actions(
+    agent_role_id: str,
+    service: AgentForbiddenActionService = Depends(get_service),
+) -> List[AgentForbiddenAction]:
+    """List forbidden actions for an agent role."""
+    return service.list(agent_role_id)
+
 
 @router.delete("/forbidden-actions/{action_id}")
-
-
-def remove_forbidden_action(
+def delete_forbidden_action(
     action_id: str,
-    db: Session = Depends(get_db)
-):
-    """Remove a forbidden action"""
-    success = crud_rules.remove_forbidden_action(db, action_id)
+    service: AgentForbiddenActionService = Depends(get_service),
+) -> dict:
+    """Remove a forbidden action."""
+    success = service.delete(action_id)
     if not success:
-    raise HTTPException(status_code=404, detail="Forbidden action not found")
+        raise HTTPException(status_code=404, detail="Forbidden action not found")
     return {"message": "Forbidden action removed successfully"}

--- a/backend/services/agent_forbidden_action_service.py
+++ b/backend/services/agent_forbidden_action_service.py
@@ -1,0 +1,44 @@
+from typing import List, Optional
+from sqlalchemy.orm import Session
+
+from .. import models
+
+
+class AgentForbiddenActionService:
+    """Service for managing agent forbidden actions."""
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def create(self, agent_role_id: str, action: str, reason: Optional[str] = None) -> models.AgentForbiddenAction:
+        """Create a forbidden action for a given agent role."""
+        forbidden = models.AgentForbiddenAction(
+            agent_role_id=agent_role_id,
+            action=action,
+            reason=reason,
+            is_active=True,
+        )
+        self.db.add(forbidden)
+        self.db.commit()
+        self.db.refresh(forbidden)
+        return forbidden
+
+    def list(self, agent_role_id: Optional[str] = None) -> List[models.AgentForbiddenAction]:
+        """List forbidden actions, optionally filtered by agent role."""
+        query = self.db.query(models.AgentForbiddenAction)
+        if agent_role_id:
+            query = query.filter(models.AgentForbiddenAction.agent_role_id == agent_role_id)
+        return query.all()
+
+    def delete(self, action_id: str) -> bool:
+        """Delete a forbidden action by ID."""
+        action = (
+            self.db.query(models.AgentForbiddenAction)
+            .filter(models.AgentForbiddenAction.id == action_id)
+            .first()
+        )
+        if action:
+            self.db.delete(action)
+            self.db.commit()
+            return True
+        return False


### PR DESCRIPTION
## Summary
- implement `AgentForbiddenActionService` with create, list and delete helpers
- expose REST endpoints for managing forbidden actions
- combine roles subrouters and update registration

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError or incompatible dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6841747de59c832c882e910422abb563