### PR TITLE
Add agent capability service and routes

### DIFF
--- a/backend/routers/rules/roles/capabilities.py
+++ b/backend/routers/rules/roles/capabilities.py
@@ -1,32 +1,58 @@
+from typing import List
+from sqlalchemy.ext.asyncio import AsyncSession
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy.orm import Session
-from typing import Optional
 
 from ....database import get_db
-from ....crud import rules as crud_rules
+from ....services.agent_capability_service import AgentCapabilityService
+from ....schemas.agent_capability import (
+    AgentCapability,
+    AgentCapabilityCreate,
+    AgentCapabilityUpdate,
+)
 
-router = APIRouter()  # Agent Capabilities
-@router.post("/{agent_role_id}/capabilities")
+router = APIRouter()
 
 
-def add_capability(
-    agent_role_id: str,
-    capability: str,
-    description: Optional[str] = None,
-    db: Session = Depends(get_db)
+async def get_service(db: AsyncSession = Depends(get_db)) -> AgentCapabilityService:
+    return AgentCapabilityService(db)
+
+
+@router.get("/{role_id}/capabilities", response_model=List[AgentCapability])
+async def list_capabilities(
+    role_id: str,
+    service: AgentCapabilityService = Depends(get_service),
 ):
-    """Add a capability to an agent role"""
-    return crud_rules.add_agent_capability(db, agent_role_id, capability, description)
+    return await service.list_capabilities(agent_role_id=role_id)
+
+
+@router.post("/{role_id}/capabilities", response_model=AgentCapability)
+async def create_capability(
+    role_id: str,
+    capability_in: AgentCapabilityCreate,
+    service: AgentCapabilityService = Depends(get_service),
+):
+    data = capability_in.copy(update={"agent_role_id": role_id})
+    return await service.create_capability(data)
+
+
+@router.put("/capabilities/{capability_id}", response_model=AgentCapability)
+async def update_capability(
+    capability_id: str,
+    capability_update: AgentCapabilityUpdate,
+    service: AgentCapabilityService = Depends(get_service),
+):
+    updated = await service.update_capability(capability_id, capability_update)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Capability not found")
+    return updated
+
 
 @router.delete("/capabilities/{capability_id}")
-
-
-def remove_capability(
+async def delete_capability(
     capability_id: str,
-    db: Session = Depends(get_db)
+    service: AgentCapabilityService = Depends(get_service),
 ):
-    """Remove an agent capability"""
-    success = crud_rules.remove_agent_capability(db, capability_id)
+    success = await service.delete_capability(capability_id)
     if not success:
-    raise HTTPException(status_code=404, detail="Capability not found")
-    return {"message": "Capability removed successfully"}
+        raise HTTPException(status_code=404, detail="Capability not found")
+    return {"message": "Capability deleted successfully"}

--- a/backend/schemas/agent_capability.py
+++ b/backend/schemas/agent_capability.py
@@ -1,0 +1,37 @@
+from pydantic import BaseModel, Field, ConfigDict
+from typing import Optional
+from datetime import datetime
+
+
+class AgentCapabilityBase(BaseModel):
+    """Base schema for agent capabilities."""
+
+    agent_role_id: str = Field(..., description="ID of the related agent role.")
+    capability: str = Field(..., description="Name of the capability.")
+    description: Optional[str] = Field(
+        None, description="Optional description for the capability."
+    )
+    is_active: bool = Field(True, description="Whether the capability is active.")
+
+
+class AgentCapabilityCreate(AgentCapabilityBase):
+    """Schema for creating an agent capability."""
+
+    pass
+
+
+class AgentCapabilityUpdate(BaseModel):
+    """Schema for updating an agent capability."""
+
+    capability: Optional[str] = Field(None, description="Updated capability name.")
+    description: Optional[str] = Field(None, description="Updated description.")
+    is_active: Optional[bool] = Field(None, description="Updated active state.")
+
+
+class AgentCapability(AgentCapabilityBase):
+    """Schema representing an agent capability."""
+
+    id: str = Field(..., description="Unique identifier of the capability.")
+    created_at: datetime = Field(..., description="Creation timestamp.")
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/services/agent_capability_service.py
+++ b/backend/services/agent_capability_service.py
@@ -1,0 +1,69 @@
+from typing import List, Optional
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import models
+from ..schemas.agent_capability import (
+    AgentCapabilityCreate,
+    AgentCapabilityUpdate,
+)
+
+
+class AgentCapabilityService:
+    """Service providing CRUD operations for AgentCapability."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def get_capability(
+        self, capability_id: str
+    ) -> Optional[models.AgentCapability]:
+        query = select(models.AgentCapability).filter(
+            models.AgentCapability.id == capability_id
+        )
+        result = await self.db.execute(query)
+        return result.scalar_one_or_none()
+
+    async def list_capabilities(
+        self, agent_role_id: Optional[str] = None
+    ) -> List[models.AgentCapability]:
+        query = select(models.AgentCapability)
+        if agent_role_id:
+            query = query.filter(models.AgentCapability.agent_role_id == agent_role_id)
+        result = await self.db.execute(query)
+        return list(result.scalars().all())
+
+    async def create_capability(
+        self, capability_in: AgentCapabilityCreate
+    ) -> models.AgentCapability:
+        capability = models.AgentCapability(
+            agent_role_id=capability_in.agent_role_id,
+            capability=capability_in.capability,
+            description=capability_in.description,
+            is_active=capability_in.is_active,
+        )
+        self.db.add(capability)
+        await self.db.commit()
+        await self.db.refresh(capability)
+        return capability
+
+    async def update_capability(
+        self, capability_id: str, capability_update: AgentCapabilityUpdate
+    ) -> Optional[models.AgentCapability]:
+        capability = await self.get_capability(capability_id)
+        if not capability:
+            return None
+        update_data = capability_update.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(capability, field, value)
+        await self.db.commit()
+        await self.db.refresh(capability)
+        return capability
+
+    async def delete_capability(self, capability_id: str) -> bool:
+        capability = await self.get_capability(capability_id)
+        if not capability:
+            return False
+        await self.db.delete(capability)
+        await self.db.commit()
+        return True


### PR DESCRIPTION
## Summary
- implement `AgentCapabilityService` with CRUD methods
- add schema for agent capabilities
- expose new capability endpoints

## Testing
- `flake8 services/agent_capability_service.py routers/rules/roles/capabilities.py ../backend/schemas/agent_capability.py`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684180b94b9c832cbbc6846ebaec85b6