### PR TITLE
Fix bcrypt compatibility

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,7 +15,8 @@ alembic = "*"
 psycopg2-binary = "*"
 python-dotenv = "*"
 fastapi-mcp = "*"
-passlib = { extras = ["bcrypt"], version = "*" }
+passlib = { version = "1.7.4" }
+bcrypt = "<4"
 python-jose = "*"
 aiosqlite = "*"
 aiohttp = "*"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,7 +5,8 @@ alembic
 psycopg2-binary
 python-dotenv
 fastapi-mcp
-passlib[bcrypt]
+passlib==1.7.4
+bcrypt<4
 python-jose
 aiosqlite
 aiohttp


### PR DESCRIPTION
## Summary
- pin bcrypt to <4 to avoid incompatibility with passlib

## Testing
- `pytest tests/test_memory_ingestion.py::test_ingest_file_and_retrieve -q`
- `flake8 | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_684180bd3d74832c9a22e18fd21d6078