### PR TITLE
Add error protocol API and types

### DIFF
--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -11,7 +11,6 @@ export * from "./mcp";
 export * from "./project_template";
 export * from "./agent_prompt_template";
 export * from "./verification_requirement";
-export * from "./error_protocol";
 
 // Common types used across the application
 // Canonical shared sort direction type for all entities


### PR DESCRIPTION
## Summary
- implement error protocol API service with CRUD wrappers
- define `ErrorProtocol` schemas and types
- export service via API index
- clean up stale type export

## Testing
- `npm run lint`
- `npm run type-check` *(fails: TypeScript errors)*
- `npm run test` *(fails: tests in task management integration)*

------
https://chatgpt.com/codex/tasks/task_e_684180b1a2b0832cb9b487481aa38a64