### PR TITLE
Add user roles API

### DIFF
--- a/backend/app_factory.py
+++ b/backend/app_factory.py
@@ -68,6 +68,17 @@ def include_app_routers(application: FastAPI) -> None:
         logger.warning(f"Could not import users router: {e}")
 
     try:
+        from .routers.users.roles import router as user_roles_router
+        application.include_router(
+            user_roles_router,
+            prefix="/api/v1/users",
+            tags=["User Roles"],
+        )
+        logger.info("User roles router included successfully")
+    except ImportError as e:
+        logger.warning(f"Could not import user roles router: {e}")
+
+    try:
         from .routers.admin import router as admin_router
         application.include_router(admin_router, prefix="/api/v1", tags=["admin"])
         logger.info("Admin router included successfully")

--- a/backend/routers/users/__init__.py
+++ b/backend/routers/users/__init__.py
@@ -1,7 +1,9 @@
 from fastapi import APIRouter
 from .core.core import router as core_router
 from .auth.auth import router as auth_router
+from .roles import router as roles_router
 
 router = APIRouter()
 router.include_router(core_router)
 router.include_router(auth_router)
+router.include_router(roles_router)

--- a/backend/routers/users/roles.py
+++ b/backend/routers/users/roles.py
@@ -1,0 +1,70 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from ...database import get_sync_db as get_db
+from ...services.user_role_service import UserRoleService
+from ...schemas import user as user_schemas
+from ...schemas.api_responses import DataResponse, ListResponse
+from ...services.exceptions import EntityNotFoundError
+from ...enums import UserRoleEnum
+
+router = APIRouter(prefix="/{user_id}/roles", tags=["User Roles"])
+
+
+def get_role_service(db: Session = Depends(get_db)) -> UserRoleService:
+    return UserRoleService(db)
+
+
+@router.post("/", response_model=DataResponse[user_schemas.UserRole], status_code=status.HTTP_201_CREATED)
+def assign_role(
+    user_id: str,
+    role_data: user_schemas.UserRoleCreate,
+    service: UserRoleService = Depends(get_role_service),
+):
+    """Assign a role to a user."""
+    if role_data.user_id and role_data.user_id != user_id:
+        role_data.user_id = user_id
+    try:
+        role = service.assign_role_to_user(user_id, role_data.role_name)
+        return DataResponse[user_schemas.UserRole](
+            data=user_schemas.UserRole.model_validate(role),
+            message="Role assigned successfully",
+        )
+    except Exception as exc:  # pragma: no cover - unexpected errors
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.get("/", response_model=ListResponse[user_schemas.UserRole])
+def list_roles(
+    user_id: str,
+    service: UserRoleService = Depends(get_role_service),
+):
+    """List roles for a user."""
+    roles = service.get_user_roles(user_id)
+    pydantic_roles = [user_schemas.UserRole.model_validate(r) for r in roles]
+    return ListResponse[user_schemas.UserRole](
+        data=pydantic_roles,
+        total=len(pydantic_roles),
+        page=1,
+        page_size=len(pydantic_roles),
+        has_more=False,
+        message=f"Retrieved {len(pydantic_roles)} roles",
+    )
+
+
+@router.delete("/{role}", response_model=DataResponse[bool])
+def remove_role(
+    user_id: str,
+    role: UserRoleEnum,
+    service: UserRoleService = Depends(get_role_service),
+):
+    """Remove a role from a user."""
+    try:
+        success = service.remove_role_from_user(user_id, role.value)
+        if not success:
+            raise EntityNotFoundError("UserRole", role.value)
+        return DataResponse[bool](data=True, message="Role removed successfully")
+    except EntityNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except Exception as exc:  # pragma: no cover - unexpected errors
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/backend/services/user_role_service.py
+++ b/backend/services/user_role_service.py
@@ -1,43 +1,59 @@
 from sqlalchemy.orm import Session
-from .. import models, schemas
+from .. import models
 from typing import List, Optional
 
 
 class UserRoleService:
-def __init__(self, db: Session):
-    self.db = db
+    def __init__(self, db: Session):
+        self.db = db
 
-def assign_role_to_user(self, user_id: str, role_name: str) -> Optional[models.UserRole]:  # Check if the user and role exist (optional, depending on schema constraints)  # user = self.db.query(models.User).filter(models.User.id == user_id).first()  # role = self.db.query(models.Role).filter(models.Role.name == role_name).first()  # Assuming a separate Role model if roles are predefined  # if not user or not role:  # return None  # Check if the role is already assigned
-    existing_role = self.db.query(models.UserRole).filter(
-    models.UserRole.user_id == user_id,
-    models.UserRole.role_name == role_name
-    ).first()
+    def assign_role_to_user(self, user_id: str, role_name: str) -> Optional[models.UserRole]:
+        existing_role = (
+            self.db.query(models.UserRole)
+            .filter(
+                models.UserRole.user_id == user_id,
+                models.UserRole.role_name == role_name,
+            )
+            .first()
+        )
+        if existing_role:
+            return existing_role
 
