### PR TITLE
Add forbidden action deletion tool

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -155,7 +155,7 @@ cd backend
 - ✅ **Task Comments**: API for listing and adding comments to tasks is fully functional.
 - ✅ **Project Members**: API for managing project members (add, remove, list) is fully functional.
 - ✅ **Agent Handoff Criteria**: Endpoints under `/api/v1/rules/roles/handoff-criteria` allow creation, listing, and deletion of handoff criteria for agent roles.
-- ✅ **Forbidden Action MCP Tools**: MCP endpoints `/mcp-tools/forbidden-action/create` and `/mcp-tools/forbidden-action/list` enable managing forbidden actions.
+- ✅ **Forbidden Action MCP Tools**: MCP endpoints `/mcp-tools/forbidden-action/create`, `/mcp-tools/forbidden-action/list`, and `/mcp-tools/forbidden-action/delete` enable managing forbidden actions.
 ## 🔍 Troubleshooting
 
 ### Server Won't Start

--- a/backend/docs/fastapi_mcp/README.md
+++ b/backend/docs/fastapi_mcp/README.md
@@ -95,6 +95,7 @@ FastAPI-MCP automatically exposes selected API endpoints as tools under the `/mc
 - `/mcp-tools/memory/search` (GET)
 - `/mcp-tools/forbidden-action/create` (POST)
 - `/mcp-tools/forbidden-action/list` (GET)
+- `/mcp-tools/forbidden-action/delete` (DELETE)
 - `/mcp-tools/handoff/create` (POST)
 - `/mcp-tools/handoff/list` (GET)
 - `/mcp-tools/handoff/delete` (DELETE)
@@ -108,8 +109,9 @@ FastAPI-MCP automatically exposes selected API endpoints as tools under the `/mc
 ### Forbidden Action Tools
 
 Use these routes to restrict actions for specific agent roles. Create new
