### PR TITLE
Add knowledge graph endpoint

### DIFF
--- a/backend/routers/memory/core/core.py
+++ b/backend/routers/memory/core/core.py
@@ -24,6 +24,17 @@ router = APIRouter(
 def get_memory_service(db: Session = Depends(get_db)) -> MemoryService:
     return MemoryService(db)
 
+
+@router.get("/graph")
+def get_memory_graph(
+    memory_service: MemoryService = Depends(get_memory_service),
+):
+    """Retrieve the entire knowledge graph."""
+    try:
+        return memory_service.get_knowledge_graph()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+
 # =============================
 # CRUD Endpoints
 # =============================

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -12,7 +12,9 @@ from ..schemas.memory import (
     MemoryEntityCreate,
     MemoryEntityUpdate,
     MemoryObservationCreate,
-    MemoryRelationCreate
+    MemoryRelationCreate,
+    MemoryEntity,
+    MemoryRelation,
 )
 from ..schemas.file_ingest import FileIngestInput
 from ..crud.memory import (
@@ -390,3 +392,17 @@ class MemoryService:
         self, query: str, limit: int = 10
     ) -> List[models.MemoryEntity]:
         return self.get_memory_entities(name=query, limit=limit)
+
+    def get_knowledge_graph(self) -> Dict[str, List[Dict[str, Any]]]:
+        """Return all memory entities and relations as a graph structure."""
+        entities = self.db.query(models.MemoryEntity).all()
+        relations = self.db.query(models.MemoryRelation).all()
+
+        pydantic_entities = [
+            MemoryEntity.model_validate(e).model_dump() for e in entities
+        ]
+        pydantic_relations = [
+            MemoryRelation.model_validate(r).model_dump() for r in relations
+        ]
+
+        return {"entities": pydantic_entities, "relations": pydantic_relations}

--- a/backend/tests/test_memory_graph.py
+++ b/backend/tests/test_memory_graph.py
@@ -1,0 +1,89 @@
+import types
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient, ASGITransport
+
+from backend.routers.memory import (
+    router,
+    get_memory_service,
+    get_current_active_user,
+)
+from backend.routers.memory.core.core import (
+    get_memory_service as core_get_memory_service,
+)
+from backend.schemas.memory import MemoryEntity, MemoryRelation
+from datetime import datetime, timezone
+
+
+class DummyGraphService:
+    def __init__(self):
+        now = datetime.now(timezone.utc)
+        self.entities = [
+            MemoryEntity(
+                id=1,
+                entity_type="text",
+                content="a",
+                entity_metadata=None,
+                source="test",
+                source_metadata=None,
+                created_by_user_id="u",
+                created_at=now,
+                updated_at=None,
+            ),
+            MemoryEntity(
+                id=2,
+                entity_type="text",
+                content="b",
+                entity_metadata=None,
+                source="test",
+                source_metadata=None,
+                created_by_user_id="u",
+                created_at=now,
+                updated_at=None,
+            ),
+        ]
+        self.relations = [
+            MemoryRelation(
+                id=1,
+                from_entity_id=1,
+                to_entity_id=2,
+                relation_type="linked",
+                metadata_=None,
+                created_at=now,
+                updated_at=None,
+                from_entity=None,
+                to_entity=None,
+            )
+        ]
+
+    def get_knowledge_graph(self):
+        return {"entities": self.entities, "relations": self.relations}
+
+
+dummy_user = types.SimpleNamespace(id="user1")
+
+def override_user():
+    return dummy_user
+
+dummy_service = DummyGraphService()
+
+def override_service():
+    return dummy_service
+
+app = FastAPI()
+app.include_router(router)
+app.dependency_overrides[get_memory_service] = override_service
+app.dependency_overrides[core_get_memory_service] = override_service
+app.dependency_overrides[get_current_active_user] = override_user
+
+
+@pytest.mark.asyncio
+async def test_get_graph_endpoint():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/entities/graph")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["entities"]) == 2
+        assert len(data["relations"]) == 1
+        assert data["relations"][0]["from_entity_id"] == 1
+        assert data["relations"][0]["to_entity_id"] == 2


### PR DESCRIPTION
## Summary
- expose all memory entities and relations via `MemoryService.get_knowledge_graph`
- add `/graph` route to memory core router
- test knowledge graph endpoint

## Testing
- `pytest backend/tests/test_memory_graph.py -q`
- `flake8 backend/services/memory_service.py backend/routers/memory/core/core.py backend/tests/test_memory_graph.py`

------
https://chatgpt.com/codex/tasks/task_e_684180c162b4832c8cf4b22f75dc33af