### PR TITLE
Add universal mandate tools

### DIFF
--- a/SYSTEM_GUIDE.md
+++ b/SYSTEM_GUIDE.md
@@ -52,6 +52,7 @@ node dev_start.js
 - **Main Application**: `/` (React/Next.js app)
 - **Project Management**: `/projects`
 - **Task Dashboard**: `/tasks`
+- **Universal Mandates**: `/universal-mandates`
 
 ## 🔧 Development Tools
 
@@ -199,6 +200,7 @@ The backend exposes several MCP tools that mirror core API functionality:
 - `project_tools.py` - project CRUD helpers
 - `project_file_tools.py` - associate memory files with projects
 - `rule_tools.py` - manage agent rules and mandates
+- `mandate_tools.py` - create, list, and delete universal mandates
 - `agent_handoff_tools.py` - create, list, and delete agent handoff criteria
 - `forbidden_action_tools.py` - manage forbidden actions for agent roles
 - `error_protocol_tools.py` - manage agent error protocols

--- a/backend/mcp_tools/__init__.py
+++ b/backend/mcp_tools/__init__.py
@@ -27,5 +27,8 @@ __all__ = [
     'remove_error_protocol_tool',
     'assign_role_tool',
     'list_roles_tool',
-    'remove_role_tool'
+    'remove_role_tool',
+    'create_mandate_tool',
+    'list_mandates_tool',
+    'delete_mandate_tool'
 ]

