### PR TITLE
Add user role management page and API service

### DIFF
--- a/frontend/src/app/user-roles/page.tsx
+++ b/frontend/src/app/user-roles/page.tsx
@@ -1,0 +1,138 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  TableContainer,
+  Select,
+  Button,
+  Flex,
+} from '@chakra-ui/react';
+import { getUsers } from '@/services/api/users';
+import { userRolesApi } from '@/services/api/user_roles';
+import { User, UserRole } from '@/types/user';
+import { handleApiError } from '@/lib/apiErrorHandler';
+
+const UserRolesPage: React.FC = () => {
+  const [users, setUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [selectedRoles, setSelectedRoles] = useState<
+    Record<string, UserRole | ''>
+  >({});
+
+  const fetchUsers = async () => {
+    try {
+      const result = await getUsers(0, 100);
+      setUsers(result);
+    } catch (err) {
+      handleApiError(err, 'Failed to load users');
+    }
+  };
+
+  useEffect(() => {
+    fetchUsers();
+  }, []);
+
+  const handleAssign = async (userId: string) => {
+    const role = selectedRoles[userId];
+    if (!role) return;
+    setLoading(true);
+    try {
+      await userRolesApi.assign(userId, role);
+      await fetchUsers();
+      setSelectedRoles((prev) => ({ ...prev, [userId]: '' }));
+    } catch (err) {
+      handleApiError(err, 'Failed to assign role');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleRemove = async (userId: string, role: UserRole) => {
+    setLoading(true);
+    try {
+      await userRolesApi.remove(userId, role);
+      await fetchUsers();
+    } catch (err) {
+      handleApiError(err, 'Failed to remove role');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box p="4">
+      <TableContainer>
+        <Table variant="simple" size="sm">
+          <Thead>
+            <Tr>
+              <Th>Username</Th>
+              <Th>Roles</Th>
+              <Th>Assign Role</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {users.map((u) => (
+              <Tr key={u.id} data-testid="user-row">
+                <Td>{u.username}</Td>
+                <Td>
+                  <Flex wrap="wrap" gap="2">
+                    {u.user_roles.map((r) => (
+                      <Button
+                        key={r.role_name}
+                        size="xs"
+                        onClick={() => handleRemove(u.id, r.role_name)}
+                        data-testid={`remove-${u.id}-${r.role_name}`}
+                      >
+                        {r.role_name} ✕
+                      </Button>
+                    ))}
+                  </Flex>
+                </Td>
+                <Td>
+                  <Flex>
+                    <Select
+                      size="sm"
+                      value={selectedRoles[u.id] || ''}
+                      onChange={(e) =>
+                        setSelectedRoles((prev) => ({
+                          ...prev,
+                          [u.id]: e.target.value as UserRole,
+                        }))
+                      }
+                      placeholder="Select role"
+                      mr="2"
+                      data-testid={`select-${u.id}`}
+                    >
+                      {Object.values(UserRole).map((r) => (
+                        <option key={r} value={r}>
+                          {r}
+                        </option>
+                      ))}
+                    </Select>
+                    <Button
+                      size="sm"
+                      onClick={() => handleAssign(u.id)}
+                      isDisabled={!selectedRoles[u.id]}
+                      isLoading={loading}
+                      data-testid={`assign-${u.id}`}
+                    >
+                      Add
+                    </Button>
+                  </Flex>
+                </Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+};
+
+export default UserRolesPage;

--- a/frontend/src/services/api/__tests__/user_roles.test.ts
+++ b/frontend/src/services/api/__tests__/user_roles.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { userRolesApi } from '../user_roles';
+import { buildApiUrl, API_CONFIG } from '../config';
+import { request } from '../request';
+
+vi.mock('../request', () => ({ request: vi.fn() }));
+
+const requestMock = request as unknown as vi.Mock;
+
+describe('userRolesApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requestMock.mockResolvedValue(undefined);
+  });
+
+  it('assign calls correct URL and method', async () => {
+    await userRolesApi.assign('u1', 'admin' as any);
+    expect(requestMock).toHaveBeenCalledWith(
+      buildApiUrl(API_CONFIG.ENDPOINTS.USERS, '/u1/roles'),
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('remove calls correct URL and method', async () => {
+    await userRolesApi.remove('u1', 'admin' as any);
+    expect(requestMock).toHaveBeenCalledWith(
+      buildApiUrl(API_CONFIG.ENDPOINTS.USERS, '/u1/roles/admin'),
+      expect.objectContaining({ method: 'DELETE' })
+    );
+  });
+});

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -15,3 +15,4 @@ export * from "./agent_handoff_criteria";
 export * from "./forbidden_actions";
 export * from "./verification_requirements";
 export * from "./error_protocols";
+export * from './user_roles';

--- a/frontend/src/services/api/user_roles.ts
+++ b/frontend/src/services/api/user_roles.ts
@@ -1,0 +1,25 @@
+import { request } from './request';
+import { buildApiUrl, API_CONFIG } from './config';
+import { UserRole, UserRoleObject } from '@/types/user';
+
+export const userRolesApi = {
+  async assign(userId: string, roleName: UserRole): Promise<UserRoleObject> {
+    return request<UserRoleObject>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.USERS, `/${userId}/roles`),
+      {
+        method: 'POST',
+        body: JSON.stringify({ role_name: roleName }),
+      }
+    );
+  },
+
+  async remove(
+    userId: string,
+    roleName: UserRole
+  ): Promise<{ message: string }> {
+    return request<{ message: string }>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.USERS, `/${userId}/roles/${roleName}`),
+      { method: 'DELETE' }
+    );
+  },
+};


### PR DESCRIPTION
## Summary
- create API helper for assigning/removing user roles
- expose new API from services index
- add Vitest tests for the helper
- add user-roles page showing table of users with role controls

## Testing
- `npm run lint`
- `npm test` *(fails: observer.observe is not a function, tsc errors)*

------
https://chatgpt.com/codex/tasks/task_e_684180befa60832c8cdf8b5645ec0e2e