### PR TITLE
Add agent handoff criteria CRUD

### DIFF
--- a/backend/routers/rules/roles/handoff_criteria.py
+++ b/backend/routers/rules/roles/handoff_criteria.py
@@ -7,6 +7,7 @@ from ....services.agent_handoff_service import AgentHandoffService
 from ....schemas.agent_handoff_criteria import (
     AgentHandoffCriteria,
     AgentHandoffCriteriaCreate,
+    AgentHandoffCriteriaUpdate,
 )
 
 router = APIRouter()
@@ -22,6 +23,19 @@ def list_handoff_criteria(
     return service.list_criteria(agent_role_id)
 
 
+@router.get("/{criteria_id}", response_model=AgentHandoffCriteria)
+def get_handoff_criteria(
+    criteria_id: str,
+    db: Session = Depends(get_db),
+):
+    """Retrieve a single handoff criteria by ID."""
+    service = AgentHandoffService(db)
+    db_obj = service.get_criteria(criteria_id)
+    if not db_obj:
+        raise HTTPException(status_code=404, detail="Criteria not found")
+    return db_obj
+
+
 @router.post("/", response_model=AgentHandoffCriteria)
 def create_handoff_criteria(
     criteria: AgentHandoffCriteriaCreate,
@@ -30,6 +44,20 @@ def create_handoff_criteria(
     """Create new handoff criteria."""
     service = AgentHandoffService(db)
     return service.create_criteria(criteria)
+
+
+@router.put("/{criteria_id}", response_model=AgentHandoffCriteria)
+def update_handoff_criteria(
+    criteria_id: str,
+    criteria_update: AgentHandoffCriteriaUpdate,
+    db: Session = Depends(get_db),
+):
+    """Update existing handoff criteria."""
+    service = AgentHandoffService(db)
+    db_obj = service.update_criteria(criteria_id, criteria_update)
+    if not db_obj:
+        raise HTTPException(status_code=404, detail="Criteria not found")
+    return db_obj
 
 
 @router.delete("/{criteria_id}")

--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -78,6 +78,7 @@ from .agent_handoff_criteria import (
     AgentHandoffCriteriaBase,
     AgentHandoffCriteriaCreate,
     AgentHandoffCriteria,
+    AgentHandoffCriteriaUpdate,
 )
 from .agent_error_protocol import (
     AgentErrorProtocolBase,

--- a/backend/schemas/_schema_init.py
+++ b/backend/schemas/_schema_init.py
@@ -32,6 +32,7 @@ from .project import (  # noqa: F401
 from .agent_handoff_criteria import (  # noqa: F401
     AgentHandoffCriteria,
     AgentHandoffCriteriaCreate,
+    AgentHandoffCriteriaUpdate,
 )
 from .project_template import (  # noqa: F401
     ProjectTemplate,

--- a/backend/schemas/agent_handoff_criteria.py
+++ b/backend/schemas/agent_handoff_criteria.py
@@ -23,6 +23,26 @@ class AgentHandoffCriteriaCreate(AgentHandoffCriteriaBase):
     pass
 
 
+class AgentHandoffCriteriaUpdate(BaseModel):
+    """Schema for updating handoff criteria."""
+
+    agent_role_id: Optional[str] = Field(
+        None, description="ID of the related agent role."
+    )
+    criteria: Optional[str] = Field(
+        None, description="Handoff trigger criteria."
+    )
+    description: Optional[str] = Field(
+        None, description="Optional description of the criteria."
+    )
+    target_agent_role: Optional[str] = Field(
+        None, description="Suggested target agent role for handoff."
+    )
+    is_active: Optional[bool] = Field(
+        None, description="Whether this criteria is active."
+    )
+
+
 class AgentHandoffCriteria(AgentHandoffCriteriaBase):
     """Schema representing handoff criteria."""
 

--- a/backend/services/agent_handoff_service.py
+++ b/backend/services/agent_handoff_service.py
@@ -2,7 +2,10 @@ from sqlalchemy.orm import Session
 from typing import List, Optional
 
 from .. import models
-from ..schemas.agent_handoff_criteria import AgentHandoffCriteriaCreate
+from ..schemas.agent_handoff_criteria import (
+    AgentHandoffCriteriaCreate,
+    AgentHandoffCriteriaUpdate,
+)
 
 
 class AgentHandoffService:
@@ -11,7 +14,9 @@ class AgentHandoffService:
     def __init__(self, db: Session):
         self.db = db
 
-    def create_criteria(self, criteria_in: AgentHandoffCriteriaCreate) -> models.AgentHandoffCriteria:
+    def create_criteria(
+        self, criteria_in: AgentHandoffCriteriaCreate
+    ) -> models.AgentHandoffCriteria:
         db_criteria = models.AgentHandoffCriteria(
             agent_role_id=criteria_in.agent_role_id,
             criteria=criteria_in.criteria,
@@ -24,11 +29,35 @@ class AgentHandoffService:
         self.db.refresh(db_criteria)
         return db_criteria
 
-    def list_criteria(self, agent_role_id: Optional[str] = None) -> List[models.AgentHandoffCriteria]:
+    def list_criteria(
+        self, agent_role_id: Optional[str] = None
+    ) -> List[models.AgentHandoffCriteria]:
         query = self.db.query(models.AgentHandoffCriteria)
         if agent_role_id:
-            query = query.filter(models.AgentHandoffCriteria.agent_role_id == agent_role_id)
+            query = query.filter(
+                models.AgentHandoffCriteria.agent_role_id == agent_role_id
+            )
         return query.all()
+
+    def get_criteria(self, criteria_id: str) -> Optional[models.AgentHandoffCriteria]:
+        return (
+            self.db.query(models.AgentHandoffCriteria)
+            .filter(models.AgentHandoffCriteria.id == criteria_id)
+            .first()
+        )
+
+    def update_criteria(
+        self, criteria_id: str, criteria_update: AgentHandoffCriteriaUpdate
+    ) -> Optional[models.AgentHandoffCriteria]:
+        db_obj = self.get_criteria(criteria_id)
+        if not db_obj:
+            return None
+        update_data = criteria_update.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(db_obj, field, value)
+        self.db.commit()
+        self.db.refresh(db_obj)
+        return db_obj
 
     def delete_criteria(self, criteria_id: str) -> bool:
         db_obj = (


### PR DESCRIPTION
## Summary
- support retrieving and updating handoff criteria
- expose new endpoints for handoff criteria management

## Testing
- `flake8 services/agent_handoff_service.py routers/rules/roles/handoff_criteria.py schemas/agent_handoff_criteria.py`
- `pytest -q` *(fails: AttributeError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_684180b91680832c9890ba2549d8f205