### PR TITLE
feat: add agent capabilities feature

### DIFF
--- a/frontend/src/components/agents/AgentCapabilities.tsx
+++ b/frontend/src/components/agents/AgentCapabilities.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Flex,
+  Input,
+  List,
+  ListItem,
+  Spinner,
+  Text,
+  useToast,
+} from '@chakra-ui/react';
+import { agentCapabilitiesApi } from '@/services/api';
+import type { AgentCapability } from '@/types/agents';
+
+interface AgentCapabilitiesProps {
+  agentRoleId: string;
+}
+
+const AgentCapabilities: React.FC<AgentCapabilitiesProps> = ({
+  agentRoleId,
+}) => {
+  const toast = useToast();
+  const [capabilities, setCapabilities] = useState<AgentCapability[] | null>(
+    null
+  );
+  const [newCap, setNewCap] = useState('');
+  const [newDesc, setNewDesc] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editCap, setEditCap] = useState('');
+  const [editDesc, setEditDesc] = useState('');
+
+  const loadCapabilities = async () => {
+    try {
+      const data = await agentCapabilitiesApi.list(agentRoleId);
+      setCapabilities(data);
+    } catch (err) {
+      toast({
+        title: 'Failed to load capabilities',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  useEffect(() => {
+    loadCapabilities();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agentRoleId]);
+
+  const handleCreate = async () => {
+    if (!newCap.trim()) return;
+    setLoading(true);
+    try {
+      await agentCapabilitiesApi.create(agentRoleId, {
+        capability: newCap,
+        description: newDesc || undefined,
+      });
+      setNewCap('');
+      setNewDesc('');
+      await loadCapabilities();
+      toast({
+        title: 'Capability added',
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+      });
+    } catch (err) {
+      toast({
+        title: 'Failed to add capability',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    setLoading(true);
+    try {
+      await agentCapabilitiesApi.delete(id);
+      await loadCapabilities();
+      toast({
+        title: 'Capability removed',
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+      });
+    } catch (err) {
+      toast({
+        title: 'Failed to remove capability',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const startEdit = (cap: AgentCapability) => {
+    setEditingId(cap.id);
+    setEditCap(cap.capability);
+    setEditDesc(cap.description || '');
+  };
+
+  const handleUpdate = async (id: string) => {
+    setLoading(true);
+    try {
+      await agentCapabilitiesApi.update(id, {
+        capability: editCap,
+        description: editDesc || undefined,
+      });
+      setEditingId(null);
+      await loadCapabilities();
+      toast({
+        title: 'Capability updated',
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+      });
+    } catch (err) {
+      toast({
+        title: 'Failed to update capability',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!capabilities) {
+    return (
+      <Flex justify="center" align="center" p="4" minH="100px">
+        <Spinner />
+      </Flex>
+    );
+  }
+
+  return (
+    <Box>
+      <Flex mb={2} gap={2} flexWrap="wrap">
+        <Input
+          placeholder="Capability"
+          value={newCap}
+          onChange={(e) => setNewCap(e.target.value)}
+        />
+        <Input
+          placeholder="Description"
+          value={newDesc}
+          onChange={(e) => setNewDesc(e.target.value)}
+        />
+        <Button
+          onClick={handleCreate}
+          isLoading={loading}
+          disabled={!newCap.trim()}
+        >
+          Add
+        </Button>
+      </Flex>
+      {capabilities.length === 0 ? (
+        <Text>No capabilities.</Text>
+      ) : (
+        <List spacing={2}>
+          {capabilities.map((cap) => (
+            <ListItem key={cap.id} borderWidth="1px" borderRadius="md" p={2}>
+              {editingId === cap.id ? (
+                <Flex gap={2} flexWrap="wrap">
+                  <Input
+                    value={editCap}
+                    onChange={(e) => setEditCap(e.target.value)}
+                  />
+                  <Input
+                    value={editDesc}
+                    onChange={(e) => setEditDesc(e.target.value)}
+                  />
+                  <Button
+                    size="sm"
+                    onClick={() => handleUpdate(cap.id)}
+                    isLoading={loading}
+                  >
+                    Save
+                  </Button>
+                  <Button size="sm" onClick={() => setEditingId(null)}>
+                    Cancel
+                  </Button>
+                </Flex>
+              ) : (
+                <Flex justify="space-between" align="center">
+                  <Box>
+                    <Text fontWeight="bold">{cap.capability}</Text>
+                    {cap.description && (
+                      <Text fontSize="sm">{cap.description}</Text>
+                    )}
+                  </Box>
+                  <Flex gap={2}>
+                    <Button size="sm" onClick={() => startEdit(cap)}>
+                      Edit
+                    </Button>
+                    <Button
+                      size="sm"
+                      colorScheme="red"
+                      onClick={() => handleDelete(cap.id)}
+                    >
+                      Delete
+                    </Button>
+                  </Flex>
+                </Flex>
+              )}
+            </ListItem>
+          ))}
+        </List>
+      )}
+    </Box>
+  );
+};
+
+export default AgentCapabilities;

--- a/frontend/src/components/agents/__tests__/AgentCapabilities.test.tsx
+++ b/frontend/src/components/agents/__tests__/AgentCapabilities.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen, TestWrapper } from '@/__tests__/utils/test-utils';
+import AgentCapabilities from '../AgentCapabilities';
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual('@chakra-ui/react');
+  return {
+    ...actual,
+    useToast: () => vi.fn(),
+    useColorModeValue: (l: any, d: any) => l,
+  };
+});
+
+const listMock = vi.fn().mockResolvedValue([]);
+const createMock = vi.fn().mockResolvedValue({});
+
+vi.mock('@/services/api', () => ({
+  agentCapabilitiesApi: {
+    list: listMock,
+    create: createMock,
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+describe('AgentCapabilities', () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listMock.mockResolvedValue([]);
+  });
+
+  it('renders without crashing', () => {
+    render(
+      <TestWrapper>
+        <AgentCapabilities agentRoleId="role1" />
+      </TestWrapper>
+    );
+    expect(document.body).toBeInTheDocument();
+  });
+
+  it('handles adding capability', async () => {
+    render(
+      <TestWrapper>
+        <AgentCapabilities agentRoleId="role1" />
+      </TestWrapper>
+    );
+
+    const input = screen.getByPlaceholderText('Capability');
+    await user.type(input, 'demo');
+    await user.click(screen.getByRole('button', { name: /add/i }));
+
+    expect(createMock).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/services/api/__tests__/agent_capabilities.test.ts
+++ b/frontend/src/services/api/__tests__/agent_capabilities.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { agentCapabilitiesApi } from '../agent_capabilities';
+import { request } from '../request';
+import { buildApiUrl, API_CONFIG } from '../config';
+
+vi.mock('../request');
+vi.mock('../config');
+
+const mockRequest = vi.mocked(request);
+const mockBuildApiUrl = vi.mocked(buildApiUrl);
+
+const sampleCap = {
+  id: '1',
+  agent_role_id: 'role1',
+  capability: 'demo',
+  description: null,
+  is_active: true,
+  created_at: '2024-01-01T00:00:00Z',
+};
+
+describe('agentCapabilitiesApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBuildApiUrl.mockReturnValue('http://localhost:8000/api/test');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('lists capabilities', async () => {
+    mockRequest.mockResolvedValue({ data: [sampleCap] });
+
+    const result = await agentCapabilitiesApi.list('role1');
+
+    expect(mockBuildApiUrl).toHaveBeenCalledWith(
+      API_CONFIG.ENDPOINTS.RULES,
+      '/roles/capabilities?agent_role_id=role1'
+    );
+    expect(mockRequest).toHaveBeenCalledWith('http://localhost:8000/api/test');
+    expect(result).toEqual([sampleCap]);
+  });
+
+  it('gets capability', async () => {
+    mockRequest.mockResolvedValue({ data: sampleCap });
+
+    const result = await agentCapabilitiesApi.get('1');
+
+    expect(mockBuildApiUrl).toHaveBeenCalled();
+    expect(mockRequest).toHaveBeenCalledWith('http://localhost:8000/api/test');
+    expect(result).toEqual(sampleCap);
+  });
+
+  it('creates capability', async () => {
+    mockRequest.mockResolvedValue({ data: sampleCap });
+
+    const result = await agentCapabilitiesApi.create('role1', {
+      capability: 'demo',
+    });
+
+    expect(mockBuildApiUrl).toHaveBeenCalled();
+    expect(mockRequest).toHaveBeenCalledWith(
+      'http://localhost:8000/api/test',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(result).toEqual(sampleCap);
+  });
+
+  it('updates capability', async () => {
+    mockRequest.mockResolvedValue({ data: sampleCap });
+
+    const result = await agentCapabilitiesApi.update('1', {
+      capability: 'demo2',
+    });
+
+    expect(mockBuildApiUrl).toHaveBeenCalled();
+    expect(mockRequest).toHaveBeenCalledWith(
+      'http://localhost:8000/api/test',
+      expect.objectContaining({ method: 'PUT' })
+    );
+    expect(result).toEqual(sampleCap);
+  });
+
+  it('deletes capability', async () => {
+    mockRequest.mockResolvedValue({ message: 'deleted' });
+
+    await agentCapabilitiesApi.delete('1');
+
+    expect(mockBuildApiUrl).toHaveBeenCalled();
+    expect(mockRequest).toHaveBeenCalledWith('http://localhost:8000/api/test', {
+      method: 'DELETE',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add `AgentCapabilities` component for viewing and editing role capabilities
- provide API tests for `agentCapabilitiesApi`
- add component test verifying capability creation

## Testing
- `npx vitest run src/components/agents/__tests__/AgentCapabilities.test.tsx src/services/api/__tests__/agent_capabilities.test.ts` *(fails: No test files found)*
- `npx vitest run src/services/api/__tests__/agent_capabilities.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6841add52348832c897576137ebba63e