### PR TITLE
Implement forbidden actions service

### DIFF
--- a/backend/routers/rules/roles/forbidden_actions.py
+++ b/backend/routers/rules/roles/forbidden_actions.py
@@ -1,12 +1,3 @@
-<<<<<<< HEAD
-from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy.orm import Session
-from typing import List, Optional
-
-from ....database import get_sync_db as get_db
-from ....services.agent_forbidden_action_service import AgentForbiddenActionService
-from ....models.agent_forbidden_action import AgentForbiddenAction
-=======
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -14,41 +5,11 @@ from sqlalchemy.orm import Session
 
 from ....database import get_sync_db as get_db
 from ....services.agent_forbidden_action_service import AgentForbiddenActionService
-from ....models import AgentForbiddenAction
->>>>>>> main
+from ....models.agent_forbidden_action import AgentForbiddenAction
 
 router = APIRouter()
 
 
-<<<<<<< HEAD
-@router.post("/", response_model=AgentForbiddenAction)
-def create_forbidden_action(
-    role_id: str,
-    action: str,
-    reason: Optional[str] = None,
-    db: Session = Depends(get_db),
-) -> AgentForbiddenAction:
-    """Create a forbidden action for an agent role."""
-    service = AgentForbiddenActionService(db)
-    return service.create_action(role_id, action, reason)
-
-
-@router.get("/", response_model=List[AgentForbiddenAction])
-def list_forbidden_actions(
-    role_id: Optional[str] = Query(None, description="Filter by agent role"),
-    db: Session = Depends(get_db),
-) -> List[AgentForbiddenAction]:
-    """List forbidden actions, optionally filtered by role."""
-    service = AgentForbiddenActionService(db)
-    return service.list_actions(role_id)
-
-
-@router.delete("/{action_id}")
-def delete_forbidden_action(action_id: str, db: Session = Depends(get_db)):
-    """Delete a forbidden action by ID."""
-    service = AgentForbiddenActionService(db)
-    success = service.delete_action(action_id)
-=======
 def get_service(db: Session = Depends(get_db)) -> AgentForbiddenActionService:
     return AgentForbiddenActionService(db)
 
@@ -61,16 +22,46 @@ def create_forbidden_action(
     service: AgentForbiddenActionService = Depends(get_service),
 ) -> AgentForbiddenAction:
     """Add a forbidden action to an agent role."""
-    return service.create(agent_role_id, action, reason)
+    return service.create_action(agent_role_id, action, reason)
 
 
-@router.get("/{agent_role_id}/forbidden-actions", response_model=List[AgentForbiddenAction])
+@router.get(
+    "/{agent_role_id}/forbidden-actions",
+    response_model=List[AgentForbiddenAction],
+)
 def list_forbidden_actions(
     agent_role_id: str,
     service: AgentForbiddenActionService = Depends(get_service),
 ) -> List[AgentForbiddenAction]:
     """List forbidden actions for an agent role."""
-    return service.list(agent_role_id)
+    return service.list_actions(agent_role_id)
+
+
+@router.get("/forbidden-actions/{action_id}", response_model=AgentForbiddenAction)
+def get_forbidden_action(
+    action_id: str,
+    service: AgentForbiddenActionService = Depends(get_service),
+) -> AgentForbiddenAction:
+    """Retrieve a single forbidden action by ID."""
+    action_obj = service.get_action(action_id)
+    if not action_obj:
+        raise HTTPException(status_code=404, detail="Forbidden action not found")
+    return action_obj
+
+
+@router.put("/forbidden-actions/{action_id}", response_model=AgentForbiddenAction)
+def update_forbidden_action(
+    action_id: str,
+    action: Optional[str] = None,
+    reason: Optional[str] = None,
+    is_active: Optional[bool] = None,
+    service: AgentForbiddenActionService = Depends(get_service),
+) -> AgentForbiddenAction:
+    """Update a forbidden action."""
+    updated = service.update_action(action_id, action, reason, is_active)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Forbidden action not found")
+    return updated
 
 
 @router.delete("/forbidden-actions/{action_id}")
@@ -79,8 +70,7 @@ def delete_forbidden_action(
     service: AgentForbiddenActionService = Depends(get_service),
 ) -> dict:
     """Remove a forbidden action."""
