### PR TITLE
Add memory relation update tool

### DIFF
--- a/backend/docs/fastapi_mcp/README.md
+++ b/backend/docs/fastapi_mcp/README.md
@@ -92,6 +92,7 @@ FastAPI-MCP automatically exposes selected API endpoints as tools under the `/mc
 - `/mcp-tools/memory/update-entity` (POST)
 - `/mcp-tools/memory/add-observation` (POST)
 - `/mcp-tools/memory/add-relation` (POST)
+- `/mcp-tools/memory/update-relation` (POST)
 - `/mcp-tools/memory/search` (GET)
 - `/mcp-tools/forbidden-action/create` (POST)
 - `/mcp-tools/forbidden-action/list` (GET)

--- a/backend/mcp_tools/__init__.py
+++ b/backend/mcp_tools/__init__.py
@@ -27,5 +27,6 @@ __all__ = [
     'remove_error_protocol_tool',
     'assign_role_tool',
     'list_roles_tool',
-    'remove_role_tool'
+    'remove_role_tool',
+    'update_relation_tool'
 ]

--- a/backend/schemas/memory.py
+++ b/backend/schemas/memory.py
@@ -65,6 +65,22 @@ class MemoryRelationBase(BaseModel):
 class MemoryRelationCreate(MemoryRelationBase):
     pass
 
+
+class MemoryRelationUpdate(BaseModel):
+    """Schema for updating a memory relation."""
+    from_entity_id: Optional[int] = Field(
+        None, description="The ID of the source memory entity"
+    )
+    to_entity_id: Optional[int] = Field(
+        None, description="The ID of the target memory entity"
+    )
+    relation_type: Optional[str] = Field(
+        None, description="The type of the relationship"
+    )
+    metadata_: Optional[Dict[str, Any]] = Field(
+        None, description="Optional structured metadata for the relation"
+    )
+
 class MemoryRelation(MemoryRelationBase):
     """Schema for representing a memory relation in API responses, including relationships."""
     id: int = Field(..., description="Unique integer ID of the relation.")

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -13,6 +13,7 @@ from ..schemas.memory import (
     MemoryEntityUpdate,
     MemoryObservationCreate,
     MemoryRelationCreate,
+    MemoryRelationUpdate,
     MemoryEntity,
     MemoryRelation,
 )
@@ -330,6 +331,20 @@ class MemoryService:
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Error creating memory relation",
             )
+
+    def update_memory_relation(
+        self, relation_id: int, relation_update: MemoryRelationUpdate
+    ) -> Optional[models.MemoryRelation]:
+        """Update an existing memory relation."""
+        db_relation = self.get_memory_relation(relation_id)
+        if not db_relation:
+            return None
+        for key, value in relation_update.model_dump(exclude_unset=True).items():
+            setattr(db_relation, key, value)
+        self.db.commit()
+        self.db.refresh(db_relation)
+        logger.info(f"Updated memory relation: {relation_id}")
+        return db_relation
 
     def get_memory_relation(
         self, relation_id: int


### PR DESCRIPTION
## Summary
- add `MemoryRelationUpdate` schema
- add CRUD and service logic for relation updates
- support updating relations via a new MCP tool
- register `/mcp-tools/memory/update-relation` route
- document the new route

## Testing
- `flake8 .` *(fails: command not found initially)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6841ad900d48832ca816f303f7e2b1af