### PR TITLE
Add partial validation flags

### DIFF
--- a/DEV_SCRIPTS.md
+++ b/DEV_SCRIPTS.md
@@ -42,3 +42,12 @@ frontend or manage the full stack.
 
 These scripts simplify local development by automating common setup and startup
 steps. See `DEV_LAUNCHER_GUIDE.md` for more launcher details.
+
+## `validate_alignment.py`
+- **Purpose:** Check that backend endpoints and MCP tools are reachable.
+- **What it does:** Launches the backend (if needed) and sends test requests to various API routes. Flags allow running specific suites.
+- **Usage:**
+  ```bash
+  python validate_alignment.py --projects --tasks
+  ```
+  Run without flags to execute the full validation suite.

--- a/validate_alignment.py
+++ b/validate_alignment.py
@@ -9,8 +9,9 @@ import asyncio
 import aiohttp
 import sys
 import subprocess
-from typing import List, Tuple
+from typing import List, Tuple, Callable
 import time
+import argparse
 
 
 class FeatureAlignmentValidator:
@@ -338,6 +339,15 @@ class FeatureAlignmentValidator:
                         session, "GET", "/api/memory/search?q=test", "Search memory"
                     )
                 )
+                results.append(
+                    await self._test_endpoint(
+                        session,
+                        "POST",
+                        "/api/memory/ingest-text",
+                        "Ingest memory text",
+                        {"text": "sample"},
+                    )
+                )
 
         except Exception as e:
             results.append(("Memory features validation", False, f"Error: {e}"))
@@ -365,6 +375,62 @@ class FeatureAlignmentValidator:
         except Exception as e:
             results.append(("Rules features validation", False, f"Error: {e}"))
 
+        return results
+
+    async def validate_template_features(self) -> List[Tuple[str, bool, str]]:
+        """Validate project template endpoints."""
+        results = []
+        try:
+            async with aiohttp.ClientSession() as session:
+                results.append(
+                    await self._test_endpoint(
+                        session,
+                        "GET",
+                        "/api/templates",
+                        "List project templates",
+                    )
+                )
+        except Exception as e:
+            results.append(("Template features validation", False, f"Error: {e}"))
+        return results
+
+    async def validate_user_features(self) -> List[Tuple[str, bool, str]]:
+        """Validate user management endpoints."""
+        results = []
+        try:
+            async with aiohttp.ClientSession() as session:
+                results.append(
+                    await self._test_endpoint(
+                        session, "GET", "/api/v1/users/", "List users"
+                    )
+                )
+        except Exception as e:
+            results.append(("User features validation", False, f"Error: {e}"))
+        return results
+
+    async def validate_mcp_tools(self) -> List[Tuple[str, bool, str]]:
+        """Validate MCP tool endpoints."""
+        results = []
+        try:
+            async with aiohttp.ClientSession() as session:
+                results.append(
+                    await self._test_endpoint(
+                        session,
+                        "GET",
+                        "/api/mcp/mcp-tools/list",
+                        "List MCP tools",
+                    )
+                )
+                results.append(
+                    await self._test_endpoint(
+                        session,
+                        "GET",
+                        "/api/mcp/mcp-tools/projects/list",
+                        "List projects via tool",
+                    )
+                )
+        except Exception as e:
+            results.append(("MCP tools validation", False, f"Error: {e}"))
         return results
 
     async def _test_endpoint(
@@ -408,8 +474,11 @@ class FeatureAlignmentValidator:
         except Exception as e:
             return (description, False, f"❌ {method} {path} - Error: {str(e)}")
 
-    async def run_full_validation(self) -> bool:
-        """Run complete frontend-backend feature alignment validation."""
+    async def run_validation(
+        self,
+        suites: List[Tuple[str, Callable[[], asyncio.Future]]],
+    ) -> bool:
+        """Run the provided validation suites."""
         print("🔍 Frontend-Backend Feature Alignment Validation")
         print("=" * 60)
 
@@ -436,14 +505,7 @@ class FeatureAlignmentValidator:
             await self._stop_backend()
             return False
 
-        # Run all validations
-        validation_suites = [
-            ("Project Features", self.validate_project_features),
-            ("Task Features", self.validate_task_features),
-            ("Agent Features", self.validate_agent_features),
-            ("Memory Features", self.validate_memory_features),
-            ("Rules Features", self.validate_rules_features),
-        ]
+        validation_suites = suites
 
         all_results = []
         total_passed = 0
@@ -486,11 +548,59 @@ class FeatureAlignmentValidator:
         await self._stop_backend()
         return result
 
+    async def run_full_validation(self) -> bool:
+        """Run all available validation suites."""
+        suites = [
+            ("Project Features", self.validate_project_features),
+            ("Task Features", self.validate_task_features),
+            ("Agent Features", self.validate_agent_features),
+            ("Memory Features", self.validate_memory_features),
+            ("Rules Features", self.validate_rules_features),
+            ("Template Features", self.validate_template_features),
+            ("User Features", self.validate_user_features),
+            ("MCP Tools", self.validate_mcp_tools),
+        ]
+        return await self.run_validation(suites)
+
 
 async def main():
     """Main validation function."""
-    validator = FeatureAlignmentValidator()
-    success = await validator.run_full_validation()
+    parser = argparse.ArgumentParser(description="Validate backend alignment")
+    parser.add_argument("--projects", action="store_true", help="Validate project endpoints")
+    parser.add_argument("--tasks", action="store_true", help="Validate task endpoints")
+    parser.add_argument("--agents", action="store_true", help="Validate agent endpoints")
+    parser.add_argument("--memory", action="store_true", help="Validate memory endpoints")
+    parser.add_argument("--rules", action="store_true", help="Validate rules endpoints")
+    parser.add_argument("--templates", action="store_true", help="Validate template endpoints")
+    parser.add_argument("--users", action="store_true", help="Validate user endpoints")
+    parser.add_argument("--mcp-tools", action="store_true", help="Validate MCP tools")
+    parser.add_argument("--backend-url", default="http://localhost:8000", help="Backend base URL")
+    args = parser.parse_args()
+
+    validator = FeatureAlignmentValidator(backend_url=args.backend_url)
+
+    suites = []
+    if args.projects:
+        suites.append(("Project Features", validator.validate_project_features))
+    if args.tasks:
+        suites.append(("Task Features", validator.validate_task_features))
+    if args.agents:
+        suites.append(("Agent Features", validator.validate_agent_features))
+    if args.memory:
+        suites.append(("Memory Features", validator.validate_memory_features))
+    if args.rules:
+        suites.append(("Rules Features", validator.validate_rules_features))
+    if args.templates:
+        suites.append(("Template Features", validator.validate_template_features))
+    if args.users:
+        suites.append(("User Features", validator.validate_user_features))
+    if args.mcp_tools:
+        suites.append(("MCP Tools", validator.validate_mcp_tools))
+
+    if not suites:
+        success = await validator.run_full_validation()
+    else:
+        success = await validator.run_validation(suites)
 
     if not success:
         sys.exit(1)


### PR DESCRIPTION
## Summary
- expand alignment validator to check more endpoints and MCP tools
- add CLI flags for selective validation
- document validator usage in `DEV_SCRIPTS.md`

## Testing
- `flake8 validate_alignment.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm --prefix frontend run lint`
- `npm --prefix frontend run test:run` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6841ade8431c832cb6335a32fc0ac31b