### PR TITLE
Fix async tool indentation

### DIFF
--- a/backend/mcp_tools/memory_tools.py
+++ b/backend/mcp_tools/memory_tools.py
@@ -17,6 +17,7 @@ from backend.crud.memory import (
 from backend.services.memory_service import MemoryService
 from backend.schemas.memory import (
     MemoryEntityCreate,
+    MemoryRelationCreate,
     MemoryObservationCreate,
 )
 
@@ -29,39 +30,43 @@ async def add_memory_entity_tool(
 ) -> dict:
     """MCP Tool: Add entity to knowledge graph."""
     try:
-    entity = create_memory_entity(
-    db=db,
-    entity=MemoryEntityCreate(
-    name=entity_data["name"],
-    type=entity_data["type"],
-    description=entity_data.get("description"),
-    metadata_=entity_data.get("metadata", {})
-    )
-    )
+        entity = await create_memory_entity(
+            db=db,
+            entity=MemoryEntityCreate(
+                name=entity_data["name"],
+                type=entity_data["type"],
+                description=entity_data.get("description"),
+                metadata_=entity_data.get("metadata", {}),
+            ),
+        )
 
-    if "observations" in entity_data:
-    for obs_content in entity_data["observations"]:
-    add_observation_to_entity(
-    db=db,
-    entity_id=entity.id,
-    observation=MemoryObservationCreate(content=obs_content, source="mcp_tool")
-    )
+        if "observations" in entity_data:
+            for obs_content in entity_data["observations"]:
+                await add_observation_to_entity(
+                    db=db,
+                    entity_id=entity.id,
+                    observation=MemoryObservationCreate(
+                        content=obs_content, source="mcp_tool"
+                    ),
+                )
 
-    return {
-    "success": True,
-    "entity": {
-    "id": entity.id,
-    "name": entity.name,
-    "type": entity.type,
-    "description": entity.description
-    }
-    }
+        return {
+            "success": True,
+            "entity": {
+                "id": entity.id,
+                "name": entity.name,
+                "type": entity.type,
+                "description": entity.description,
+            },
+        }
     except HTTPException as e:
-    logger.error(f"MCP add memory entity failed with HTTP exception: {e.detail}")
-    raise e
+        logger.error(
+            f"MCP add memory entity failed with HTTP exception: {e.detail}"
+        )
+        raise e
     except Exception as e:
-    logger.error(f"MCP add memory entity failed: {e}")
-    raise HTTPException(status_code=500, detail=str(e))
+        logger.error(f"MCP add memory entity failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
 
 
 async def add_memory_relation_tool(
@@ -70,37 +75,43 @@ async def add_memory_relation_tool(
 ) -> dict:
     """MCP Tool: Add relation to knowledge graph."""
     try:
-    from_entity = get_memory_entity_by_name(db, relation_data["from_entity"])
-    to_entity = get_memory_entity_by_name(db, relation_data["to_entity"])
+        from_entity = await get_memory_entity_by_name(
+            db, relation_data["from_entity"]
+        )
+        to_entity = await get_memory_entity_by_name(db, relation_data["to_entity"])
 
-    if not from_entity or not to_entity:
-    raise HTTPException(status_code=404, detail="One or both entities not found")
+        if not from_entity or not to_entity:
+            raise HTTPException(
+                status_code=404, detail="One or both entities not found"
+            )
 
-    relation = create_memory_relation(
-    db=db,
-    relation=MemoryRelationCreate(
-    from_entity_id=from_entity.id,
-    to_entity_id=to_entity.id,
-    relation_type=relation_data["relation_type"],
-    metadata_=relation_data.get("metadata", {})
-    )
-    )
+        relation = await create_memory_relation(
+            db=db,
+            relation=MemoryRelationCreate(
+                from_entity_id=from_entity.id,
+                to_entity_id=to_entity.id,
+                relation_type=relation_data["relation_type"],
+                metadata_=relation_data.get("metadata", {}),
+            ),
+        )
 
-    return {
-    "success": True,
-    "relation": {
-    "id": relation.id,
-    "from_entity": from_entity.name,
-    "to_entity": to_entity.name,
-    "relation_type": relation.relation_type
-    }
-    }
+        return {
+            "success": True,
+            "relation": {
+                "id": relation.id,
+                "from_entity": from_entity.name,
+                "to_entity": to_entity.name,
+                "relation_type": relation.relation_type,
+            },
+        }
     except HTTPException as e:
-    logger.error(f"MCP add memory relation failed with HTTP exception: {e.detail}")
-    raise e
+        logger.error(
+            f"MCP add memory relation failed with HTTP exception: {e.detail}"
+        )
+        raise e
     except Exception as e:
-    logger.error(f"MCP add memory relation failed: {e}")
-    raise HTTPException(status_code=500, detail=str(e))
+        logger.error(f"MCP add memory relation failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
 
 
 async def search_memory_tool(
@@ -110,20 +121,20 @@ async def search_memory_tool(
 ) -> dict:
     """MCP Tool: Search knowledge graph."""
     try:
-    entities = search_entities(db=db, query=query, limit=limit)
+        entities = await search_entities(db=db, query=query, limit=limit)
 
-    return {
-    "success": True,
-    "entities": [
-    {
-    "id": e.id,
-    "name": e.name,
-    "type": e.type,
-    "description": e.description
-    }
-    for e in entities
-    ]
-    }
+        return {
+            "success": True,
+            "entities": [
+                {
+                    "id": e.id,
+                    "name": e.name,
+                    "type": e.type,
+                    "description": e.description,
+                }
+                for e in entities
+            ],
+        }
     except Exception as e:
         logger.error(f"MCP search memory failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
## Summary
- clean up indentation in `memory_tools`
- add missing await keywords and import

## Testing
- `flake8 backend/mcp_tools/memory_tools.py`
- `pytest backend/tests/test_simple.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684180c1b56c832c8be8d6b3f82d2319