### PR TITLE
Add schema and model pytest coverage

### DIFF
--- a/backend/tests/test_capability_schema.py
+++ b/backend/tests/test_capability_schema.py
@@ -1,0 +1,13 @@
+import pytest
+from pydantic import ValidationError
+from backend.schemas.agent_capability import AgentCapabilityCreate
+
+
+def test_capability_create_valid():
+    cap = AgentCapabilityCreate(agent_role_id="r1", capability="run")
+    assert cap.capability == "run"
+
+
+def test_capability_missing_field():
+    with pytest.raises(ValidationError):
+        AgentCapabilityCreate(agent_role_id="r1")

--- a/backend/tests/test_error_protocol_schema.py
+++ b/backend/tests/test_error_protocol_schema.py
@@ -1,0 +1,13 @@
+import pytest
+from pydantic import ValidationError
+from backend.schemas.error_protocol import ErrorProtocolCreate
+
+
+def test_error_protocol_valid():
+    proto = ErrorProtocolCreate(error_type="IO", handling_strategy="retry", priority=1)
+    assert proto.error_type == "IO"
+
+
+def test_error_protocol_missing_required():
+    with pytest.raises(ValidationError):
+        ErrorProtocolCreate(handling_strategy="retry")

--- a/backend/tests/test_forbidden_actions_model.py
+++ b/backend/tests/test_forbidden_actions_model.py
@@ -1,0 +1,28 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.exc import IntegrityError
+from backend.database import Base
+from backend.models.agent_forbidden_action import AgentForbiddenAction
+
+
+def test_create_forbidden_action_success():
+    engine = create_engine('sqlite:///:memory:')
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    with Session() as session:
+        action = AgentForbiddenAction(agent_role_id='r1', action='avoid')
+        session.add(action)
+        session.commit()
+        assert session.query(AgentForbiddenAction).count() == 1
+
+
+def test_create_forbidden_action_missing_field():
+    engine = create_engine('sqlite:///:memory:')
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    with Session() as session:
+        with pytest.raises(IntegrityError):
+            action = AgentForbiddenAction(agent_role_id='r1')
+            session.add(action)
+            session.commit()

--- a/backend/tests/test_handoff_criteria_schema.py
+++ b/backend/tests/test_handoff_criteria_schema.py
@@ -1,0 +1,13 @@
+import pytest
+from pydantic import ValidationError
+from backend.schemas.agent_handoff_criteria import AgentHandoffCriteriaCreate
+
+
+def test_handoff_criteria_valid():
+    crit = AgentHandoffCriteriaCreate(agent_role_id="r1", criteria="done")
+    assert crit.criteria == "done"
+
+
+def test_handoff_missing_agent_role():
+    with pytest.raises(ValidationError):
+        AgentHandoffCriteriaCreate(criteria="oops")

--- a/backend/tests/test_user_role_schema.py
+++ b/backend/tests/test_user_role_schema.py
@@ -1,0 +1,15 @@
+import pytest
+from pydantic import ValidationError
+from backend.schemas.user import UserRoleCreate
+from backend.enums import UserRoleEnum
+
+
+def test_user_role_create_valid():
+    role = UserRoleCreate(user_id="u1", role_name=UserRoleEnum.ADMIN)
+    assert role.user_id == "u1"
+    assert role.role_name is UserRoleEnum.ADMIN
+
+
+def test_user_role_create_invalid_role():
+    with pytest.raises(ValidationError):
+        UserRoleCreate(user_id="u1", role_name="invalid")

--- a/backend/tests/test_verification_requirement_model.py
+++ b/backend/tests/test_verification_requirement_model.py
@@ -1,0 +1,28 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.exc import IntegrityError
+from backend.database import Base
+from backend.models.agent_verification_requirement import AgentVerificationRequirement
+
+
+def test_create_verification_requirement_success():
+    engine = create_engine('sqlite:///:memory:')
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    with Session() as session:
+        req = AgentVerificationRequirement(agent_role_id='r1', requirement='check')
+        session.add(req)
+        session.commit()
+        assert session.query(AgentVerificationRequirement).count() == 1
+
+
+def test_create_verification_requirement_missing_field():
+    engine = create_engine('sqlite:///:memory:')
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    with Session() as session:
+        with pytest.raises(IntegrityError):
+            req = AgentVerificationRequirement(agent_role_id='r1')
+            session.add(req)
+            session.commit()

--- a/backend/tests/test_workflow_schema.py
+++ b/backend/tests/test_workflow_schema.py
@@ -1,0 +1,24 @@
+import pytest
+from pydantic import ValidationError
+from backend.schemas.workflow import WorkflowCreate
+from backend.schemas.workflow_step import WorkflowStepCreate
+
+
+def test_workflow_create_valid():
+    wf = WorkflowCreate(name="WF", workflow_type="basic")
+    assert wf.name == "WF"
+
+
+def test_workflow_create_missing_name():
+    with pytest.raises(ValidationError):
+        WorkflowCreate(workflow_type="basic")
+
+
+def test_workflow_step_valid():
+    step = WorkflowStepCreate(workflow_id="w1", agent_role_id="a1", step_order=1, title="step")
+    assert step.step_order == 1
+
+
+def test_workflow_step_missing_order():
+    with pytest.raises(ValidationError):
+        WorkflowStepCreate(workflow_id="w1", agent_role_id="a1", title="step")


### PR DESCRIPTION
## Summary
- add pytest modules for user role, capability, handoff criteria, forbidden action, verification requirement, error protocol and workflow schemas
- cover success and error cases for models and schemas

## Testing
- `pytest test_capability_schema.py test_handoff_criteria_schema.py test_error_protocol_schema.py test_workflow_schema.py test_user_role_schema.py test_forbidden_actions_model.py test_verification_requirement_model.py -q`
- `pytest -q` *(fails: ModuleNotFoundError, AssertionError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6841ade2060c832cb9a2c3d52cd2b892