### PR TITLE
Add agent capabilities management UI

### DIFF
--- a/frontend/src/components/agents/AgentCapabilities.tsx
+++ b/frontend/src/components/agents/AgentCapabilities.tsx
@@ -1,0 +1,150 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Flex,
+  Input,
+  List,
+  ListItem,
+  Spinner,
+  Text,
+  useToast,
+} from '@chakra-ui/react';
+import { capabilitiesApi } from '@/services/api';
+import type { Capability } from '@/types/capability';
+
+interface AgentCapabilitiesProps {
+  agentRoleId: string;
+}
+
+const AgentCapabilities: React.FC<AgentCapabilitiesProps> = ({
+  agentRoleId,
+}) => {
+  const toast = useToast();
+  const [capabilities, setCapabilities] = useState<Capability[] | null>(null);
+  const [newCap, setNewCap] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const loadCapabilities = async () => {
+    try {
+      const data = await capabilitiesApi.list(agentRoleId);
+      setCapabilities(data);
+    } catch (err) {
+      toast({
+        title: 'Failed to load capabilities',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  useEffect(() => {
+    loadCapabilities();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agentRoleId]);
+
+  const handleCreate = async () => {
+    if (!newCap.trim()) return;
+    setLoading(true);
+    try {
+      await capabilitiesApi.create(agentRoleId, {
+        agent_role_id: agentRoleId,
+        capability: newCap,
+      });
+      setNewCap('');
+      await loadCapabilities();
+      toast({
+        title: 'Capability added',
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+      });
+    } catch (err) {
+      toast({
+        title: 'Failed to add capability',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    setLoading(true);
+    try {
+      await capabilitiesApi.delete(id);
+      await loadCapabilities();
+      toast({
+        title: 'Capability removed',
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+      });
+    } catch (err) {
+      toast({
+        title: 'Failed to remove capability',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!capabilities) {
+    return (
+      <Flex justify="center" align="center" p="4" minH="100px">
+        <Spinner />
+      </Flex>
+    );
+  }
+
+  return (
+    <Box>
+      <Flex mb={2} gap={2}>
+        <Input
+          placeholder="New capability"
+          value={newCap}
+          onChange={(e) => setNewCap(e.target.value)}
+        />
+        <Button
+          onClick={handleCreate}
+          isLoading={loading}
+          disabled={!newCap.trim()}
+        >
+          Add
+        </Button>
+      </Flex>
+      {capabilities.length === 0 ? (
+        <Text>No capabilities.</Text>
+      ) : (
+        <List spacing={2}>
+          {capabilities.map((cap) => (
+            <ListItem key={cap.id} borderWidth="1px" borderRadius="md" p={2}>
+              <Flex justify="space-between" align="center">
+                <Text>{cap.capability}</Text>
+                <Button
+                  size="sm"
+                  colorScheme="red"
+                  onClick={() => handleDelete(cap.id)}
+                >
+                  Delete
+                </Button>
+              </Flex>
+            </ListItem>
+          ))}
+        </List>
+      )}
+    </Box>
+  );
+};
+
+export default AgentCapabilities;

--- a/frontend/src/components/agents/__tests__/AgentCapabilities.test.tsx
+++ b/frontend/src/components/agents/__tests__/AgentCapabilities.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@/__tests__/utils/test-utils';
+import AgentCapabilities from '../AgentCapabilities';
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual('@chakra-ui/react');
+  return {
+    ...actual,
+    useToast: () => vi.fn(),
+    useColorModeValue: (light: any, dark: any) => light,
+  };
+});
+
+describe('AgentCapabilities', () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render without crashing', () => {
+    render(<AgentCapabilities agentRoleId="role1" />, {
+      wrapper: ({ children }) => <div>{children}</div>,
+    });
+    expect(document.body).toBeInTheDocument();
+  });
+
+  it('should handle user interactions', async () => {
+    render(<AgentCapabilities agentRoleId="role1" />, {
+      wrapper: ({ children }) => <div>{children}</div>,
+    });
+
+    const buttons = screen.queryAllByRole('button');
+    const inputs = screen.queryAllByRole('textbox');
+
+    if (buttons.length > 0) {
+      await user.click(buttons[0]);
+    }
+
+    if (inputs.length > 0) {
+      await user.type(inputs[0], 'test input');
+    }
+
+    expect(document.body).toBeInTheDocument();
+  });
+});

--- a/frontend/src/services/api/capabilities.ts
+++ b/frontend/src/services/api/capabilities.ts
@@ -1,0 +1,36 @@
+import { request } from './request';
+import { buildApiUrl, API_CONFIG } from './config';
+import type { Capability, CapabilityCreateData } from '@/types/capability';
+
+export const capabilitiesApi = {
+  async list(agentRoleName: string): Promise<Capability[]> {
+    const res = await request<any>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/roles/${agentRoleName}`)
+    );
+    return (res as any).capabilities ?? (res as Capability[]);
+  },
+
+  async create(
+    agentRoleId: string,
+    data: CapabilityCreateData
+  ): Promise<Capability> {
+    const res = await request<any>(
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.RULES,
+        `/roles/${agentRoleId}/capabilities`
+      ),
+      { method: 'POST', body: JSON.stringify(data) }
+    );
+    return (res as any).data ?? (res as Capability);
+  },
+
+  async delete(capabilityId: string): Promise<void> {
+    await request(
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.RULES,
+        `/roles/capabilities/${capabilityId}`
+      ),
+      { method: 'DELETE' }
+    );
+  },
+};

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -15,3 +15,4 @@ export * from "./agent_handoff_criteria";
 export * from "./forbidden_actions";
 export * from "./verification_requirements";
 export * from "./error_protocols";
+export * from "./capabilities";

--- a/frontend/src/types/capability.ts
+++ b/frontend/src/types/capability.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+export const capabilityBaseSchema = z.object({
+  agent_role_id: z.string(),
+  capability: z.string().min(1, 'Capability is required'),
+  description: z.string().nullable().optional(),
+  is_active: z.boolean().default(true),
+});
+
+export const capabilityCreateSchema = capabilityBaseSchema.omit({
+  agent_role_id: true,
+});
+export type CapabilityCreateData = z.infer<typeof capabilityCreateSchema> & {
+  agent_role_id: string;
+};
+
+export const capabilitySchema = capabilityBaseSchema.extend({
+  id: z.string(),
+  created_at: z.string().datetime({ message: 'Invalid ISO datetime string' }),
+});
+export type Capability = z.infer<typeof capabilitySchema>;
+
+export interface CapabilityResponse {
+  data: Capability;
+  error?: { code: string; message: string; field?: string };
+}
+
+export interface CapabilityListResponse {
+  data: Capability[];
+  total: number;
+  page: number;
+  pageSize: number;
+  error?: { code: string; message: string; field?: string };
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -12,6 +12,7 @@ export * from "./project_template";
 export * from "./agent_prompt_template";
 export * from "./verification_requirement";
 export * from "./error_protocol";
+export * from "./capability";
 
 // Common types used across the application
 // Canonical shared sort direction type for all entities


### PR DESCRIPTION
## Summary
- implement `AgentCapabilities` component for editing agent role capabilities
- provide capability API client and types
- export new helpers from API and types modules
- add unit tests for the new component

## Testing
- `npm run lint`
- `npx vitest run src/components/agents/__tests__/AgentCapabilities.test.tsx` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_684180b8852c832c9752463b5a9978a9