### PR TITLE
Add agent handoff MCP tools

### DIFF
--- a/backend/docs/fastapi_mcp/README.md
+++ b/backend/docs/fastapi_mcp/README.md
@@ -104,9 +104,11 @@ FastAPI-MCP automatically exposes selected API endpoints as tools under the `/mc
 
 ### Agent Handoff Tools
 
-Use these routes to manage when one agent role should hand off control to
-another. Create new rules with `/mcp-tools/handoff/create`, list all criteria
-via `/mcp-tools/handoff/list`, and remove a rule using `/mcp-tools/handoff/delete`.
+Manage when one agent role should hand off control to another:
+
+- `/mcp-tools/handoff/create` - create a new handoff criteria
+- `/mcp-tools/handoff/list` - list existing criteria
+- `/mcp-tools/handoff/delete` - remove a criteria by ID
 
 ## Development and Contributing
 


### PR DESCRIPTION
## Summary
- implement agent handoff tools for MCP
- expose handoff tool endpoints in MCP router
- document handoff tools in FastAPI MCP README

## Testing
- `flake8 mcp_tools/agent_handoff_tools.py routers/mcp/core.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684180b71314832cab5ca9fa6bd640e3