-    if existing_role:
-    return existing_role  # Role already assigned
+        db_user_role = models.UserRole(user_id=user_id, role_name=role_name)
+        self.db.add(db_user_role)
+        self.db.commit()
+        self.db.refresh(db_user_role)
+        return db_user_role
 
-    db_user_role = models.UserRole(user_id=user_id, role_name=role_name)
-    self.db.add(db_user_role)
-    self.db.commit()
-    self.db.refresh(db_user_role)
-    return db_user_role
+    def remove_role_from_user(self, user_id: str, role_name: str) -> bool:
+        db_user_role = (
+            self.db.query(models.UserRole)
+            .filter(
+                models.UserRole.user_id == user_id,
+                models.UserRole.role_name == role_name,
+            )
+            .first()
+        )
+        if db_user_role:
+            self.db.delete(db_user_role)
+            self.db.commit()
+            return True
+        return False
 
-def remove_role_from_user(self, user_id: str, role_name: str) -> bool:
-    db_user_role = self.db.query(models.UserRole).filter(
-    models.UserRole.user_id == user_id,
-    models.UserRole.role_name == role_name
-    ).first()
+    def get_user_roles(self, user_id: str) -> List[models.UserRole]:
+        return (
+            self.db.query(models.UserRole)
+            .filter(models.UserRole.user_id == user_id)
+            .all()
+        )
 
-    if db_user_role:
-    self.db.delete(db_user_role)
-    self.db.commit()
-    return True
-    return False  # Role not found or not assigned
-
-def get_user_roles(self, user_id: str) -> List[models.UserRole]:
-    return self.db.query(models.UserRole).filter(models.UserRole.user_id == user_id).all()  # You might add other methods like checking if a user has a specific role
-def has_role(self, user_id: str, role_name: str) -> bool:
-    return self.db.query(models.UserRole).filter(
-    models.UserRole.user_id == user_id,
-    models.UserRole.role_name == role_name
-    ).first() is not None
+    def has_role(self, user_id: str, role_name: str) -> bool:
+        return (
+            self.db.query(models.UserRole)
+            .filter(
+                models.UserRole.user_id == user_id,
+                models.UserRole.role_name == role_name,
+            )
+            .first()
+            is not None
+        )

--- a/backend/tests/test_user_roles.py
+++ b/backend/tests/test_user_roles.py
@@ -1,0 +1,67 @@
+import types
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient, ASGITransport
+
+from backend.routers.users.roles import router, get_role_service
+from backend.enums import UserRoleEnum
+
+
+class DummyService:
+    def __init__(self):
+        self.roles = {}
+
+    def assign_role_to_user(self, user_id: str, role_name: str):
+        role = types.SimpleNamespace(user_id=user_id, role_name=role_name)
+        self.roles.setdefault(user_id, []).append(role)
+        return role
+
+    def get_user_roles(self, user_id: str):
+        return self.roles.get(user_id, [])
+
+    def remove_role_from_user(self, user_id: str, role_name: str):
+        roles = self.roles.get(user_id, [])
+        for r in roles:
+            if r.role_name == role_name:
+                roles.remove(r)
+                return True
+        return False
+
+
+dummy_service = DummyService()
+
+
+def override_service():
+    return dummy_service
+
+
+app = FastAPI()
+app.include_router(router)
+app.dependency_overrides[get_role_service] = override_service
+
+
+@pytest.mark.asyncio
+async def test_role_lifecycle():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/123/roles/",
+            json={"user_id": "123", "role_name": UserRoleEnum.ADMIN.value},
+        )
+        assert resp.status_code == 201
+
+        resp = await client.get("/123/roles/")
+        assert resp.status_code == 200
+        assert len(resp.json()["data"]) == 1
+
+        resp = await client.delete("/123/roles/admin")
+        assert resp.status_code == 200
+
+        resp = await client.get("/123/roles/")
+        assert resp.json()["data"] == []
+
+
+@pytest.mark.asyncio
+async def test_remove_missing_role():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.delete("/999/roles/manager")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- implement user roles router with assign/list/remove
- wire router into user module and app factory
- add service helper for role management
- test role lifecycle via new endpoints

## Testing
- `pytest -q` *(fails: test_memory_ingestion, test_openapi, test_project_task_endpoints, test_rules_service, test_user_roles)*

------
https://chatgpt.com/codex/tasks/task_e_684180c12f40832cb04557bc3865cf47