### PR TITLE
Add memory search endpoint

### DIFF
--- a/backend/docs/fastapi_mcp/README.md
+++ b/backend/docs/fastapi_mcp/README.md
@@ -93,6 +93,7 @@ FastAPI-MCP automatically exposes selected API endpoints as tools under the `/mc
 - `/mcp-tools/memory/add-observation` (POST)
 - `/mcp-tools/memory/add-relation` (POST)
 - `/mcp-tools/memory/search` (GET)
+- `/mcp-tools/memory/search-graph` (GET)
 - `/mcp-tools/forbidden-action/create` (POST)
 - `/mcp-tools/forbidden-action/list` (GET)
 - `/mcp-tools/handoff/create` (POST)
@@ -104,6 +105,12 @@ FastAPI-MCP automatically exposes selected API endpoints as tools under the `/mc
 - `/mcp-tools/template/create` (POST)
 - `/mcp-tools/template/list` (GET)
 - `/mcp-tools/template/delete` (POST)
+
+Both `/mcp-tools/memory/search` and `/mcp-tools/memory/search-graph` accept the
+following query parameters:
+
+- `query` – the text to search for in memory entity content.
+- `limit` – maximum number of results to return (default `10`).
 
 ### Forbidden Action Tools
 

--- a/backend/mcp_tools/__init__.py
+++ b/backend/mcp_tools/__init__.py
@@ -1,7 +1,6 @@
-"""
-MCP Tools package initialization.
-"""
+"""MCP Tools package initialization."""
 
+from .memory_tools import search_graph_tool
 
 __all__ = [
     'create_project_tool',


### PR DESCRIPTION
## Summary
- add `/api/memory/search` endpoint
- expose `search_graph_tool` in MCP tools
- document search params in MCP README

## Testing
- `flake8 routers/memory/__init__.py mcp_tools/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError, assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841adcb5c84832ca6d18c1bb46a8439