### PR TITLE
Implement memory relation updates

### DIFF
--- a/backend/routers/memory/relations/relations.py
+++ b/backend/routers/memory/relations/relations.py
@@ -3,108 +3,153 @@ from sqlalchemy.orm import Session
 from typing import List, Optional
 
 from ....database import get_sync_db as get_db
-from ....services.memory_service import MemoryService  # Assuming relation management is part of memory service
+from ....services.memory_service import MemoryService
 from ....schemas.memory import MemoryRelation, MemoryRelationCreate
 from ....services.exceptions import EntityNotFoundError, DuplicateEntityError
 
 router = APIRouter()
 
+
 def get_memory_service(db: Session = Depends(get_db)) -> MemoryService:
     return MemoryService(db)
 
+
 @router.post("/relations/", response_model=MemoryRelation)
-
-
 def create_relation(
     relation: MemoryRelationCreate,
-    memory_service: MemoryService = Depends(get_memory_service)
+    memory_service: MemoryService = Depends(get_memory_service),
 ):
     """Create a relationship between two memory entities."""
     try:
-    return memory_service.create_relation(relation)
+        return memory_service.create_relation(relation)
     except (EntityNotFoundError, DuplicateEntityError) as e:
-    raise HTTPException(status_code=400, detail=str(e))  # Use 400 for bad request if entities not found or duplicate
-    except Exception as e:
-    raise HTTPException(
-    status_code=500,
-    detail=f"Internal server error: {e}"
-    )
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:  # pragma: no cover - unexpected error
+        raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+
+
+@router.put("/relations/{relation_id}", response_model=MemoryRelation)
+def update_relation(
+    relation_update: MemoryRelationCreate,
+    relation_id: int = Path(..., description="ID of the relation to update."),
+    memory_service: MemoryService = Depends(get_memory_service),
+):
+    """Update an existing memory relation."""
+    try:
+        db_relation = memory_service.update_memory_relation(
+            relation_id,
+            relation_update,
+        )
+        if db_relation is None:
+            raise EntityNotFoundError("MemoryRelation", relation_id)
+        return db_relation
+    except EntityNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except DuplicateEntityError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:  # pragma: no cover - unexpected error
+        raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+
 
 @router.get("/relations/by-type/{relation_type}", response_model=List[MemoryRelation])
-
-
 def read_relations_by_type(
-    relation_type: str = Path(..., description="The type of relations to filter by."),
-    skip: int = Query(0, description="The number of items to skip before returning"
-        "results."),
-    limit: int = Query(100, description="The maximum number of items to return."),
-    memory_service: MemoryService = Depends(get_memory_service)
+    relation_type: str = Path(
+        ..., description="The type of relations to filter by."
+    ),
+    skip: int = Query(
+        0,
+        description="The number of items to skip before returning results.",
+    ),
+    limit: int = Query(
+        100,
+        description="The maximum number of items to return.",
+    ),
+    memory_service: MemoryService = Depends(get_memory_service),
 ):
     """Retrieve a list of memory relations filtered by type."""
     try:
-    return memory_service.get_relations_by_type(relation_type=relation_type, skip=skip, limit=limit)
-    except Exception as e:
-    raise HTTPException(
-    status_code=500,
-    detail=f"Internal server error: {e}"
-    )
-@router.get("/entities/{from_entity_id}/relations/{to_entity_id}", response_model=List[MemoryRelation])
+        return memory_service.get_memory_relations_by_type(
+            relation_type=relation_type, skip=skip, limit=limit
+        )
+    except Exception as e:  # pragma: no cover - unexpected error
+        raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
 
 
+@router.get(
+    "/entities/{from_entity_id}/relations/{to_entity_id}",
+    response_model=List[MemoryRelation],
+)
 def read_relations_between_entities(
-    from_entity_id: int = Path(..., description="ID of the source entity."),
-    to_entity_id: int = Path(..., description="ID of the target entity."),
-    relation_type: Optional[str] = Query(None, description="Optional relation type to filter by."),
-    skip: int = Query(0, description="The number of items to skip before returning"
-        "results."),
-    limit: int = Query(100, description="The maximum number of items to return."),
-    memory_service: MemoryService = Depends(get_memory_service)
+    from_entity_id: int = Path(
+        ..., description="ID of the source entity."
+    ),
+    to_entity_id: int = Path(
+        ..., description="ID of the target entity."
+    ),
+    relation_type: Optional[str] = Query(
+        None, description="Optional relation type to filter by."
+    ),
+    skip: int = Query(
+        0, description="The number of items to skip before returning results."
+    ),
+    limit: int = Query(
+        100, description="The maximum number of items to return."
+    ),
+    memory_service: MemoryService = Depends(get_memory_service),
 ):
     """Retrieve relations between two specific memory entities."""
     try:
-    return memory_service.get_relations_between_entities(from_entity_id=from_entity_id, to_entity_id=to_entity_id, relation_type=relation_type, skip=skip, limit=limit)
-    except Exception as e:
-    raise HTTPException(
-    status_code=500,
-    detail=f"Internal server error: {e}"
-    )
+        return memory_service.get_memory_relations_between_entities(
+            from_entity_id=from_entity_id,
+            to_entity_id=to_entity_id,
+            relation_type=relation_type,
+            skip=skip,
+            limit=limit,
+        )
+    except Exception as e:  # pragma: no cover - unexpected error
+        raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
 
