### PR TITLE
Add agent error protocol management

### DIFF
--- a/backend/routers/rules/violations/error_protocols.py
+++ b/backend/routers/rules/violations/error_protocols.py
@@ -13,12 +13,17 @@ from ....schemas.agent_error_protocol import (
 router = APIRouter()
 
 
-async def get_service(db: AsyncSession = Depends(get_db)) -> AgentErrorProtocolService:
+async def get_service(
+    db: AsyncSession = Depends(get_db),
+) -> AgentErrorProtocolService:
     return AgentErrorProtocolService(db)
 
 
 @router.get("/error-protocols/{protocol_id}", response_model=AgentErrorProtocol)
-async def read_error_protocol(protocol_id: str, service: AgentErrorProtocolService = Depends(get_service)):
+async def read_error_protocol(
+    protocol_id: str,
+    service: AgentErrorProtocolService = Depends(get_service),
+):
     protocol = await service.get_protocol(protocol_id)
     if not protocol:
         raise HTTPException(status_code=404, detail="Error protocol not found")
@@ -26,7 +31,10 @@ async def read_error_protocol(protocol_id: str, service: AgentErrorProtocolServi
 
 
 @router.get("/{role_id}/error-protocols", response_model=List[AgentErrorProtocol])
-async def list_error_protocols(role_id: str, service: AgentErrorProtocolService = Depends(get_service)):
+async def list_error_protocols(
+    role_id: str,
+    service: AgentErrorProtocolService = Depends(get_service),
+):
     return await service.list_protocols(agent_role_id=role_id)
 
 
@@ -53,7 +61,10 @@ async def update_error_protocol(
 
 
 @router.delete("/error-protocols/{protocol_id}")
-async def delete_error_protocol(protocol_id: str, service: AgentErrorProtocolService = Depends(get_service)):
+async def delete_error_protocol(
+    protocol_id: str,
+    service: AgentErrorProtocolService = Depends(get_service),
+):
     success = await service.delete_protocol(protocol_id)
     if not success:
         raise HTTPException(status_code=404, detail="Error protocol not found")

--- a/backend/services/agent_error_protocol_service.py
+++ b/backend/services/agent_error_protocol_service.py
@@ -4,7 +4,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import models
 from ..schemas.agent_error_protocol import (
-    AgentErrorProtocol,
     AgentErrorProtocolCreate,
     AgentErrorProtocolUpdate,
 )
@@ -16,10 +15,13 @@ class AgentErrorProtocolService:
     def __init__(self, db: AsyncSession):
         self.db = db
 
-    async def get_protocol(self, protocol_id: str) -> Optional[models.AgentErrorProtocol]:
-        result = await self.db.execute(
-            select(models.AgentErrorProtocol).filter(models.AgentErrorProtocol.id == protocol_id)
+    async def get_protocol(
+        self, protocol_id: str
+    ) -> Optional[models.AgentErrorProtocol]:
+        stmt = select(models.AgentErrorProtocol).filter(
+            models.AgentErrorProtocol.id == protocol_id
         )
+        result = await self.db.execute(stmt)
         return result.scalar_one_or_none()
 
     async def list_protocols(
@@ -27,7 +29,9 @@ class AgentErrorProtocolService:
     ) -> List[models.AgentErrorProtocol]:
         query = select(models.AgentErrorProtocol)
         if agent_role_id:
-            query = query.filter(models.AgentErrorProtocol.agent_role_id == agent_role_id)
+            query = query.filter(
+                models.AgentErrorProtocol.agent_role_id == agent_role_id
+            )
         result = await self.db.execute(query)
         return list(result.scalars().all())
 
@@ -47,7 +51,9 @@ class AgentErrorProtocolService:
         return db_protocol
 
     async def update_protocol(
-        self, protocol_id: str, protocol_update: AgentErrorProtocolUpdate
+        self,
+        protocol_id: str,
+        protocol_update: AgentErrorProtocolUpdate,
     ) -> Optional[models.AgentErrorProtocol]:
         db_protocol = await self.get_protocol(protocol_id)
         if not db_protocol:


### PR DESCRIPTION
## Summary
- implement async CRUD service for agent error protocols
- expose `/error-protocols` API endpoints with FastAPI router
- register router within rules package
- make style fixes for flake8

## Testing
- `flake8 services/agent_error_protocol_service.py routers/rules/violations/error_protocols.py routers/rules/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_684180abcb54832cbaa856adf82d605c