-    success = service.delete(action_id)
->>>>>>> main
+    success = service.delete_action(action_id)
     if not success:
         raise HTTPException(status_code=404, detail="Forbidden action not found")
     return {"message": "Forbidden action removed successfully"}

--- a/backend/services/agent_forbidden_action_service.py
+++ b/backend/services/agent_forbidden_action_service.py
@@ -10,72 +10,66 @@ class AgentForbiddenActionService:
     def __init__(self, db: Session) -> None:
         self.db = db
 
-<<<<<<< HEAD
     def create_action(
-        self, role_id: str, action: str, reason: Optional[str] = None
+        self, agent_role_id: str, action: str, reason: Optional[str] = None
     ) -> models.AgentForbiddenAction:
         """Create a forbidden action for an agent role."""
         db_action = models.AgentForbiddenAction(
-            agent_role_id=role_id,
-=======
-    def create(self, agent_role_id: str, action: str, reason: Optional[str] = None) -> models.AgentForbiddenAction:
-        """Create a forbidden action for a given agent role."""
-        forbidden = models.AgentForbiddenAction(
             agent_role_id=agent_role_id,
->>>>>>> main
             action=action,
             reason=reason,
             is_active=True,
         )
-<<<<<<< HEAD
         self.db.add(db_action)
         self.db.commit()
         self.db.refresh(db_action)
         return db_action
 
     def list_actions(
-        self, role_id: Optional[str] = None
+        self, agent_role_id: Optional[str] = None
     ) -> List[models.AgentForbiddenAction]:
         """List forbidden actions, optionally filtered by agent role."""
         query = self.db.query(models.AgentForbiddenAction)
-        if role_id:
-            query = query.filter(models.AgentForbiddenAction.agent_role_id == role_id)
-        return query.all()
-
-    def delete_action(self, action_id: str) -> bool:
-        """Delete a forbidden action by ID."""
-        db_action = (
-=======
-        self.db.add(forbidden)
-        self.db.commit()
-        self.db.refresh(forbidden)
-        return forbidden
-
-    def list(self, agent_role_id: Optional[str] = None) -> List[models.AgentForbiddenAction]:
-        """List forbidden actions, optionally filtered by agent role."""
-        query = self.db.query(models.AgentForbiddenAction)
         if agent_role_id:
-            query = query.filter(models.AgentForbiddenAction.agent_role_id == agent_role_id)
+            query = query.filter(
+                models.AgentForbiddenAction.agent_role_id == agent_role_id
+            )
         return query.all()
 
-    def delete(self, action_id: str) -> bool:
-        """Delete a forbidden action by ID."""
-        action = (
->>>>>>> main
+    def get_action(self, action_id: str) -> Optional[models.AgentForbiddenAction]:
+        """Retrieve a single forbidden action by ID."""
+        return (
             self.db.query(models.AgentForbiddenAction)
             .filter(models.AgentForbiddenAction.id == action_id)
             .first()
         )
-<<<<<<< HEAD
+
+    def update_action(
+        self,
+        action_id: str,
+        action: Optional[str] = None,
+        reason: Optional[str] = None,
+        is_active: Optional[bool] = None,
+    ) -> Optional[models.AgentForbiddenAction]:
+        """Update a forbidden action."""
+        db_action = self.get_action(action_id)
+        if not db_action:
+            return None
+        if action is not None:
+            db_action.action = action
+        if reason is not None:
+            db_action.reason = reason
+        if is_active is not None:
+            db_action.is_active = is_active
+        self.db.commit()
+        self.db.refresh(db_action)
+        return db_action
+
+    def delete_action(self, action_id: str) -> bool:
+        """Delete a forbidden action by ID."""
+        db_action = self.get_action(action_id)
         if not db_action:
             return False
         self.db.delete(db_action)
         self.db.commit()
         return True
-=======
-        if action:
-            self.db.delete(action)
-            self.db.commit()
-            return True
-        return False
->>>>>>> main


### PR DESCRIPTION
## Summary
- implement CRUD logic in `AgentForbiddenActionService`
- add router for forbidden action endpoints
- ensure router registered with rules package

## Testing
- `flake8 backend/services/agent_forbidden_action_service.py backend/routers/rules/roles/forbidden_actions.py`
- `pytest` *(fails: 12 failed, 35 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6841add60dd8832cb9c791419a8cb9b3