### PR TITLE
feat: add verification requirement tools

### DIFF
--- a/SYSTEM_GUIDE.md
+++ b/SYSTEM_GUIDE.md
@@ -39,6 +39,8 @@ node dev_start.js
 - **✅ Agent System**: Rules-based agents with capabilities and constraints
 - **✅ Memory System**: Knowledge graph for file and content management
 - **✅ Audit Logging**: Complete action tracking and history
+- **✅ Verification Requirement Tools**: Manage agent role verification
+  requirements via MCP (create, list, delete)
 
 ## 🌐 System Endpoints
 

--- a/backend/mcp_tools/README.md
+++ b/backend/mcp_tools/README.md
@@ -58,6 +58,7 @@ actions = await list_forbidden_actions_tool(agent_role_id="manager", db=session)
 - `agent_handoff_tools.py`
 - `forbidden_action_tools.py`
 - `error_protocol_tools.py`
+- `verification_requirement_tools.py`
 
 <!-- File List End -->
 

--- a/backend/mcp_tools/__init__.py
+++ b/backend/mcp_tools/__init__.py
@@ -23,5 +23,8 @@ __all__ = [
     'delete_project_template_tool',
     'add_error_protocol_tool',
     'list_error_protocols_tool',
-    'remove_error_protocol_tool'
+    'remove_error_protocol_tool',
+    'create_verification_requirement_tool',
+    'list_verification_requirements_tool',
+    'delete_verification_requirement_tool'
 ]

--- a/backend/mcp_tools/verification_requirement_tools.py
+++ b/backend/mcp_tools/verification_requirement_tools.py
@@ -1,0 +1,118 @@
+"""MCP tools for agent verification requirements."""
+
+import logging
+from typing import Optional
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from backend.models.agent_verification_requirement import AgentVerificationRequirement
+from backend.services.audit_log_service import AuditLogService
+
+logger = logging.getLogger(__name__)
+
+
+async def create_verification_requirement_tool(
+    agent_role_id: str,
+    requirement: str,
+    description: Optional[str],
+    is_mandatory: bool,
+    db: Session,
+) -> dict:
+    """MCP Tool: Create a verification requirement for an agent role."""
+    try:
+        req = AgentVerificationRequirement(
+            agent_role_id=agent_role_id,
+            requirement=requirement,
+            description=description,
+            is_mandatory=is_mandatory,
+        )
+        db.add(req)
+        db.commit()
+        db.refresh(req)
+        AuditLogService(db).log_action(
+            action="verification_requirement_created",
+            entity_type="agent_verification_requirement",
+            entity_id=req.id,
+            changes={
+                "requirement": requirement,
+                "description": description,
+                "is_mandatory": is_mandatory,
+            },
+        )
+        return {
+            "success": True,
+            "verification_requirement": {
+                "id": req.id,
+                "agent_role_id": req.agent_role_id,
+                "requirement": req.requirement,
+                "description": req.description,
+                "is_mandatory": req.is_mandatory,
+                "created_at": req.created_at.isoformat(),
+            },
+        }
+    except Exception as exc:
+        logger.error(f"MCP create verification requirement failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+async def list_verification_requirements_tool(
+    agent_role_id: Optional[str],
+    db: Session,
+    skip: int = 0,
+    limit: int = 100,
+) -> dict:
+    """MCP Tool: List verification requirements for agent roles."""
+    try:
+        query = db.query(AgentVerificationRequirement)
+        if agent_role_id:
+            query = query.filter(
+                AgentVerificationRequirement.agent_role_id == agent_role_id
+            )
+        items = query.offset(skip).limit(limit).all()
+        return {
+            "success": True,
+            "verification_requirements": [
+                {
+                    "id": r.id,
+                    "agent_role_id": r.agent_role_id,
+                    "requirement": r.requirement,
+                    "description": r.description,
+                    "is_mandatory": r.is_mandatory,
+                    "created_at": r.created_at.isoformat(),
+                }
+                for r in items
+            ],
+        }
+    except Exception as exc:
+        logger.error(f"MCP list verification requirements failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+async def delete_verification_requirement_tool(
+    requirement_id: str,
+    db: Session,
+) -> dict:
+    """MCP Tool: Delete a verification requirement."""
+    try:
+        obj = (
+            db.query(AgentVerificationRequirement)
+            .filter(AgentVerificationRequirement.id == requirement_id)
+            .first()
+        )
+        if not obj:
+            raise HTTPException(status_code=404, detail="Requirement not found")
+        db.delete(obj)
+        db.commit()
+        AuditLogService(db).log_action(
+            action="verification_requirement_deleted",
+            entity_type="agent_verification_requirement",
+            entity_id=requirement_id,
+            changes={},
+        )
+        return {"success": True}
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"MCP delete verification requirement failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/backend/routers/mcp/core.py
+++ b/backend/routers/mcp/core.py
@@ -997,3 +997,77 @@ async def mcp_list_forbidden_actions(
     except Exception as e:
         logger.error(f"MCP list forbidden actions failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/mcp-tools/verification-requirement/create",
+    tags=["mcp-tools"],
+    operation_id="create_verification_requirement_tool",
+)
+async def mcp_create_verification_requirement(
+    agent_role_id: str,
+    requirement: str,
+    description: Optional[str] = None,
+    is_mandatory: bool = True,
+    db: Session = Depends(get_db_session),
+):
+    """MCP Tool: Create a verification requirement for an agent role."""
+    try:
+        from ...mcp_tools.verification_requirement_tools import (
+            create_verification_requirement_tool,
+        )
+
+        return await create_verification_requirement_tool(
+            agent_role_id=agent_role_id,
+            requirement=requirement,
+            description=description,
+            is_mandatory=is_mandatory,
+            db=db,
+        )
+    except Exception as e:
+        logger.error(f"MCP create verification requirement failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get(
+    "/mcp-tools/verification-requirement/list",
+    tags=["mcp-tools"],
+    operation_id="list_verification_requirements_tool",
+)
+async def mcp_list_verification_requirements(
+    agent_role_id: Optional[str] = Query(None),
+    db: Session = Depends(get_db_session),
+):
+    """MCP Tool: List verification requirements."""
+    try:
+        from ...mcp_tools.verification_requirement_tools import (
+            list_verification_requirements_tool,
+        )
+
+        return await list_verification_requirements_tool(agent_role_id, db)
+    except Exception as e:
+        logger.error(f"MCP list verification requirements failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.delete(
+    "/mcp-tools/verification-requirement/delete",
+    tags=["mcp-tools"],
+    operation_id="delete_verification_requirement_tool",
+)
+async def mcp_delete_verification_requirement(
+    requirement_id: str,
+    db: Session = Depends(get_db_session),
+):
+    """MCP Tool: Delete a verification requirement."""
+    try:
+        from ...mcp_tools.verification_requirement_tools import (
+            delete_verification_requirement_tool,
+        )
+
+        return await delete_verification_requirement_tool(requirement_id, db)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"MCP delete verification requirement failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
## Summary
- add verification requirement tools for MCP
- expose FastAPI routes for new tools
- document tools in SYSTEM_GUIDE

## Testing
- `pytest -q tests/test_simple.py`

------
https://chatgpt.com/codex/tasks/task_e_684180ab79f4832ca18fbbf4d815367c