### PR TITLE
Add error protocol tools to MCP

### DIFF
--- a/backend/docs/fastapi_mcp/README.md
+++ b/backend/docs/fastapi_mcp/README.md
@@ -102,6 +102,13 @@ FastAPI-MCP automatically exposes selected API endpoints as tools under the `/mc
 - `/mcp-tools/error-protocol/list` (GET)
 - `/mcp-tools/error-protocol/remove` (DELETE)
 
+### Error Protocol Tools
+
+Use these routes to manage custom strategies for handling agent errors. Create a
+protocol with `/mcp-tools/error-protocol/add`, list protocols via
+`/mcp-tools/error-protocol/list`, and remove a protocol using
+`/mcp-tools/error-protocol/remove`.
+
 ### Agent Handoff Tools
 
 Use these routes to manage when one agent role should hand off control to


### PR DESCRIPTION
## Summary
- expose error protocol tools via MCP router
- document error protocol endpoints in FastAPI-MCP guide

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684180a9c3e4832c9fec7f9a469907d7