-forbidden actions with `/mcp-tools/forbidden-action/create` and list all
-entries via `/mcp-tools/forbidden-action/list`.
+forbidden actions with `/mcp-tools/forbidden-action/create`, list all
+entries via `/mcp-tools/forbidden-action/list`, and remove them using
+`/mcp-tools/forbidden-action/delete`.
 
 ```python
 from backend.mcp_tools.forbidden_action_tools import create_forbidden_action_tool

--- a/backend/mcp_tools/__init__.py
+++ b/backend/mcp_tools/__init__.py
@@ -16,6 +16,7 @@ __all__ = [
     'remove_project_file_tool',
     'create_forbidden_action_tool',
     'list_forbidden_actions_tool',
+    'delete_forbidden_action_tool',
     'create_handoff_criteria_tool',
     'list_handoff_criteria_tool',
     'delete_handoff_criteria_tool',

--- a/backend/routers/mcp/core.py
+++ b/backend/routers/mcp/core.py
@@ -34,6 +34,7 @@ from ....schemas.error_protocol import ErrorProtocolCreate
 from ....mcp_tools.forbidden_action_tools import (
     add_forbidden_action_tool,
     list_forbidden_actions_tool,
+    delete_forbidden_action_tool,
 )
 from ....schemas.universal_mandate import UniversalMandateCreate
 from .... import models
@@ -1028,6 +1029,25 @@ async def mcp_list_forbidden_actions(
         return await list_forbidden_actions_tool(agent_role_id, db)
     except Exception as e:
         logger.error(f"MCP list forbidden actions failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.delete(
+    "/mcp-tools/forbidden-action/delete",
+    tags=["mcp-tools"],
+    operation_id="delete_forbidden_action_tool",
+)
+async def mcp_delete_forbidden_action(
+    action_id: str,
+    db: Session = Depends(get_db_session),
+):
+    """MCP Tool: Delete a forbidden action."""
+    try:
+        return await delete_forbidden_action_tool(action_id, db)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"MCP delete forbidden action failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/frontend/src/components/agents/AgentForbiddenActions.tsx
+++ b/frontend/src/components/agents/AgentForbiddenActions.tsx
@@ -1,0 +1,140 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Flex,
+  Input,
+  List,
+  ListItem,
+  Spinner,
+  Text,
+  useToast,
+} from "@chakra-ui/react";
+import { forbiddenActionsApi } from "@/services/api";
+import type { AgentForbiddenAction } from "@/types";
+
+interface AgentForbiddenActionsProps {
+  agentRoleId: string;
+}
+
+const AgentForbiddenActions: React.FC<AgentForbiddenActionsProps> = ({ agentRoleId }) => {
+  const toast = useToast();
+  const [actions, setActions] = useState<AgentForbiddenAction[] | null>(null);
+  const [newAction, setNewAction] = useState("");
+  const [reason, setReason] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const loadActions = async () => {
+    try {
+      const data = await forbiddenActionsApi.list(agentRoleId);
+      setActions(data);
+    } catch (err) {
+      toast({
+        title: "Failed to load actions",
+        description: err instanceof Error ? err.message : String(err),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  useEffect(() => {
+    loadActions();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agentRoleId]);
+
+  const handleCreate = async () => {
+    if (!newAction.trim()) return;
+    setLoading(true);
+    try {
+      await forbiddenActionsApi.create(agentRoleId, {
+        action: newAction,
+        reason: reason || undefined,
+      });
+      setNewAction("");
+      setReason("");
+      await loadActions();
+      toast({ title: "Action added", status: "success", duration: 3000, isClosable: true });
+    } catch (err) {
+      toast({
+        title: "Failed to add action",
+        description: err instanceof Error ? err.message : String(err),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    setLoading(true);
+    try {
+      await forbiddenActionsApi.delete(id);
+      await loadActions();
+      toast({ title: "Action removed", status: "success", duration: 3000, isClosable: true });
+    } catch (err) {
+      toast({
+        title: "Failed to remove action",
+        description: err instanceof Error ? err.message : String(err),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!actions) {
+    return (
+      <Flex justify="center" align="center" p="4" minH="100px">
+        <Spinner />
+      </Flex>
+    );
+  }
+
+  return (
+    <Box>
+      <Flex mb={2} gap={2} flexWrap="wrap">
+        <Input
+          placeholder="Forbidden action"
+          value={newAction}
+          onChange={(e) => setNewAction(e.target.value)}
+        />
+        <Input
+          placeholder="Reason (optional)"
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+        />
+        <Button onClick={handleCreate} isLoading={loading} disabled={!newAction.trim()}>
+          Add
+        </Button>
+      </Flex>
+      {actions.length === 0 ? (
+        <Text>No forbidden actions.</Text>
+      ) : (
+        <List spacing={2}>
+          {actions.map((a) => (
+            <ListItem key={a.id} borderWidth="1px" borderRadius="md" p={2}>
+              <Flex justify="space-between" align="center">
+                <Box>
+                  <Text fontWeight="bold">{a.action}</Text>
+                  {a.reason && <Text fontSize="sm">{a.reason}</Text>}
+                </Box>
+                <Button size="sm" colorScheme="red" onClick={() => handleDelete(a.id)}>
+                  Delete
+                </Button>
+              </Flex>
+            </ListItem>
+          ))}
+        </List>
+      )}
+    </Box>
+  );
+};
+
+export default AgentForbiddenActions;


### PR DESCRIPTION
## Summary
- support deleting forbidden actions via MCP tool
- expose delete tool in MCP router
- document new endpoints
- add AgentForbiddenActions component for managing forbidden actions

## Testing
- `flake8 backend/mcp_tools/forbidden_action_tools.py backend/routers/mcp/core.py`
- `npm run lint`
- `npm test` *(fails: observer.observe is not a function)*
- `npm run type-check` *(fails: merge conflict markers)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6841add69d00832ca27707dfc027c0dc