### PR TITLE
Add relation update API

### DIFF
--- a/frontend/src/services/api/memory.ts
+++ b/frontend/src/services/api/memory.ts
@@ -11,9 +11,24 @@ import type {
   MemoryObservationCreateData,
   MemoryRelation,
   MemoryRelationCreateData,
+  MemoryRelationUpdateData,
   MemoryRelationFilters,
   KnowledgeGraph,
 } from "@/types/memory";
+
+export const updateRelation = async (
+  relationId: number,
+  data: MemoryRelationUpdateData
+): Promise<MemoryRelation> => {
+  const response = await request<{ data: MemoryRelation }>(
+    buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/relations/${relationId}`),
+    {
+      method: "PUT",
+      body: JSON.stringify(data),
+    }
+  );
+  return response.data;
+};
 
 // --- Memory Entity APIs ---
 export const memoryApi = {
@@ -172,6 +187,9 @@ export const memoryApi = {
     );
     return response.data;
   },
+
+  // Update a relation
+  updateRelation,
 
   // Delete a relation
   deleteRelation: async (relationId: number): Promise<void> => {

--- a/frontend/src/types/memory.ts
+++ b/frontend/src/types/memory.ts
@@ -59,6 +59,12 @@ export type MemoryRelationCreateData = z.infer<
   typeof memoryRelationCreateSchema
 >;
 
+export const memoryRelationUpdateSchema = memoryRelationBaseSchema.partial();
+
+export type MemoryRelationUpdateData = z.infer<
+  typeof memoryRelationUpdateSchema
+>;
+
 export const memoryRelationSchema = memoryRelationBaseSchema.extend({
   id: z.number(),
   created_at: z.string().datetime({ message: 'Invalid ISO datetime string' }),


### PR DESCRIPTION
## Summary
- support updating memory relations with new `updateRelation` api
- expose related update types

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot read properties of undefined)*
- `pytest -q` *(fails: AttributeError: 'str' object has no attribute 'file_path')*

------
https://chatgpt.com/codex/tasks/task_e_6841ad909efc832cbb030e8fafc6be2d