### PR TITLE
Add search graph tool

### DIFF
--- a/backend/docs/fastapi_mcp/README.md
+++ b/backend/docs/fastapi_mcp/README.md
@@ -93,6 +93,7 @@ FastAPI-MCP automatically exposes selected API endpoints as tools under the `/mc
 - `/mcp-tools/memory/add-observation` (POST)
 - `/mcp-tools/memory/add-relation` (POST)
 - `/mcp-tools/memory/search` (GET)
+- `/mcp-tools/memory/search-graph` (GET)
 - `/mcp-tools/handoff/create` (POST)
 - `/mcp-tools/handoff/list` (GET)
 - `/mcp-tools/handoff/delete` (DELETE)

--- a/backend/mcp_tools/__init__.py
+++ b/backend/mcp_tools/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     'list_tasks_tool',
     'add_memory_entity_tool',
     'search_memory_tool',
+    'search_graph_tool',
     'add_project_file_tool',
     'list_project_files_tool',
     'remove_project_file_tool',

--- a/backend/mcp_tools/memory_tools.py
+++ b/backend/mcp_tools/memory_tools.py
@@ -15,7 +15,10 @@ from backend.crud.memory import (
     get_memory_entity_by_name,
 )
 from backend.services.memory_service import MemoryService
-from backend.schemas.memory import MemoryEntityCreate, MemoryObservationCreate
+from backend.schemas.memory import (
+    MemoryEntityCreate,
+    MemoryObservationCreate,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -123,6 +126,32 @@ async def search_memory_tool(
     }
     except Exception as e:
         logger.error(f"MCP search memory failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+async def search_graph_tool(
+    query: str,
+    limit: int = 10,
+    db: Session = None,
+) -> dict:
+    """MCP Tool: Search memory graph using MemoryService."""
+    try:
+        service = MemoryService(db)
+        results = service.search_memory_entities(query, limit=limit)
+        return {
+            "success": True,
+            "entities": [
+                {
+                    "id": e.id,
+                    "name": e.name,
+                    "type": e.type,
+                    "description": e.description,
+                }
+                for e in results
+            ],
+        }
+    except Exception as e:
+        logger.error(f"MCP search graph failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/backend/routers/mcp/core.py
+++ b/backend/routers/mcp/core.py
@@ -678,6 +678,36 @@ async def mcp_search_memory(
 
 
 @router.get(
+    "/mcp-tools/memory/search-graph",
+    tags=["mcp-tools"],
+    operation_id="search_graph_tool",
+)
+async def mcp_search_graph(
+    query: str,
+    limit: int = 10,
+    memory_service: MemoryService = Depends(get_memory_service),
+):
+    """MCP Tool: Search memory graph."""
+    try:
+        results = memory_service.search_memory_entities(query, limit=limit)
+        return {
+            "success": True,
+            "results": [
+                {
+                    "id": r.id,
+                    "type": r.type,
+                    "name": r.name,
+                    "description": r.description,
+                }
+                for r in results
+            ],
+        }
+    except Exception as e:
+        logger.error(f"MCP search graph failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get(
     "/mcp-tools/memory/get-content",
     tags=["mcp-tools"],
     operation_id="get_memory_content_tool",


### PR DESCRIPTION
## Summary
- expose graph search tool using `MemoryService.search_memory_entities`
- register `/mcp-tools/memory/search-graph` route
- document new route in FastAPI MCP docs

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6841746bc6b4832cbc1a243868548a4c