### PR TITLE
Add forbidden actions manager component

### DIFF
--- a/frontend/src/components/agents/AgentForbiddenActions.tsx
+++ b/frontend/src/components/agents/AgentForbiddenActions.tsx
@@ -1,0 +1,137 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Flex,
+  Input,
+  List,
+  ListItem,
+  Spinner,
+  Text,
+  useToast,
+} from "@chakra-ui/react";
+import { forbiddenActionsApi } from "@/services/api";
+import type { AgentForbiddenAction } from "@/types";
+
+interface AgentForbiddenActionsProps {
+  agentRoleId: string;
+}
+
+const AgentForbiddenActions: React.FC<AgentForbiddenActionsProps> = ({ agentRoleId }) => {
+  const toast = useToast();
+  const [actions, setActions] = useState<AgentForbiddenAction[] | null>(null);
+  const [newAction, setNewAction] = useState("");
+  const [newReason, setNewReason] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const loadActions = async () => {
+    try {
+      const data = await forbiddenActionsApi.list(agentRoleId);
+      setActions(data);
+    } catch (err) {
+      toast({
+        title: "Failed to load forbidden actions",
+        description: err instanceof Error ? err.message : String(err),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  useEffect(() => {
+    loadActions();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agentRoleId]);
+
+  const handleCreate = async () => {
+    if (!newAction.trim()) return;
+    setLoading(true);
+    try {
+      await forbiddenActionsApi.create(agentRoleId, {
+        action: newAction,
+        reason: newReason || null,
+      });
+      setNewAction("");
+      setNewReason("");
+      await loadActions();
+      toast({ title: "Forbidden action added", status: "success", duration: 3000, isClosable: true });
+    } catch (err) {
+      toast({
+        title: "Failed to add forbidden action",
+        description: err instanceof Error ? err.message : String(err),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    setLoading(true);
+    try {
+      await forbiddenActionsApi.delete(id);
+      await loadActions();
+      toast({ title: "Forbidden action removed", status: "success", duration: 3000, isClosable: true });
+    } catch (err) {
+      toast({
+        title: "Failed to remove forbidden action",
+        description: err instanceof Error ? err.message : String(err),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!actions) {
+    return (
+      <Flex justify="center" align="center" p="4" minH="100px">
+        <Spinner />
+      </Flex>
+    );
+  }
+
+  return (
+    <Box>
+      <Flex mb={2} gap={2}>
+        <Input
+          placeholder="Forbidden action"
+          value={newAction}
+          onChange={(e) => setNewAction(e.target.value)}
+        />
+        <Input
+          placeholder="Reason (optional)"
+          value={newReason}
+          onChange={(e) => setNewReason(e.target.value)}
+        />
+        <Button onClick={handleCreate} isLoading={loading} disabled={!newAction.trim()}>
+          Add
+        </Button>
+      </Flex>
+      {actions.length === 0 ? (
+        <Text>No forbidden actions.</Text>
+      ) : (
+        <List spacing={2}>
+          {actions.map((action) => (
+            <ListItem key={action.id} borderWidth="1px" borderRadius="md" p={2}>
+              <Flex justify="space-between" align="center">
+                <Text>{action.action}</Text>
+                <Button size="sm" colorScheme="red" onClick={() => handleDelete(action.id)}>
+                  Delete
+                </Button>
+              </Flex>
+            </ListItem>
+          ))}
+        </List>
+      )}
+    </Box>
+  );
+};
+
+export default AgentForbiddenActions;

--- a/frontend/src/components/agents/__tests__/AgentForbiddenActions.test.tsx
+++ b/frontend/src/components/agents/__tests__/AgentForbiddenActions.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor } from '@/__tests__/utils/test-utils';
+import AgentForbiddenActions from '../AgentForbiddenActions';
+import { forbiddenActionsApi } from '@/services/api';
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual('@chakra-ui/react');
+  return {
+    ...actual,
+    useToast: () => vi.fn(),
+    useColorModeValue: (light: any, dark: any) => light,
+  };
+});
+
+vi.mock('@/services/api');
+
+const mockedApi = vi.mocked(forbiddenActionsApi);
+
+describe('AgentForbiddenActions', () => {
+  const user = userEvent.setup();
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedApi.list.mockResolvedValue([]);
+    mockedApi.create.mockResolvedValue({} as any);
+    mockedApi.delete.mockResolvedValue({ message: 'ok' });
+  });
+
+  it('fetches actions on mount', async () => {
+    render(
+      <AgentForbiddenActions agentRoleId="role1" />,
+      { wrapper: ({ children }) => <div>{children}</div> }
+    );
+    await waitFor(() => {
+      expect(mockedApi.list).toHaveBeenCalledWith('role1');
+    });
+  });
+
+  it('calls create API when adding an action', async () => {
+    render(
+      <AgentForbiddenActions agentRoleId="role1" />,
+      { wrapper: ({ children }) => <div>{children}</div> }
+    );
+
+    await waitFor(() => expect(mockedApi.list).toHaveBeenCalled());
+
+    await user.type(screen.getByPlaceholderText('Forbidden action'), 'test');
+    await user.type(screen.getByPlaceholderText('Reason (optional)'), 'because');
+    await user.click(screen.getByText('Add'));
+
+    await waitFor(() => {
+      expect(mockedApi.create).toHaveBeenCalledWith('role1', {
+        action: 'test',
+        reason: 'because',
+      });
+    });
+  });
+
+  it('calls delete API when deleting an action', async () => {
+    mockedApi.list.mockResolvedValue([{ id: '1', agent_role_id: 'role1', action: 'A', reason: null, is_active: true, created_at: '' }]);
+    render(
+      <AgentForbiddenActions agentRoleId="role1" />,
+      { wrapper: ({ children }) => <div>{children}</div> }
+    );
+
+    await waitFor(() => expect(screen.getByText('A')).toBeInTheDocument());
+
+    await user.click(screen.getByText('Delete'));
+
+    await waitFor(() => {
+      expect(mockedApi.delete).toHaveBeenCalledWith('1');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add `AgentForbiddenActions` component for managing forbidden actions
- provide Chakra UI form to add/remove actions
- test that API calls for list, create, and delete are triggered

## Testing
- `npm run lint`
- `npm run test` *(fails: observer.observe is not a function / error_protocol module missing)*

------
https://chatgpt.com/codex/tasks/task_e_684180b34fec832ca8f1ac65eb8381f8