### PR TITLE
Add user role MCP tools

### DIFF
--- a/backend/docs/fastapi_mcp/README.md
+++ b/backend/docs/fastapi_mcp/README.md
@@ -102,6 +102,9 @@ FastAPI-MCP automatically exposes selected API endpoints as tools under the `/mc
 - `/mcp-tools/error-protocol/add` (POST)
 - `/mcp-tools/error-protocol/list` (GET)
 - `/mcp-tools/error-protocol/remove` (DELETE)
+- `/mcp-tools/user-role/assign` (POST)
+- `/mcp-tools/user-role/list` (GET)
+- `/mcp-tools/user-role/remove` (DELETE)
 
 ### Agent Handoff Tools
 

--- a/backend/mcp_tools/README.md
+++ b/backend/mcp_tools/README.md
@@ -12,6 +12,7 @@ Key files:
 *   `agent_handoff_tools.py`: Tools for managing agent handoff criteria.
 *   `forbidden_action_tools.py`: Tools for creating and listing forbidden actions for agent roles.
 *   `error_protocol_tools.py`: Tools for creating and listing error protocols for agent roles.
+*   `user_role_tools.py`: Tools for assigning, listing, and removing user roles.
 *   `__init__.py`: Initializes the mcp_tools package.
 
 ## Architecture Diagram
@@ -58,6 +59,7 @@ actions = await list_forbidden_actions_tool(agent_role_id="manager", db=session)
 - `agent_handoff_tools.py`
 - `forbidden_action_tools.py`
 - `error_protocol_tools.py`
+- `user_role_tools.py`
 
 <!-- File List End -->
 

--- a/backend/mcp_tools/__init__.py
+++ b/backend/mcp_tools/__init__.py
@@ -24,5 +24,8 @@ __all__ = [
     'delete_project_template_tool',
     'add_error_protocol_tool',
     'list_error_protocols_tool',
-    'remove_error_protocol_tool'
+    'remove_error_protocol_tool',
+    'assign_role_tool',
+    'list_roles_tool',
+    'remove_role_tool'
 ]

--- a/backend/mcp_tools/user_role_tools.py
+++ b/backend/mcp_tools/user_role_tools.py
@@ -1,0 +1,57 @@
+"""MCP Tools for managing user roles."""
+
+import logging
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+from backend.services.user_role_service import UserRoleService
+
+logger = logging.getLogger(__name__)
+
+
+def _get_service(db: Session) -> UserRoleService:
+    return UserRoleService(db)
+
+
+async def assign_role_tool(user_id: str, role_name: str, db: Session) -> dict:
+    """Assign a role to a user."""
+    try:
+        service = _get_service(db)
+        role = service.assign_role_to_user(user_id, role_name)
+        return {
+            "success": True,
+            "role": {"user_id": role.user_id, "role_name": role.role_name},
+        }
+    except Exception as exc:
+        logger.error(f"MCP assign role failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+async def list_roles_tool(user_id: str, db: Session) -> dict:
+    """List roles assigned to a user."""
+    try:
+        service = _get_service(db)
+        roles = service.get_user_roles(user_id)
+        return {
+            "success": True,
+            "roles": [
+                {"user_id": r.user_id, "role_name": r.role_name} for r in roles
+            ],
+        }
+    except Exception as exc:
+        logger.error(f"MCP list roles failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+async def remove_role_tool(user_id: str, role_name: str, db: Session) -> dict:
+    """Remove a role from a user."""
+    try:
+        service = _get_service(db)
+        success = service.remove_role_from_user(user_id, role_name)
+        if not success:
+            raise HTTPException(status_code=404, detail="Role not found")
+        return {"success": True}
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"MCP remove role failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/backend/routers/mcp/core.py
+++ b/backend/routers/mcp/core.py
@@ -1027,3 +1027,64 @@ async def mcp_list_forbidden_actions(
     except Exception as e:
         logger.error(f"MCP list forbidden actions failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/mcp-tools/user-role/assign",
+    tags=["mcp-tools"],
+    operation_id="assign_role_tool",
+)
+async def mcp_assign_role(
+    user_id: str,
+    role_name: str,
+    db: Session = Depends(get_db_session),
+):
+    """MCP Tool: Assign a role to a user."""
+    try:
+        from ...mcp_tools.user_role_tools import assign_role_tool
+
+        return await assign_role_tool(user_id, role_name, db)
+    except Exception as e:
+        logger.error(f"MCP assign role failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get(
+    "/mcp-tools/user-role/list",
+    tags=["mcp-tools"],
+    operation_id="list_roles_tool",
+)
+async def mcp_list_roles(
+    user_id: str,
+    db: Session = Depends(get_db_session),
+):
+    """MCP Tool: List roles assigned to a user."""
+    try:
+        from ...mcp_tools.user_role_tools import list_roles_tool
+
+        return await list_roles_tool(user_id, db)
+    except Exception as e:
+        logger.error(f"MCP list roles failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.delete(
+    "/mcp-tools/user-role/remove",
+    tags=["mcp-tools"],
+    operation_id="remove_role_tool",
+)
+async def mcp_remove_role(
+    user_id: str,
+    role_name: str,
+    db: Session = Depends(get_db_session),
+):
+    """MCP Tool: Remove a role from a user."""
+    try:
+        from ...mcp_tools.user_role_tools import remove_role_tool
+
+        return await remove_role_tool(user_id, role_name, db)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"MCP remove role failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
## Summary
- implement `assign_role_tool`, `list_roles_tool`, and `remove_role_tool`
- mount user role endpoints in MCP router
- document the new tools

## Testing
- `flake8 backend/mcp_tools/user_role_tools.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684180c1cfb4832c8de24268793def6f