### PR TITLE
Implement Node version check

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,9 +2,20 @@
 
 const [major] = process.versions.node.split('.').map(Number);
 if (major < 18) {
-  console.error(`Node.js 18 or higher is required. Current version: ${process.version}`);
+  console.error(
+    `Node.js 18 or higher is required. Current version: ${process.version}`
+  );
   process.exit(1);
 }
 
-require('./dev_launcher.js');
+if (process.argv.includes('--help') || process.argv.includes('-h')) {
+  console.log(`Usage: mcp-project-manager [options]
 
+Starts the development environment.
+
+Options:
+  --help, -h   Show this help message`);
+  process.exit(0);
+}
+
+require('./dev_launcher.js');

--- a/tests/cli/node-version.test.js
+++ b/tests/cli/node-version.test.js
@@ -1,0 +1,15 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const cliPath = path.resolve('cli.js');
+
+test('cli exits with error when Node version is below 18', () => {
+  const script = `Object.defineProperty(process.versions,'node',{value:'16.0.0'});require('${cliPath.replace(/\\/g, '\\\\')}');`;
+  const result = spawnSync(process.execPath, ['-e', script], {
+    encoding: 'utf8',
+  });
+  assert.strictEqual(result.status, 1, 'expected exit code 1');
+  assert.match(result.stderr, /Node\.js 18 or higher is required/);
+});


### PR DESCRIPTION
## Summary
- enforce Node 18+ in `cli.js`
- show a small help message when `--help` is passed
- add `node-version.test.js` to verify version enforcement

## Testing
- `node --test tests/cli/*.test.js`
- `python3 -m venv backend/.venv && source backend/.venv/bin/activate && pip install -r backend/requirements.txt && ../backend/.venv/bin/pytest tests/test_simple.py -v`

------
https://chatgpt.com/codex/tasks/task_e_6841ade9b484832ca2d2733713690649