--- a/backend/mcp_tools/mandate_tools.py
+++ b/backend/mcp_tools/mandate_tools.py
@@ -1,0 +1,68 @@
+import logging
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from backend.services.rules_service import RulesService
+from backend.schemas.universal_mandate import UniversalMandateCreate
+
+logger = logging.getLogger(__name__)
+
+
+async def create_mandate_tool(
+    mandate_data: UniversalMandateCreate, db: Session
+) -> dict:
+    """MCP Tool: Create a universal mandate."""
+    try:
+        service = RulesService(db)
+        mandate = service.create_universal_mandate(mandate_data)
+        return {
+            "success": True,
+            "mandate": {
+                "id": mandate.id,
+                "title": mandate.title,
+                "description": mandate.description,
+                "priority": mandate.priority,
+                "is_active": mandate.is_active,
+            },
+        }
+    except Exception as exc:  # pragma: no cover - DB failure
+        logger.error(f"MCP create mandate failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+async def list_mandates_tool(active_only: bool, db: Session) -> dict:
+    """MCP Tool: List universal mandates."""
+    try:
+        service = RulesService(db)
+        mandates = service.list_universal_mandates(active_only=active_only)
+        return {
+            "success": True,
+            "mandates": [
+                {
+                    "id": m.id,
+                    "title": m.title,
+                    "description": m.description,
+                    "priority": m.priority,
+                    "is_active": m.is_active,
+                }
+                for m in mandates
+            ],
+        }
+    except Exception as exc:  # pragma: no cover - DB failure
+        logger.error(f"MCP list mandates failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+async def delete_mandate_tool(mandate_id: str, db: Session) -> dict:
+    """MCP Tool: Delete a universal mandate."""
+    try:
+        service = RulesService(db)
+        success = service.delete_universal_mandate(mandate_id)
+        if not success:
+            raise HTTPException(status_code=404, detail="Mandate not found")
+        return {"success": True}
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - DB failure
+        logger.error(f"MCP delete mandate failed: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/backend/routers/rules/mandates/mandates.py
+++ b/backend/routers/rules/mandates/mandates.py
@@ -42,5 +42,17 @@ def update_mandate(
     """Update a universal mandate"""
     result = crud_rules.update_universal_mandate(db, mandate_id, mandate_update)
     if not result:
-    raise HTTPException(status_code=404, detail="Mandate not found")
+        raise HTTPException(status_code=404, detail="Mandate not found")
     return result
+
+
+@router.delete("/{mandate_id}")
+def delete_mandate(
+    mandate_id: str,
+    db: Session = Depends(get_db)
+):
+    """Delete a universal mandate"""
+    success = crud_rules.delete_universal_mandate(db, mandate_id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Mandate not found")
+    return {"success": True}

--- a/backend/services/rules_service.py
+++ b/backend/services/rules_service.py
@@ -188,6 +188,18 @@ def get_universal_mandates_for_prompt(self) -> List[str]:
     mandates = crud_rules.get_universal_mandates(self.db)
     return [f"**{mandate.title}**: {mandate.description}" for mandate in mandates]
 
+def list_universal_mandates(self, active_only: bool = True):
+    """Return universal mandates."""
+    return crud_rules.get_universal_mandates(self.db, active_only=active_only)
+
+def create_universal_mandate(self, mandate: "UniversalMandateCreate"):
+    """Create a universal mandate."""
+    return crud_rules.create_universal_mandate(self.db, mandate)
+
+def delete_universal_mandate(self, mandate_id: str) -> bool:
+    """Delete a universal mandate by ID."""
+    return crud_rules.delete_universal_mandate(self.db, mandate_id)
+
 def delete_prompt_template(self, template_id: str) -> bool:
     """Delete an agent prompt template by ID."""
     return crud_rules.delete_agent_prompt_template(self.db, template_id)

--- a/frontend/src/app/universal-mandates/page.tsx
+++ b/frontend/src/app/universal-mandates/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+import React from 'react';
+import UniversalMandateList from '@/components/mandate/UniversalMandateList';
+
+const UniversalMandatesPage: React.FC = () => {
+  return <UniversalMandateList />;
+};
+
+export default UniversalMandatesPage;

--- a/frontend/src/components/mandate/UniversalMandateList.tsx
+++ b/frontend/src/components/mandate/UniversalMandateList.tsx
@@ -1,0 +1,143 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Flex,
+  Heading,
+  IconButton,
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+  Input,
+  NumberInput,
+  NumberInputField,
+  useToast,
+} from '@chakra-ui/react';
+import { DeleteIcon } from '@chakra-ui/icons';
+import { useMandateStore } from '@/store/mandateStore';
+import { UniversalMandateCreateData } from '@/types/rules';
+
+const UniversalMandateList: React.FC = () => {
+  const { mandates, fetchMandates, addMandate, removeMandate, loading } =
+    useMandateStore((s) => ({
+      mandates: s.mandates,
+      fetchMandates: s.fetchMandates,
+      addMandate: s.addMandate,
+      removeMandate: s.removeMandate,
+      loading: s.loading,
+    }));
+  const toast = useToast();
+
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [priority, setPriority] = useState(5);
+
+  useEffect(() => {
+    fetchMandates();
+  }, [fetchMandates]);
+
+  const handleAdd = async () => {
+    const data: UniversalMandateCreateData = {
+      title,
+      content: description,
+      priority,
+      is_active: true,
+    } as UniversalMandateCreateData;
+    try {
+      await addMandate(data);
+      setTitle('');
+      setDescription('');
+      setPriority(5);
+      toast({ title: 'Mandate created', status: 'success', duration: 3000 });
+    } catch (err) {
+      toast({
+        title: 'Error creating mandate',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+      });
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await removeMandate(id);
+      toast({ title: 'Mandate deleted', status: 'success', duration: 3000 });
+    } catch (err) {
+      toast({
+        title: 'Error deleting mandate',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+      });
+    }
+  };
+
+  return (
+    <Box p="4">
+      <Heading size="md" mb="4">
+        Universal Mandates
+      </Heading>
+      <Flex mb="4" gap="2">
+        <Input
+          placeholder="Title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          mr="2"
+        />
+        <Input
+          placeholder="Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          mr="2"
+        />
+        <NumberInput
+          maxW="80px"
+          mr="2"
+          min={1}
+          max={10}
+          value={priority}
+          onChange={(v) => setPriority(Number(v))}
+        >
+          <NumberInputField />
+        </NumberInput>
+        <Button onClick={handleAdd} isLoading={loading} colorScheme="blue">
+          Add
+        </Button>
+      </Flex>
+      <Table variant="simple" size="sm">
+        <Thead>
+          <Tr>
+            <Th>Title</Th>
+            <Th>Description</Th>
+            <Th>Priority</Th>
+            <Th></Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {mandates.map((m) => (
+            <Tr key={m.id} data-testid="mandate-row">
+              <Td>{m.title}</Td>
+              <Td>{m.content ?? m.description}</Td>
+              <Td>{m.priority}</Td>
+              <Td>
+                <IconButton
+                  aria-label="Delete"
+                  icon={<DeleteIcon />}
+                  size="sm"
+                  onClick={() => handleDelete(m.id)}
+                />
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </Box>
+  );
+};
+
+export default UniversalMandateList;

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -5,3 +5,4 @@ export * from './baseStore';
 export * from './authStore';
 export * from './memoryStore';
 export * from './templateStore';
+export * from './mandateStore';

--- a/frontend/src/store/mandateStore.ts
+++ b/frontend/src/store/mandateStore.ts
@@ -1,0 +1,40 @@
+import { createBaseStore, BaseState, withLoading } from './baseStore';
+import { rulesApi } from '@/services/api';
+import type { UniversalMandate, UniversalMandateCreateData } from '@/types/rules';
+
+export interface MandateState extends BaseState {
+  mandates: UniversalMandate[];
+  fetchMandates: () => Promise<void>;
+  addMandate: (data: UniversalMandateCreateData) => Promise<void>;
+  removeMandate: (id: string) => Promise<void>;
+}
+
+const initialData: Omit<MandateState, keyof BaseState | 'fetchMandates' | 'addMandate' | 'removeMandate'> = {
+  mandates: [],
+};
+
+const actionsCreator = (set: any) => ({
+  fetchMandates: async () =>
+    withLoading(set, async () => {
+      const resp = await rulesApi.mandates.list();
+      set({ mandates: resp.data });
+    }),
+  addMandate: async (data: UniversalMandateCreateData) =>
+    withLoading(set, async () => {
+      const m = await rulesApi.mandates.create(data);
+      set((state: MandateState) => ({ mandates: [...state.mandates, m] }));
+    }),
+  removeMandate: async (id: string) =>
+    withLoading(set, async () => {
+      await rulesApi.mandates.delete(id);
+      set((state: MandateState) => ({
+        mandates: state.mandates.filter((m) => m.id !== id),
+      }));
+    }),
+});
+
+export const useMandateStore = createBaseStore<MandateState, ReturnType<typeof actionsCreator>>(
+  initialData as any,
+  actionsCreator,
+  { name: 'mandate-store' },
+);


### PR DESCRIPTION
## Summary
- add `create_mandate_tool`, `list_mandates_tool`, and `delete_mandate_tool`
- expose new mandate tools in MCP package
- implement CRUD helpers for universal mandates
- create `/universal-mandates` page and supporting store/component
- document new page and tools

## Testing
- `npm run lint`
- `npm run test:run` *(fails: Transform failed with 1 error, several failing tests)*
- `flake8`
- `pytest` *(fails: 12 failed, 35 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6841addbe204832c82f781e74086bb33