-@router.get("/entities/{entity_id}/relations/", response_model=List[MemoryRelation])
 
-
+@router.get(
+    "/entities/{entity_id}/relations/",
+    response_model=List[MemoryRelation],
+)
 def get_entity_relations(
-    entity_id: int = Path(..., description="ID of the entity to retrieve relations for."),
-    relation_type: Optional[str] = Query(None, description="Optional relation type to filter by."),
-    memory_service: MemoryService = Depends(get_memory_service)
+    entity_id: int = Path(
+        ..., description="ID of the entity to retrieve relations for."
+    ),
+    relation_type: Optional[str] = Query(
+        None, description="Optional relation type to filter by."
+    ),
+    memory_service: MemoryService = Depends(get_memory_service),
 ):
-    """Get all relations for a specific entity (where it is either the source or target)."""
+    """Get all relations for a specific entity."""
     try:
-    return memory_service.get_entity_relations(entity_id=entity_id, relation_type=relation_type)
+        return memory_service.get_relations_for_entity(
+            entity_id=entity_id,
+            relation_type=relation_type,
+        )
     except EntityNotFoundError as e:
-    raise HTTPException(status_code=404, detail=str(e))
-    except Exception as e:
-    raise HTTPException(
-    status_code=500,
-    detail=f"Internal server error: {e}"
-    )
-
-@router.delete("/relations/{relation_id}", status_code=status.HTTP_204_NO_CONTENT)
+        raise HTTPException(status_code=404, detail=str(e))
+    except Exception as e:  # pragma: no cover - unexpected error
+        raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
 
 
+@router.delete(
+    "/relations/{relation_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
 def delete_relation(
     relation_id: int = Path(..., description="ID of the relation to delete."),
-    memory_service: MemoryService = Depends(get_memory_service)
+    memory_service: MemoryService = Depends(get_memory_service),
 ):
     """Delete a memory relation."""
     try:
-    success = memory_service.delete_relation(relation_id)
-    if not success:
-    raise EntityNotFoundError("MemoryRelation", relation_id)
-    return {"message": "Memory relation deleted successfully"}
+        success = memory_service.delete_memory_relation(relation_id)
+        if not success:
+            raise EntityNotFoundError("MemoryRelation", relation_id)
+        return {"message": "Memory relation deleted successfully"}
     except EntityNotFoundError as e:
-    raise HTTPException(status_code=404, detail=str(e))
-    except Exception as e:
-    raise HTTPException(
-    status_code=500,
-    detail=f"Internal server error: {e}"
-    )
+        raise HTTPException(status_code=404, detail=str(e))
+    except Exception as e:  # pragma: no cover - unexpected error
+        raise HTTPException(status_code=500, detail=f"Internal server error: {e}")

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -13,8 +13,6 @@ from ..schemas.memory import (
     MemoryEntityUpdate,
     MemoryObservationCreate,
     MemoryRelationCreate,
-    MemoryEntity,
-    MemoryRelation,
 )
 from ..schemas.file_ingest import FileIngestInput
 from ..crud.memory import (
@@ -339,6 +337,59 @@ class MemoryService:
             .filter(models.MemoryRelation.id == relation_id)
             .first()
         )
+
+    def update_memory_relation(
+        self, relation_id: int, relation_update: MemoryRelationCreate
+    ) -> Optional[models.MemoryRelation]:
+        """Update a memory relation's details."""
+        db_relation = self.get_memory_relation(relation_id)
+        if not db_relation:
+            return None
+
+        # Validate referenced entities exist
+        if not self.get_memory_entity_by_id(relation_update.from_entity_id):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=(
+                    f"Source entity with ID {relation_update.from_entity_id} not found"
+                ),
+            )
+        if not self.get_memory_entity_by_id(relation_update.to_entity_id):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=(
+                    f"Target entity with ID {relation_update.to_entity_id} not found"
+                ),
+            )
+
+        try:
+            db_relation.from_entity_id = relation_update.from_entity_id
+            db_relation.to_entity_id = relation_update.to_entity_id
+            db_relation.relation_type = relation_update.relation_type
+            db_relation.metadata_ = relation_update.metadata_
+
+            self.db.commit()
+            self.db.refresh(db_relation)
+            logger.info(f"Updated memory relation: {db_relation.id}")
+            return db_relation
+        except IntegrityError:
+            self.db.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "Relation of type "
+                    f"'{relation_update.relation_type}' already exists "
+                    f"between entity {relation_update.from_entity_id} "
+                    f"and entity {relation_update.to_entity_id}"
+                ),
+            )
+        except Exception as e:
+            self.db.rollback()
+            logger.error(f"Error updating memory relation: {e}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Error updating memory relation",
+            )
 
     def get_relations_for_entity(
         self, entity_id: int, relation_type: Optional[str] = None


### PR DESCRIPTION
## Summary
- support updating relations in `MemoryService`
- expose `PUT /relations/{relation_id}` endpoint
- test updating relations

## Testing
- `flake8 services/memory_service.py routers/memory/relations/relations.py tests/test_memory_service.py`
- `pytest tests/test_memory_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ad8f8804832ca6c9e6cacb5c47f1