### PR TITLE
Add observation update and delete support

### DIFF
--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -279,6 +279,38 @@ class MemoryService:
             )
         return query.offset(skip).limit(limit).all()
 
+    def update_observation(
+        self, observation_id: int, observation_update: MemoryObservationCreate
+    ) -> Optional[models.MemoryObservation]:
+        db_observation = (
+            self.db.query(models.MemoryObservation)
+            .filter(models.MemoryObservation.id == observation_id)
+            .first()
+        )
+        if not db_observation:
+            return None
+
+        update_data = observation_update.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(db_observation, field, value)
+
+        self.db.commit()
+        self.db.refresh(db_observation)
+        logger.info(f"Updated memory observation: {observation_id}")
+        return db_observation
+
+    def delete_observation(self, observation_id: int) -> Optional[models.MemoryObservation]:
+        db_observation = (
+            self.db.query(models.MemoryObservation)
+            .filter(models.MemoryObservation.id == observation_id)
+            .first()
+        )
+        if db_observation:
+            self.db.delete(db_observation)
+            self.db.commit()
+            logger.info(f"Deleted memory observation: {observation_id}")
+        return db_observation
+
     def create_memory_relation(
         self, relation: MemoryRelationCreate
     ) -> models.MemoryRelation:

--- a/backend/tests/test_memory_observations.py
+++ b/backend/tests/test_memory_observations.py
@@ -1,0 +1,78 @@
+import types
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient, ASGITransport
+
+from backend.routers.memory.observations.observations import (
+    router,
+    get_memory_service,
+)
+from backend.schemas.memory import MemoryObservationCreate
+
+
+class DummyService:
+    def __init__(self):
+        self.observations = {}
+        self.next_id = 1
+
+    def add_observation_to_entity(self, entity_id: int, observation: MemoryObservationCreate):
+        obs = types.SimpleNamespace(
+            id=self.next_id,
+            entity_id=entity_id,
+            content=observation.content,
+            metadata_=observation.metadata_,
+            source=None,
+            timestamp=datetime.now(timezone.utc),
+            created_at=datetime.now(timezone.utc),
+        )
+        self.observations[self.next_id] = obs
+        self.next_id += 1
+        return obs
+
+    def get_observations(self, entity_id=None, search_query=None, skip=0, limit=100):
+        obs = list(self.observations.values())
+        if entity_id is not None:
+            obs = [o for o in obs if o.entity_id == entity_id]
+        return obs[skip : skip + limit]
+
+    def update_observation(self, observation_id: int, observation: MemoryObservationCreate):
+        obs = self.observations.get(observation_id)
+        if not obs:
+            return None
+        obs.entity_id = observation.entity_id
+        obs.content = observation.content
+        obs.metadata_ = observation.metadata_
+        return obs
+
+    def delete_observation(self, observation_id: int):
+        return self.observations.pop(observation_id, None)
+
+
+dummy_service = DummyService()
+
+app = FastAPI()
+app.include_router(router)
+app.dependency_overrides[get_memory_service] = lambda: dummy_service
+
+
+@pytest.mark.asyncio
+async def test_update_and_delete_observation():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/entities/1/observations/",
+            json={"entity_id": 1, "content": "hello"},
+        )
+        assert resp.status_code == 200
+        obs_id = resp.json()["id"]
+
+        resp = await client.put(
+            f"/observations/{obs_id}",
+            json={"entity_id": 1, "content": "updated"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["content"] == "updated"
+
+        resp = await client.delete(f"/observations/{obs_id}")
+        assert resp.status_code == 204


### PR DESCRIPTION
## Summary
- implement update_observation and delete_observation methods
- expose PUT and DELETE endpoints for observations
- add tests for observation update and delete logic

## Testing
- `pytest backend/tests/test_memory_observations.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6841809e2074832c980a44157f435e16