### PR TITLE
Add ErrorProtocolManager component

### DIFF
--- a/frontend/src/components/agents/ErrorProtocolManager.tsx
+++ b/frontend/src/components/agents/ErrorProtocolManager.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Flex,
+  FormControl,
+  FormLabel,
+  Input,
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+  Spinner,
+  Text,
+  useToast,
+} from "@chakra-ui/react";
+import { errorProtocolsApi } from "@/services/api";
+import type { ErrorProtocol } from "@/types/agents";
+
+interface ErrorProtocolManagerProps {
+  agentRoleId: string;
+}
+
+const ErrorProtocolManager: React.FC<ErrorProtocolManagerProps> = ({ agentRoleId }) => {
+  const toast = useToast();
+  const [protocols, setProtocols] = useState<ErrorProtocol[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [errorType, setErrorType] = useState("");
+  const [protocol, setProtocol] = useState("");
+  const [editing, setEditing] = useState<ErrorProtocol | null>(null);
+
+  const loadProtocols = async () => {
+    try {
+      const data = await errorProtocolsApi.list(agentRoleId);
+      setProtocols(data);
+    } catch (err) {
+      toast({
+        title: "Failed to load protocols",
+        description: err instanceof Error ? err.message : String(err),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  useEffect(() => {
+    loadProtocols();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agentRoleId]);
+
+  const handleCreate = async () => {
+    if (!errorType.trim() || !protocol.trim()) return;
+    setLoading(true);
+    try {
+      await errorProtocolsApi.create({
+        agent_role_id: agentRoleId,
+        error_type: errorType,
+        protocol,
+      });
+      setErrorType("");
+      setProtocol("");
+      await loadProtocols();
+      toast({ title: "Protocol added", status: "success", duration: 3000, isClosable: true });
+    } catch (err) {
+      toast({
+        title: "Failed to add protocol",
+        description: err instanceof Error ? err.message : String(err),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleUpdate = async () => {
+    if (!editing) return;
+    setLoading(true);
+    try {
+      await errorProtocolsApi.update(editing.id, {
+        error_type: editing.error_type,
+        protocol: editing.protocol,
+      });
+      setEditing(null);
+      await loadProtocols();
+      toast({ title: "Protocol updated", status: "success", duration: 3000, isClosable: true });
+    } catch (err) {
+      toast({
+        title: "Failed to update protocol",
+        description: err instanceof Error ? err.message : String(err),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    setLoading(true);
+    try {
+      await errorProtocolsApi.delete(id);
+      await loadProtocols();
+      toast({ title: "Protocol deleted", status: "success", duration: 3000, isClosable: true });
+    } catch (err) {
+      toast({
+        title: "Failed to delete protocol",
+        description: err instanceof Error ? err.message : String(err),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!protocols) {
+    return (
+      <Flex justify="center" align="center" p={4} minH="100px">
+        <Spinner />
+      </Flex>
+    );
+  }
+
+  const isSubmitDisabled = editing
+    ? !editing.error_type.trim() || !editing.protocol.trim()
+    : !errorType.trim() || !protocol.trim();
+
+  return (
+    <Box>
+      <Flex
+        mb={2}
+        gap={2}
+        as="form"
+        onSubmit={(e) => {
+          e.preventDefault();
+          editing ? handleUpdate() : handleCreate();
+        }}
+      >
+        <FormControl>
+          <FormLabel>Error Type</FormLabel>
+          <Input
+            placeholder="e.g. PlanError"
+            value={editing ? editing.error_type : errorType}
+            onChange={(e) =>
+              editing
+                ? setEditing({ ...editing, error_type: e.target.value })
+                : setErrorType(e.target.value)
+            }
+          />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Protocol</FormLabel>
+          <Input
+            placeholder="Resolution steps"
+            value={editing ? editing.protocol : protocol}
+            onChange={(e) =>
+              editing
+                ? setEditing({ ...editing, protocol: e.target.value })
+                : setProtocol(e.target.value)
+            }
+          />
+        </FormControl>
+        <Button type="submit" isLoading={loading} isDisabled={isSubmitDisabled}>
+          {editing ? "Save" : "Add"}
+        </Button>
+        {editing && (
+          <Button onClick={() => setEditing(null)} isDisabled={loading}>
+            Cancel
+          </Button>
+        )}
+      </Flex>
+      {protocols.length === 0 ? (
+        <Text>No error protocols.</Text>
+      ) : (
+        <Table size="sm">
+          <Thead>
+            <Tr>
+              <Th>Error Type</Th>
+              <Th>Protocol</Th>
+              <Th></Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {protocols.map((p) => (
+              <Tr key={p.id}>
+                <Td>{p.error_type}</Td>
+                <Td>{p.protocol}</Td>
+                <Td>
+                  <Button size="sm" mr={2} onClick={() => setEditing(p)}>
+                    Edit
+                  </Button>
+                  <Button size="sm" colorScheme="red" onClick={() => handleDelete(p.id)}>
+                    Delete
+                  </Button>
+                </Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      )}
+    </Box>
+  );
+};
+
+export default ErrorProtocolManager;

--- a/frontend/src/components/agents/__tests__/ErrorProtocolManager.test.tsx
+++ b/frontend/src/components/agents/__tests__/ErrorProtocolManager.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor } from '@/__tests__/utils/test-utils';
+import ErrorProtocolManager from '../ErrorProtocolManager';
+import { errorProtocolsApi } from '@/services/api/error_protocols';
+
+vi.mock('@/services/api/error_protocols');
+
+const mockApi = vi.mocked(errorProtocolsApi);
+
+describe('ErrorProtocolManager', () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApi.list.mockResolvedValue([
+      {
+        id: '1',
+        agent_role_id: 'role1',
+        error_type: 'TypeA',
+        protocol: 'Do something',
+        created_at: '2024-01-01T00:00:00Z',
+        is_active: true,
+      },
+    ]);
+  });
+
+  it('loads and displays protocols', async () => {
+    render(
+      <ErrorProtocolManager agentRoleId="role1" />,
+      { wrapper: ({ children }) => <div>{children}</div> }
+    );
+
+    await waitFor(() => expect(mockApi.list).toHaveBeenCalled());
+    expect(screen.getByText('TypeA')).toBeInTheDocument();
+  });
+
+  it('submits new protocol and updates table', async () => {
+    mockApi.create.mockResolvedValue({
+      id: '2',
+      agent_role_id: 'role1',
+      error_type: 'TypeB',
+      protocol: 'Fix it',
+      created_at: '2024-01-02T00:00:00Z',
+      is_active: true,
+    });
+
+    mockApi.list.mockResolvedValueOnce([]); // initial load
+    mockApi.list.mockResolvedValueOnce([
+      {
+        id: '1',
+        agent_role_id: 'role1',
+        error_type: 'TypeA',
+        protocol: 'Do something',
+        created_at: '2024-01-01T00:00:00Z',
+        is_active: true,
+      },
+      {
+        id: '2',
+        agent_role_id: 'role1',
+        error_type: 'TypeB',
+        protocol: 'Fix it',
+        created_at: '2024-01-02T00:00:00Z',
+        is_active: true,
+      },
+    ]);
+
+    render(
+      <ErrorProtocolManager agentRoleId="role1" />,
+      { wrapper: ({ children }) => <div>{children}</div> }
+    );
+
+    const userInputType = screen.getByLabelText('Error Type');
+    const userInputProtocol = screen.getByLabelText('Protocol');
+    const addButton = screen.getByRole('button', { name: /add/i });
+
+    await user.type(userInputType, 'TypeB');
+    await user.type(userInputProtocol, 'Fix it');
+    await user.click(addButton);
+
+    await waitFor(() => expect(mockApi.create).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByText('TypeB')).toBeInTheDocument());
+  });
+});


### PR DESCRIPTION
## Summary
- add ErrorProtocolManager component for managing agent error protocols
- add tests for form and table logic

## Testing
- `npm --prefix frontend run lint`
- `npx -y vitest -c frontend/vitest.config.ts run frontend/src/components/agents/__tests__/ErrorProtocolManager.test.tsx` *(fails: MISSING DEPENDENCY jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_684180a724b8832ca77abcf4c2ba2d97