### PR TITLE
Add project export endpoint

### DIFF
--- a/backend/routers/projects/core.py
+++ b/backend/routers/projects/core.py
@@ -358,3 +358,30 @@ async def unarchive_project(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Internal server error: {str(e)}",
         )
+
+
+@router.get(
+    "/{project_id}/export",
+    response_model=DataResponse[dict],
+    summary="Export Project",
+    operation_id="export_project",
+)
+async def export_project(
+    project_id: str,
+    project_service: ProjectService = Depends(get_project_service),
+):
+    """Export a project's details including tasks and members."""
+    try:
+        export_data = await project_service.export_project(project_id)
+        return DataResponse[dict](
+            data=export_data,
+            message="Project exported successfully",
+        )
+    except EntityNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except Exception as e:
+        logging.error(f"Unexpected error in GET /projects/{project_id}/export: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Internal server error: {str(e)}",
+        )

--- a/frontend/src/components/project/ProjectDetail.tsx
+++ b/frontend/src/components/project/ProjectDetail.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import { getProjectById, deleteProject, archiveProject, unarchiveProject } from '@/services/api/projects';
+import { getProjectById, deleteProject, archiveProject, unarchiveProject, exportProject } from '@/services/api/projects';
 import { Project } from '@/types/project';
 import { generateProjectManagerPlanningPrompt, PlanningRequestData, PlanningResponseData } from '@/services/api/planning';
 import ProjectMembers from './ProjectMembers';
@@ -25,6 +25,22 @@ const ProjectDetail: React.FC = () => {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [tasksLoading, setTasksLoading] = useState(true);
   const [tasksError, setTasksError] = useState<string | null>(null);
+  const handleExport = async () => {
+    if (!project) return;
+    try {
+      const data = await exportProject(project.id);
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `${project.name}.json`;
+      link.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      alert('Failed to export project');
+      console.error(err);
+    }
+  };
 
   const fetchProject = async () => {
     if (!projectId) return;
@@ -131,6 +147,7 @@ const ProjectDetail: React.FC = () => {
         <button onClick={handleDelete}>Delete Project</button>
         <button onClick={handleArchive}>Archive Project</button>
         <button onClick={handleUnarchive}>Unarchive Project</button>
+        <button onClick={handleExport}>Download JSON</button>
       </div>
 
       <ProjectMembers projectId={project.id} />

--- a/frontend/src/services/api/projects.ts
+++ b/frontend/src/services/api/projects.ts
@@ -5,6 +5,7 @@ import {
   ProjectFilters,
   ProjectMember,
   ProjectMemberCreateData,
+  Task,
 } from '@/types';
 import { request } from './request';
 import { buildApiUrl, API_CONFIG } from './config';
@@ -254,5 +255,13 @@ export const disassociateFileFromProject = async (
     {
       method: 'DELETE',
     }
+  );
+};
+
+export const exportProject = async (
+  projectId: string,
+): Promise<{ project: Project; tasks: Task[]; members: ProjectMember[] }> => {
+  return request<{ project: Project; tasks: Task[]; members: ProjectMember[] }>(
+    buildApiUrl(API_CONFIG.ENDPOINTS.PROJECTS, `/${projectId}/export`),
   );
 };


### PR DESCRIPTION
## Summary
- provide a project export helper in the backend service and router
- create API function `exportProject`
- add download button on project detail page

## Testing
- `npm run lint` *(fails: next not found)*
- `flake8`
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6841adde4d4c832c92ef3d9ede9ab917