### PR TITLE
Add API error handler utilities

### DIFF
--- a/frontend/src/hooks/useProjectData.ts
+++ b/frontend/src/hooks/useProjectData.ts
@@ -1,5 +1,10 @@
 import { useState, useEffect, useCallback } from "react";
-import { getProjectById, updateProject, getAllTasksForProject } from "@/services/api";
+import {
+  getProjectById,
+  updateProject,
+  getAllTasksForProject,
+} from "@/services/api";
+import { handleApiError } from "@/lib/apiErrorHandler";
 import { Project, ProjectUpdateData, Task } from "@/types";
 
 export interface UseProjectDataResult {
@@ -35,6 +40,7 @@ export const useProjectData = (projectId: string): UseProjectDataResult => {
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to load project";
       setError(message);
+      handleApiError(err, "Failed to load project");
     } finally {
       setLoading(false);
     }
@@ -55,6 +61,7 @@ export const useProjectData = (projectId: string): UseProjectDataResult => {
       } catch (err) {
         const message = err instanceof Error ? err.message : "Failed to update project";
         setError(message);
+        handleApiError(err, "Failed to update project");
         throw err;
       } finally {
         setLoading(false);

--- a/frontend/src/lib/__tests__/apiErrorHandler.test.ts
+++ b/frontend/src/lib/__tests__/apiErrorHandler.test.ts
@@ -21,7 +21,7 @@ describe('handleApiError', () => {
   });
 
   it('handles ApiError instances', () => {
-    handleApiError(new ApiError('Boom', 500), 'Oops');
+    const msg = handleApiError(new ApiError('Boom', 500), 'Oops');
     expect(mockToast).toHaveBeenCalledWith(
       expect.objectContaining({
         title: 'Oops',
@@ -29,19 +29,30 @@ describe('handleApiError', () => {
         status: 'error',
       })
     );
+    expect(msg).toBe('Boom');
   });
 
   it('handles Error objects', () => {
-    handleApiError(new Error('Fail'));
+    const msg = handleApiError(new Error('Fail'));
     expect(mockToast).toHaveBeenCalledWith(
       expect.objectContaining({ description: 'Fail' })
     );
+    expect(msg).toBe('Fail');
   });
 
   it('handles string messages', () => {
-    handleApiError('Nope');
+    const msg = handleApiError('Nope');
     expect(mockToast).toHaveBeenCalledWith(
       expect.objectContaining({ description: 'Nope' })
     );
+    expect(msg).toBe('Nope');
+  });
+
+  it('returns default message for unknown error', () => {
+    const msg = handleApiError(123 as any, 'Bad');
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ description: 'An unexpected error occurred.' })
+    );
+    expect(msg).toBe('An unexpected error occurred.');
   });
 });

--- a/frontend/src/lib/apiErrorHandler.ts
+++ b/frontend/src/lib/apiErrorHandler.ts
@@ -7,7 +7,7 @@ export function handleApiError(
   error: unknown,
   title = 'API Error',
   options?: Partial<UseToastOptions>
-): void {
+): string {
   let description = 'An unexpected error occurred.';
   if (error instanceof ApiError) {
     description = error.message;
@@ -25,4 +25,5 @@ export function handleApiError(
     isClosable: true,
     ...options,
   });
+  return description;
 }

--- a/frontend/src/store/memoryStore.ts
+++ b/frontend/src/store/memoryStore.ts
@@ -1,5 +1,10 @@
 import { StoreApi } from 'zustand';
-import { createBaseStore, BaseState, handleApiError } from './baseStore';
+import {
+  createBaseStore,
+  BaseState,
+  extractErrorMessage,
+} from './baseStore';
+import { handleApiError } from '@/lib/apiErrorHandler';
 import { memoryApi } from '@/services/api';
 import type { MemoryEntity, MemoryEntityFilters } from '@/types/memory';
 
@@ -37,7 +42,9 @@ const actionsCreator = (
       });
       set({ entities: resp.data, loading: false });
     } catch (err) {
-      set({ error: handleApiError(err), loading: false });
+      const msg = extractErrorMessage(err);
+      set({ error: msg, loading: false });
+      handleApiError(err);
     }
   },
   ingestFile: async (filePath: string) => {
@@ -49,7 +56,9 @@ const actionsCreator = (
         ingestionLoading: false,
       }));
     } catch (err) {
-      set({ ingestionError: handleApiError(err), ingestionLoading: false });
+      const msg = extractErrorMessage(err);
+      set({ ingestionError: msg, ingestionLoading: false });
+      handleApiError(err);
       throw err;
     }
   },
@@ -62,7 +71,9 @@ const actionsCreator = (
         ingestionLoading: false,
       }));
     } catch (err) {
-      set({ ingestionError: handleApiError(err), ingestionLoading: false });
+      const msg = extractErrorMessage(err);
+      set({ ingestionError: msg, ingestionLoading: false });
+      handleApiError(err);
       throw err;
     }
   },
@@ -75,7 +86,9 @@ const actionsCreator = (
         ingestionLoading: false,
       }));
     } catch (err) {
-      set({ ingestionError: handleApiError(err), ingestionLoading: false });
+      const msg = extractErrorMessage(err);
+      set({ ingestionError: msg, ingestionLoading: false });
+      handleApiError(err);
       throw err;
     }
   },
@@ -88,7 +101,9 @@ const actionsCreator = (
         loading: false,
       }));
     } catch (err) {
-      set({ error: handleApiError(err), loading: false });
+      const msg = extractErrorMessage(err);
+      set({ error: msg, loading: false });
+      handleApiError(err);
       throw err;
     }
   },


### PR DESCRIPTION
## Summary
- return error message from `handleApiError`
- update memory store to show toast and store message
- use error handler in `useProjectData`
- test `handleApiError` return value

## Testing
- `npm run lint`
- `npm test` *(fails: TypeError and merge conflict error)*

------
https://chatgpt.com/codex/tasks/task_e_6841adf09d08832c8bc51139a9a7ca6d