### PR TITLE
Add global error boundary and auth improvements

### DIFF
--- a/frontend/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/frontend/src/components/__tests__/ErrorBoundary.test.tsx
@@ -15,4 +15,14 @@ describe('ErrorBoundary', () => {
     );
     expect(screen.getByRole('alert')).toHaveTextContent('Something went wrong');
   });
+
+  it('renders custom fallback when provided', () => {
+    const Custom = () => <div data-testid="custom">Oops</div>;
+    render(
+      <ErrorBoundary fallback={<Custom />}>
+        <ProblemChild />
+      </ErrorBoundary>
+    );
+    expect(screen.getByTestId('custom')).toHaveTextContent('Oops');
+  });
 });

--- a/frontend/src/components/user/LoginForm.tsx
+++ b/frontend/src/components/user/LoginForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState } from 'react';
 import {
   Box,
   VStack,
@@ -9,18 +9,20 @@ import {
   Heading,
   Text,
   useToast,
-} from "@chakra-ui/react";
-import { useRouter } from "next/navigation";
-import { login } from "@/services/api/users";
-import { LoginRequest, TokenResponse } from "@/types/user";
-import { useAuthStore } from "@/store/authStore";
+} from '@chakra-ui/react';
+import { useRouter } from 'next/navigation';
+import { login } from '@/services/api/users';
+import { LoginRequest, TokenResponse } from '@/types/user';
+import { useAuthStore } from '@/store/authStore';
 
 const LoginForm: React.FC = () => {
-  const [username, setUsername] = useState("");
-  const [password, setPassword] = useState("");
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const token = useAuthStore((state) => state.token);
   const setToken = useAuthStore((state) => state.setToken);
+  const logout = useAuthStore((state) => state.logout);
   const toast = useToast();
   const router = useRouter();
 
@@ -34,16 +36,15 @@ const LoginForm: React.FC = () => {
     try {
       const response: TokenResponse = await login(loginData);
       setToken(response.access_token);
-      localStorage.setItem("token", response.access_token);
-      router.push("/");
+      router.push('/');
     } catch (err: any) {
-      console.error("Login failed:", err);
-      const message = err.message || "An error occurred during login.";
+      console.error('Login failed:', err);
+      const message = err.message || 'An error occurred during login.';
       setError(message);
       toast({
-        title: "Login failed",
+        title: 'Login failed',
         description: message,
-        status: "error",
+        status: 'error',
         duration: 5000,
         isClosable: true,
       });
@@ -51,6 +52,33 @@ const LoginForm: React.FC = () => {
       setIsLoading(false);
     }
   };
+
+  if (token) {
+    return (
+      <Box
+        p={8}
+        maxWidth="500px"
+        borderWidth={1}
+        borderRadius={8}
+        boxShadow="lg"
+      >
+        <VStack spacing={4}>
+          <Text>You are logged in.</Text>
+          <Button
+            colorScheme="red"
+            width="full"
+            onClick={() => {
+              logout();
+              router.push('/login');
+            }}
+            data-testid="logout-button"
+          >
+            Logout
+          </Button>
+        </VStack>
+      </Box>
+    );
+  }
 
   return (
     <Box p={8} maxWidth="500px" borderWidth={1} borderRadius={8} boxShadow="lg">

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,25 +1,22 @@
-export * from "./project";
-export * from "./agent";
-export * from "./agents";
-export * from "./task";
-export * from "./user";
-export * from "./audit_log";
-export * from "./memory";
-export * from "./comment";
-export * from "./rules";
-export * from "./mcp";
-export * from "./project_template";
-export * from "./agent_prompt_template";
-<<<<<<< HEAD
-export * from "./handoff";
-=======
-export * from "./verification_requirement";
-export * from "./error_protocol";
->>>>>>> dbf07afe89e4a68f816243b7e80701b4e1995167
+export * from './project';
+export * from './agent';
+export * from './agents';
+export * from './task';
+export * from './user';
+export * from './audit_log';
+export * from './memory';
+export * from './comment';
+export * from './rules';
+export * from './mcp';
+export * from './project_template';
+export * from './agent_prompt_template';
+export * from './handoff';
+export * from './verification_requirement';
+export * from './error_protocol';
 
 // Common types used across the application
 // Canonical shared sort direction type for all entities
-export type SortDirection = "asc" | "desc";
+export type SortDirection = 'asc' | 'desc';
 
 export interface PaginationParams {
   page: number;
@@ -42,10 +39,10 @@ export interface ApiListResponse<T> extends ApiResponse<T[]> {
 }
 
 // Theme types
-export type ThemeMode = "light" | "dark" | "system";
+export type ThemeMode = 'light' | 'dark' | 'system';
 
 // Toast types
-export type ToastType = "success" | "error" | "warning" | "info";
+export type ToastType = 'success' | 'error' | 'warning' | 'info';
 
 export interface ToastMessage {
   id: string;
@@ -55,7 +52,13 @@ export interface ToastMessage {
 }
 
 // Canonical task sort field type (should match all UI/usage fields)
-export type TaskSortField = "created_at" | "title" | "status" | "agent" | "project_id" | "updated_at";
+export type TaskSortField =
+  | 'created_at'
+  | 'title'
+  | 'status'
+  | 'agent'
+  | 'project_id'
+  | 'updated_at';
 
 // Canonical task sort options type
 export interface TaskSortOptions {
@@ -64,5 +67,5 @@ export interface TaskSortOptions {
 }
 
 // Add shared types for group by and view mode
-export type GroupByType = "status" | "project" | "agent" | "parent";
-export type ViewMode = "list" | "kanban";
+export type GroupByType = 'status' | 'project' | 'agent' | 'parent';
+export type ViewMode = 'list' | 'kanban';


### PR DESCRIPTION
## Summary
- implement ErrorBoundary with custom fallback support
- add logout option in LoginForm and persist token using auth store
- test ErrorBoundary and LoginForm behavior

## Testing
- `npm run lint --prefix frontend`
- `npx vitest run -c frontend/vitest.config.ts frontend/src/components/__tests__/ErrorBoundary.test.tsx frontend/src/components/user/__tests__/LoginForm.test.tsx` *(fails: MISSING DEPENDENCY jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_6841adea38a4832ca1c75797fb9dd4b4