### PR TITLE
Add project template routes docs

### DIFF
--- a/backend/docs/fastapi_mcp/README.md
+++ b/backend/docs/fastapi_mcp/README.md
@@ -101,6 +101,9 @@ FastAPI-MCP automatically exposes selected API endpoints as tools under the `/mc
 - `/mcp-tools/error-protocol/add` (POST)
 - `/mcp-tools/error-protocol/list` (GET)
 - `/mcp-tools/error-protocol/remove` (DELETE)
+- `/mcp-tools/template/create` (POST)
+- `/mcp-tools/template/list` (GET)
+- `/mcp-tools/template/delete` (POST)
 
 ### Agent Handoff Tools
 


### PR DESCRIPTION
## Summary
- document project template MCP endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `flake8 backend/mcp_tools/project_template_tools.py backend/routers/mcp/core.py`


------
https://chatgpt.com/codex/tasks/task_e_6841809ffe20832c990ac3b4ae292f66