### PR TITLE
Add workflow service and router

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -44,8 +44,17 @@ logger = logging.getLogger(__name__)
 
 def include_app_routers(app: FastAPI):
     from .routers import (
-        users, projects, tasks, comments, agents, memory,
-        mcp, rules, project_templates, audit_logs
+        users,
+        projects,
+        tasks,
+        comments,
+        agents,
+        memory,
+        mcp,
+        rules,
+        project_templates,
+        audit_logs,
+        workflows,
     )
     from .routers.admin import router as admin_router
     from .routers.users.auth.auth import router as auth_router
@@ -66,6 +75,7 @@ def include_app_routers(app: FastAPI):
         tags=["templates"],
     )
     app.include_router(audit_logs.router, prefix="/api/audit-logs", tags=["audit-logs"])
+    app.include_router(workflows.router, prefix="/api/workflows", tags=["workflows"])
 
 
 @asynccontextmanager

--- a/backend/routers/workflows/__init__.py
+++ b/backend/routers/workflows/__init__.py
@@ -1,0 +1,5 @@
+from fastapi import APIRouter
+from .core import router as core_router
+
+router = APIRouter()
+router.include_router(core_router)

--- a/backend/routers/workflows/core.py
+++ b/backend/routers/workflows/core.py
@@ -1,0 +1,96 @@
+from fastapi import APIRouter, Depends, HTTPException, status, Path, Query
+from sqlalchemy.orm import Session
+
+from ...database import get_sync_db as get_db
+from ...services.workflow_service import WorkflowService
+from ...schemas.workflow import Workflow, WorkflowCreate, WorkflowUpdate
+from ...schemas.api_responses import DataResponse, ListResponse
+from ...auth import get_current_active_user
+from ...models import User as UserModel
+
+router = APIRouter(
+    prefix="/workflows",
+    tags=["Workflows"],
+    dependencies=[Depends(get_current_active_user)],
+)
+
+
+def get_workflow_service(db: Session = Depends(get_db)) -> WorkflowService:
+    return WorkflowService(db)
+
+
+@router.post(
+    "/",
+    response_model=DataResponse[Workflow],
+    status_code=status.HTTP_201_CREATED,
+)
+def create_workflow(
+    workflow: WorkflowCreate,
+    workflow_service: WorkflowService = Depends(get_workflow_service),
+    current_user: UserModel = Depends(get_current_active_user),
+):
+    db_workflow = workflow_service.create_workflow(workflow)
+    return DataResponse[Workflow](
+        data=Workflow.model_validate(db_workflow),
+        message="Workflow created successfully",
+    )
+
+
+@router.get("/", response_model=ListResponse[Workflow])
+def list_workflows(
+    skip: int = Query(0),
+    limit: int = Query(100),
+    workflow_service: WorkflowService = Depends(get_workflow_service),
+):
+    workflows = workflow_service.get_workflows(skip=skip, limit=limit)
+    return ListResponse[Workflow](
+        data=[Workflow.model_validate(wf) for wf in workflows],
+        total=len(workflows),
+        page=skip // limit + 1 if limit else 1,
+        page_size=limit,
+        has_more=False,
+        message=f"Retrieved {len(workflows)} workflows",
+    )
+
+
+@router.get("/{workflow_id}", response_model=DataResponse[Workflow])
+def read_workflow(
+    workflow_id: str = Path(...),
+    workflow_service: WorkflowService = Depends(get_workflow_service),
+):
+    db_workflow = workflow_service.get_workflow(workflow_id)
+    if db_workflow is None:
+        raise HTTPException(status_code=404, detail="Workflow not found")
+    return DataResponse[Workflow](
+        data=Workflow.model_validate(db_workflow),
+        message="Workflow retrieved successfully",
+    )
+
+
+@router.put("/{workflow_id}", response_model=DataResponse[Workflow])
+def update_workflow(
+    workflow_id: str,
+    workflow_update: WorkflowUpdate,
+    workflow_service: WorkflowService = Depends(get_workflow_service),
+):
+    db_workflow = workflow_service.update_workflow(workflow_id, workflow_update)
+    if db_workflow is None:
+        raise HTTPException(status_code=404, detail="Workflow not found")
+    return DataResponse[Workflow](
+        data=Workflow.model_validate(db_workflow),
+        message="Workflow updated successfully",
+    )
+
+
+@router.delete("/{workflow_id}", response_model=DataResponse[dict])
+def delete_workflow(
+    workflow_id: str,
+    workflow_service: WorkflowService = Depends(get_workflow_service),
+):
+    success = workflow_service.delete_workflow(workflow_id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Workflow not found")
+    return DataResponse[dict](
+        data={"message": "Workflow deleted"},
+        message="Workflow deleted",
+    )

--- a/backend/services/workflow_service.py
+++ b/backend/services/workflow_service.py
@@ -1,0 +1,62 @@
+from sqlalchemy.orm import Session
+from typing import List, Optional
+
+from .. import models
+from ..schemas.workflow import WorkflowCreate, WorkflowUpdate
+
+
+class WorkflowService:
+    """Service layer for project workflows."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create_workflow(self, workflow: WorkflowCreate) -> models.Workflow:
+        db_workflow = models.Workflow(**workflow.model_dump())
+        self.db.add(db_workflow)
+        self.db.commit()
+        self.db.refresh(db_workflow)
+        return db_workflow
+
+    def get_workflow(self, workflow_id: str) -> Optional[models.Workflow]:
+        return (
+            self.db.query(models.Workflow)
+            .filter(models.Workflow.id == workflow_id)
+            .first()
+        )
+
+    def get_workflow_by_name(self, name: str) -> Optional[models.Workflow]:
+        return (
+            self.db.query(models.Workflow)
+            .filter(models.Workflow.name == name)
+            .first()
+        )
+
+    def get_workflows(self, skip: int = 0, limit: int = 100) -> List[models.Workflow]:
+        return (
+            self.db.query(models.Workflow)
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
+
+    def update_workflow(
+        self, workflow_id: str, workflow_update: WorkflowUpdate
+    ) -> Optional[models.Workflow]:
+        db_workflow = self.get_workflow(workflow_id)
+        if not db_workflow:
+            return None
+        update_data = workflow_update.model_dump(exclude_unset=True)
+        for key, value in update_data.items():
+            setattr(db_workflow, key, value)
+        self.db.commit()
+        self.db.refresh(db_workflow)
+        return db_workflow
+
+    def delete_workflow(self, workflow_id: str) -> bool:
+        db_workflow = self.get_workflow(workflow_id)
+        if not db_workflow:
+            return False
+        self.db.delete(db_workflow)
+        self.db.commit()
+        return True

--- a/backend/tests/test_workflow_endpoints.py
+++ b/backend/tests/test_workflow_endpoints.py
@@ -1,0 +1,103 @@
+import types
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient, ASGITransport
+
+from backend.routers.workflows.core import router, get_workflow_service
+from backend.schemas.workflow import Workflow, WorkflowCreate, WorkflowUpdate
+from backend.auth import get_current_active_user
+
+
+class DummyService:
+    def __init__(self):
+        self.workflows = {}
+        self.next_id = 1
+
+    def create_workflow(self, workflow: WorkflowCreate):
+        wf = Workflow(
+            id=str(self.next_id),
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            **workflow.model_dump(),
+        )
+        self.workflows[wf.id] = wf
+        self.next_id += 1
+        return wf
+
+    def get_workflow(self, workflow_id: str):
+        return self.workflows.get(workflow_id)
+
+    def get_workflows(self, skip: int = 0, limit: int = 100):
+        return list(self.workflows.values())[skip : skip + limit]
+
+    def update_workflow(self, workflow_id: str, workflow_update: WorkflowUpdate):
+        wf = self.workflows.get(workflow_id)
+        if not wf:
+            return None
+        data = wf.model_dump()
+        data.update(workflow_update.model_dump(exclude_unset=True))
+        data["updated_at"] = datetime.now(timezone.utc)
+        wf = Workflow(**data)
+        self.workflows[workflow_id] = wf
+        return wf
+
+    def delete_workflow(self, workflow_id: str):
+        return self.workflows.pop(workflow_id, None) is not None
+
+
+dummy_service = DummyService()
+
+
+def override_service():
+    return dummy_service
+
+
+dummy_user = types.SimpleNamespace(id="u")
+
+
+def override_user():
+    return dummy_user
+
+
+app = FastAPI()
+app.include_router(router)
+app.dependency_overrides[get_workflow_service] = override_service
+app.dependency_overrides[get_current_active_user] = override_user
+
+
+@pytest.mark.asyncio
+async def test_create_and_get_workflow():
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/workflows/",
+            json={"name": "Test", "workflow_type": "basic"},
+        )
+        assert resp.status_code == 201
+        wf_id = resp.json()["data"]["id"]
+
+        resp = await client.get(f"/workflows/{wf_id}")
+        assert resp.status_code == 200
+        assert resp.json()["data"]["name"] == "Test"
+
+
+@pytest.mark.asyncio
+async def test_update_and_delete_workflow():
+    wf = dummy_service.create_workflow(
+        WorkflowCreate(name="Temp", workflow_type="basic")
+    )
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.put(f"/workflows/{wf.id}", json={"name": "Updated"})
+        assert resp.status_code == 200
+        assert resp.json()["data"]["name"] == "Updated"
+
+        resp = await client.delete(f"/workflows/{wf.id}")
+        assert resp.status_code == 200
+        assert resp.json()["data"]["message"] == "Workflow deleted"

--- a/backend/tests/test_workflow_service.py
+++ b/backend/tests/test_workflow_service.py
@@ -1,0 +1,43 @@
+from unittest.mock import MagicMock
+
+from backend.services.workflow_service import WorkflowService
+from backend.schemas.workflow import WorkflowCreate, WorkflowUpdate
+
+
+def test_create_workflow_adds_and_commits():
+    session = MagicMock()
+    service = WorkflowService(session)
+
+    workflow = service.create_workflow(
+        WorkflowCreate(name="WF", description=None, workflow_type="basic")
+    )
+
+    session.add.assert_called_once()
+    session.commit.assert_called_once()
+    session.refresh.assert_called_once_with(workflow)
+    assert workflow.name == "WF"
+
+
+def test_update_workflow_updates_fields():
+    session = MagicMock()
+    service = WorkflowService(session)
+    existing = MagicMock()
+    service.get_workflow = MagicMock(return_value=existing)
+
+    result = service.update_workflow("1", WorkflowUpdate(name="New"))
+
+    service.get_workflow.assert_called_once_with("1")
+    session.commit.assert_called_once()
+    session.refresh.assert_called_once_with(existing)
+    assert result == existing
+
+
+def test_update_workflow_returns_none_if_missing():
+    session = MagicMock()
+    service = WorkflowService(session)
+    service.get_workflow = MagicMock(return_value=None)
+
+    result = service.update_workflow("x", WorkflowUpdate(name="n"))
+
+    assert result is None
+    session.commit.assert_not_called()


### PR DESCRIPTION
## Summary
- implement `WorkflowService` with CRUD helpers
- expose workflow API routes and register in `main.py`
- cover new service and routes with tests

## Testing
- `flake8 backend/services/workflow_service.py backend/routers/workflows/core.py backend/tests/test_workflow_service.py backend/tests/test_workflow_endpoints.py backend/main.py`
- `pytest backend/tests/test_workflow_service.py backend/tests/test_workflow_endpoints.py -q`
- `pytest -q` *(fails: ModuleNotFoundError for `aiohttp`)*

------
https://chatgpt.com/codex/tasks/task_e_6841addcf7a0832c9401540155c3e786