### PR TITLE
Implement forbidden actions API

### DIFF
--- a/frontend/src/services/api/forbidden_actions.ts
+++ b/frontend/src/services/api/forbidden_actions.ts
@@ -4,9 +4,7 @@ import type {
   AgentForbiddenAction,
   AgentForbiddenActionCreateData,
   AgentForbiddenActionUpdateData,
-  ApiListResponse,
-  ApiResponse,
-} from '@/types';
+} from '@/types/agents';
 
 /**
  * Thin REST wrapper for agent forbidden actions endpoints.
@@ -15,56 +13,52 @@ export const forbiddenActionsApi = {
   /** Create a forbidden action for an agent role */
   async create(
     roleId: string,
-    data: AgentForbiddenActionCreateData
+    data: AgentForbiddenActionCreateData,
   ): Promise<AgentForbiddenAction> {
-    const res = await request<ApiResponse<AgentForbiddenAction>>(
+    return request<AgentForbiddenAction>(
       buildApiUrl(
         API_CONFIG.ENDPOINTS.RULES,
-        `/roles/${roleId}/forbidden-actions`
+        `/roles/${roleId}/forbidden-actions`,
       ),
       {
         method: 'POST',
         body: JSON.stringify(data),
-      }
+      },
     );
-    return (res as any).data ?? (res as unknown as AgentForbiddenAction);
   },
 
   /** Retrieve forbidden actions for a role */
   async list(roleId: string): Promise<AgentForbiddenAction[]> {
-    const res = await request<ApiListResponse<AgentForbiddenAction>>(
+    return request<AgentForbiddenAction[]>(
       buildApiUrl(
         API_CONFIG.ENDPOINTS.RULES,
-        `/roles/${roleId}/forbidden-actions`
-      )
+        `/roles/${roleId}/forbidden-actions`,
+      ),
     );
-    return (res as any).data ?? (res as unknown as AgentForbiddenAction[]);
   },
 
   /** Get a single forbidden action by ID */
   async get(actionId: string): Promise<AgentForbiddenAction> {
-    const res = await request<ApiResponse<AgentForbiddenAction>>(
+    return request<AgentForbiddenAction>(
       buildApiUrl(
         API_CONFIG.ENDPOINTS.RULES,
-        `/roles/forbidden-actions/${actionId}`
-      )
+        `/roles/forbidden-actions/${actionId}`,
+      ),
     );
-    return (res as any).data ?? (res as unknown as AgentForbiddenAction);
   },
 
   /** Update a forbidden action */
   async update(
     actionId: string,
-    data: AgentForbiddenActionUpdateData
+    data: AgentForbiddenActionUpdateData,
   ): Promise<AgentForbiddenAction> {
-    const res = await request<ApiResponse<AgentForbiddenAction>>(
+    return request<AgentForbiddenAction>(
       buildApiUrl(
         API_CONFIG.ENDPOINTS.RULES,
-        `/roles/forbidden-actions/${actionId}`
+        `/roles/forbidden-actions/${actionId}`,
       ),
-      { method: 'PUT', body: JSON.stringify(data) }
+      { method: 'PUT', body: JSON.stringify(data) },
     );
-    return (res as any).data ?? (res as unknown as AgentForbiddenAction);
   },
 
   /** Delete a forbidden action */

--- a/frontend/src/types/agents.ts
+++ b/frontend/src/types/agents.ts
@@ -53,3 +53,43 @@ export const errorProtocolSchema = errorProtocolBaseSchema.extend({
   created_at: z.string().datetime({ message: 'Invalid ISO datetime string' }),
 });
 export type ErrorProtocol = z.infer<typeof errorProtocolSchema>;
+
+// --- Agent Forbidden Action Schemas ---
+export const agentForbiddenActionBaseSchema = z.object({
+  agent_role_id: z.string(),
+  action: z.string(),
+  reason: z.string().nullable().optional(),
+  is_active: z.boolean().default(true),
+});
+
+export const agentForbiddenActionCreateSchema =
+  agentForbiddenActionBaseSchema.omit({ agent_role_id: true });
+export type AgentForbiddenActionCreateData = z.infer<
+  typeof agentForbiddenActionCreateSchema
+>;
+
+export const agentForbiddenActionUpdateSchema = agentForbiddenActionBaseSchema
+  .partial()
+  .omit({ agent_role_id: true });
+export type AgentForbiddenActionUpdateData = z.infer<
+  typeof agentForbiddenActionUpdateSchema
+>;
+
+export const agentForbiddenActionSchema = agentForbiddenActionBaseSchema.extend({
+  id: z.string(),
+  created_at: z.string().datetime({ message: 'Invalid ISO datetime string' }),
+});
+export type AgentForbiddenAction = z.infer<typeof agentForbiddenActionSchema>;
+
+export interface AgentForbiddenActionResponse {
+  data: AgentForbiddenAction;
+  error?: { code: string; message: string; field?: string };
+}
+
+export interface AgentForbiddenActionListResponse {
+  data: AgentForbiddenAction[];
+  total: number;
+  page: number;
+  pageSize: number;
+  error?: { code: string; message: string; field?: string };
+}


### PR DESCRIPTION
## Summary
- provide CRUD wrapper for forbidden actions with strong types
- define AgentForbiddenAction schemas in agents types
- wire up export through API index

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend run test:run` *(fails: observer.observe is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_684180b2cdf4832c834c425930eaa75a