### PR TITLE
Add user role update endpoint

### DIFF
--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -29,6 +29,7 @@ from .user import (
     User,
     UserRoleBase,
     UserRoleCreate,
+    UserRoleUpdate,
     UserRole,
 )
 

--- a/backend/schemas/user.py
+++ b/backend/schemas/user.py
@@ -29,8 +29,12 @@ class UserRole(UserRoleBase):
  model_config = ConfigDict(from_attributes=True)
 
 class UserRoleCreate(UserRoleBase):
- """Schema for creating a new user role association."""
- pass
+    """Schema for creating a new user role association."""
+    pass
+
+class UserRoleUpdate(BaseModel):
+    """Schema for updating an existing user role association."""
+    role_name: UserRoleEnum = Field(..., description="The updated role name.")
 
 # --- User Schemas ---
 class UserBase(BaseModel):

--- a/backend/services/user_role_service.py
+++ b/backend/services/user_role_service.py
@@ -41,6 +41,40 @@ class UserRoleService:
             return True
         return False
 
+    def update_user_role(
+        self, user_id: str, current_role_name: str, new_role_name: str
+    ) -> Optional[models.UserRole]:
+        """Update a user's role."""
+        role = (
+            self.db.query(models.UserRole)
+            .filter(
+                models.UserRole.user_id == user_id,
+                models.UserRole.role_name == current_role_name,
+            )
+            .first()
+        )
+        if not role:
+            return None
+
+        if current_role_name == new_role_name:
+            return role
+
+        existing = (
+            self.db.query(models.UserRole)
+            .filter(
+                models.UserRole.user_id == user_id,
+                models.UserRole.role_name == new_role_name,
+            )
+            .first()
+        )
+        if existing:
+            return existing
+
+        role.role_name = new_role_name
+        self.db.commit()
+        self.db.refresh(role)
+        return role
+
     def get_user_roles(self, user_id: str) -> List[models.UserRole]:
         return (
             self.db.query(models.UserRole)


### PR DESCRIPTION
## Summary
- support updating user roles via new API endpoint
- extend UserRoleService with update logic
- add `UserRoleUpdate` schema
- test user role update flow

## Testing
- `flake8 routers/users/roles.py services/user_role_service.py tests/test_user_roles.py schemas/user.py schemas/__init__.py`
- `pytest tests/test_user_roles.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6841adcdf8e4832ca2a9051d73f7d8f2