### PR TITLE
Add capability management tools

### DIFF
--- a/SYSTEM_GUIDE.md
+++ b/SYSTEM_GUIDE.md
@@ -192,6 +192,11 @@ NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
 - `routers/` - API route definitions
 - `services/` - Business logic layer
 
+### MCP Tools
+The `backend/mcp_tools/` package provides utility endpoints for agents.
+Recent additions include capability management tools for adding, listing, and
+removing agent capabilities.
+
 ## 📈 Performance Considerations
 
 ### Backend Optimizations

--- a/backend/mcp_tools/README.md
+++ b/backend/mcp_tools/README.md
@@ -10,6 +10,7 @@ Key files:
 *   `project_file_tools.py`: Associate memory files with projects.
 *   `rule_tools.py`: Tools for managing agent rules and mandates.
 *   `agent_handoff_tools.py`: Tools for managing agent handoff criteria.
+*   `agent_capability_tools.py`: Tools for adding, listing, and removing agent capabilities.
 *   `forbidden_action_tools.py`: Tools for creating and listing forbidden actions for agent roles.
 *   `error_protocol_tools.py`: Tools for creating and listing error protocols for agent roles.
 *   `__init__.py`: Initializes the mcp_tools package.
@@ -56,6 +57,7 @@ actions = await list_forbidden_actions_tool(agent_role_id="manager", db=session)
 - `project_file_tools.py`
 - `rule_tools.py`
 - `agent_handoff_tools.py`
+- `agent_capability_tools.py`
 - `forbidden_action_tools.py`
 - `error_protocol_tools.py`
 

--- a/backend/mcp_tools/__init__.py
+++ b/backend/mcp_tools/__init__.py
@@ -23,5 +23,8 @@ __all__ = [
     'delete_project_template_tool',
     'add_error_protocol_tool',
     'list_error_protocols_tool',
-    'remove_error_protocol_tool'
+    'remove_error_protocol_tool',
+    'add_capability_tool',
+    'list_capabilities_tool',
+    'remove_capability_tool'
 ]

--- a/backend/mcp_tools/agent_capability_tools.py
+++ b/backend/mcp_tools/agent_capability_tools.py
@@ -1,0 +1,99 @@
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+from typing import Optional, List
+import logging
+
+from backend.models.agent_capability import AgentCapability
+from backend.services.audit_log_service import AuditLogService
+
+logger = logging.getLogger(__name__)
+
+
+async def add_capability_tool(
+    agent_role_id: str,
+    capability: str,
+    description: Optional[str],
+    db: Session,
+) -> dict:
+    """MCP Tool: Add a capability to an agent role."""
+    try:
+        item = AgentCapability(
+            agent_role_id=agent_role_id,
+            capability=capability,
+            description=description,
+            is_active=True,
+        )
+        db.add(item)
+        db.commit()
+        db.refresh(item)
+        AuditLogService(db).log_action(
+            action="capability_added",
+            entity_type="agent_capability",
+            entity_id=item.id,
+            changes={"capability": capability, "description": description},
+        )
+        return {
+            "success": True,
+            "capability": {
+                "id": item.id,
+                "agent_role_id": item.agent_role_id,
+                "capability": item.capability,
+                "description": item.description,
+                "is_active": item.is_active,
+            },
+        }
+    except Exception as exc:
+        logger.error(f"MCP add capability failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+async def list_capabilities_tool(
+    agent_role_id: Optional[str],
+    db: Session,
+    skip: int = 0,
+    limit: int = 100,
+) -> dict:
+    """MCP Tool: List capabilities for agent roles."""
+    try:
+        query = db.query(AgentCapability)
+        if agent_role_id:
+            query = query.filter(AgentCapability.agent_role_id == agent_role_id)
+        items: List[AgentCapability] = query.offset(skip).limit(limit).all()
+        return {
+            "success": True,
+            "capabilities": [
+                {
+                    "id": c.id,
+                    "agent_role_id": c.agent_role_id,
+                    "capability": c.capability,
+                    "description": c.description,
+                    "is_active": c.is_active,
+                }
+                for c in items
+            ],
+        }
+    except Exception as exc:  # pragma: no cover - unexpected DB failure
+        logger.error(f"MCP list capabilities failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+async def remove_capability_tool(capability_id: str, db: Session) -> dict:
+    """MCP Tool: Remove an agent capability."""
+    try:
+        query = db.query(AgentCapability)
+        item = query.filter(AgentCapability.id == capability_id).first()
+        if not item:
+            raise HTTPException(status_code=404, detail="Capability not found")
+        db.delete(item)
+        db.commit()
+        AuditLogService(db).log_action(
+            action="capability_removed",
+            entity_type="agent_capability",
+            entity_id=capability_id,
+        )
+        return {"success": True}
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"MCP remove capability failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/backend/routers/mcp/core.py
+++ b/backend/routers/mcp/core.py
@@ -28,6 +28,11 @@ from ....mcp_tools.forbidden_action_tools import (
     add_forbidden_action_tool,
     list_forbidden_actions_tool,
 )
+from ....mcp_tools.agent_capability_tools import (
+    add_capability_tool,
+    list_capabilities_tool,
+    remove_capability_tool,
+)
 from ....schemas.memory import (
     MemoryEntityCreate,
     MemoryEntityUpdate,
@@ -996,4 +1001,61 @@ async def mcp_list_forbidden_actions(
         return await list_forbidden_actions_tool(agent_role_id, db)
     except Exception as e:
         logger.error(f"MCP list forbidden actions failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/mcp-tools/capability/add",
+    tags=["mcp-tools"],
+    operation_id="add_capability_tool",
+)
+async def mcp_add_capability(
+    agent_role_id: str,
+    capability: str,
+    description: Optional[str] = None,
+    db: Session = Depends(get_db_session),
+):
+    """MCP Tool: Add a capability to an agent role."""
+    try:
+        return await add_capability_tool(agent_role_id, capability, description, db)
+    except Exception as e:
+        logger.error(f"MCP add capability failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get(
+    "/mcp-tools/capability/list",
+    tags=["mcp-tools"],
+    operation_id="list_capabilities_tool",
+)
+async def mcp_list_capabilities(
+    agent_role_id: Optional[str] = Query(None),
+    db: Session = Depends(get_db_session),
+    skip: int = 0,
+    limit: int = 100,
+):
+    """MCP Tool: List capabilities for agent roles."""
+    try:
+        return await list_capabilities_tool(agent_role_id, db, skip, limit)
+    except Exception as e:
+        logger.error(f"MCP list capabilities failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.delete(
+    "/mcp-tools/capability/remove",
+    tags=["mcp-tools"],
+    operation_id="remove_capability_tool",
+)
+async def mcp_remove_capability(
+    capability_id: str,
+    db: Session = Depends(get_db_session),
+):
+    """MCP Tool: Remove an agent capability."""
+    try:
+        return await remove_capability_tool(capability_id, db)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"MCP remove capability failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
## Summary
- add MCP tools for agent capabilities
- register capability endpoints in the MCP router
- document MCP tools section in system guide
- update backend MCP tools docs and exports

## Testing
- `flake8 mcp_tools/agent_capability_tools.py`
- `flake8 routers/mcp/core.py | head -n 20`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684180b8de94832cb31593201a896d48