### PR TITLE
Add skip/limit pagination support

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -152,6 +152,7 @@ cd backend
 - ✅ **Extended Task API**: Endpoints for task dependencies, file associations, archiving, and unarchiving.
 - ✅ **Database Migrations**: Alembic support updated for Memory Service models.
 - ✅ **Task Listing**: Global task listing available at `/api/v1/tasks` with optional `project_id` and pagination. Project-specific listing at `/api/v1/projects/{project_id}/tasks`.
+- ✅ **Pagination Parameters**: All list endpoints accept `skip` and `limit` query parameters.
 - ✅ **Task Comments**: API for listing and adding comments to tasks is fully functional.
 - ✅ **Project Members**: API for managing project members (add, remove, list) is fully functional.
 - ✅ **Agent Handoff Criteria**: Endpoints under `/api/v1/rules/roles/handoff-criteria` allow creation, listing, and deletion of handoff criteria for agent roles.

--- a/backend/tests/test_project_task_endpoints.py
+++ b/backend/tests/test_project_task_endpoints.py
@@ -74,3 +74,32 @@ async def test_create_task_requires_project(authenticated_client):
         json={"title": "No Project"},
     )
     assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_projects_pagination(authenticated_client):
+    # create additional projects
+    for i in range(2):
+        await authenticated_client.post(
+            "/api/v1/projects/",
+            json={"name": f"P{i}"}
+        )
+
+    resp = await authenticated_client.get("/api/v1/projects/?skip=1&limit=1")
+    assert resp.status_code == 200
+    assert len(resp.json()["data"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_tasks_pagination(authenticated_client, test_project):
+    for i in range(3):
+        await authenticated_client.post(
+            "/api/v1/tasks/",
+            json={"title": f"t{i}", "project_id": str(test_project.id)}
+        )
+
+    resp = await authenticated_client.get(
+        f"/api/v1/tasks/?project_id={test_project.id}&skip=1&limit=1"
+    )
+    assert resp.status_code == 200
+    assert len(resp.json()["data"]) == 1

--- a/frontend/src/services/api/memory.ts
+++ b/frontend/src/services/api/memory.ts
@@ -128,9 +128,17 @@ export const memoryApi = {
   },
 
   // Get observations for an entity
-  getObservations: async (entityId: number): Promise<MemoryObservation[]> => {
+  getObservations: async (
+    entityId: number,
+    skip = 0,
+    limit = 100
+  ): Promise<MemoryObservation[]> => {
+    const params = new URLSearchParams({ skip: String(skip), limit: String(limit) });
     const response = await request<{ data: MemoryObservation[] }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/entities/${entityId}/observations`)
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.MEMORY,
+        `/entities/${entityId}/observations?${params.toString()}`
+      )
     );
     return response.data;
   },
@@ -158,7 +166,9 @@ export const memoryApi = {
   },
 
   // Get relations with filters
-  getRelations: async (filters?: MemoryRelationFilters): Promise<MemoryRelation[]> => {
+  getRelations: async (
+    filters?: MemoryRelationFilters & { skip?: number; limit?: number }
+  ): Promise<MemoryRelation[]> => {
     const params = new URLSearchParams();
     if (filters) {
       Object.entries(filters).forEach(([key, value]) => {


### PR DESCRIPTION
## Summary
- support `skip`/`limit` params in PaginationParams
- expose pagination from frontend memory API
- test pagination for projects, tasks and memory endpoints
- document skip/limit query options

## Testing
- `pytest tests/test_project_task_endpoints.py::test_projects_pagination tests/test_project_task_endpoints.py::test_tasks_pagination tests/test_memory_endpoints.py::test_list_entities_pagination -q`


------
https://chatgpt.com/codex/tasks/task_e_6841ade69c1c832ca8bfe643c3a2f023