### PR TITLE
Add TypeScript check to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,12 @@ repos:
         language: system
         pass_filenames: false
 
+      - id: npm-type-check
+        name: Type-check frontend with TypeScript
+        entry: npm run type-check --prefix frontend
+        language: system
+        pass_filenames: false
+
       - id: frontend-format
         name: Format frontend with Prettier
         entry: npm run format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,8 @@ This project uses [pre-commit](https://pre-commit.com/) to automatically check c
 pip install pre-commit
 pre-commit install
 ```
+Pre-commit will automatically run `flake8` on backend files and
+`npm run type-check` in the frontend each time you commit.
 
 ### What gets checked:
 


### PR DESCRIPTION
## Summary
- run `npm run type-check` via pre-commit
- mention type checks in the contributing guide

## Testing
- `pre-commit run --files .pre-commit-config.yaml CONTRIBUTING.md` *(fails: merge conflict markers in frontend src/types/index.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6841adef5b30832cbf263f71d0916181