### PR TITLE
Add memory search component

### DIFF
--- a/frontend/src/components/__tests__/MemorySearch.test.tsx
+++ b/frontend/src/components/__tests__/MemorySearch.test.tsx
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
-import { render, screen, waitFor, TestWrapper } from '@/__tests__/utils/test-utils';
+import {
+  render,
+  screen,
+  waitFor,
+  TestWrapper,
+} from '@/__tests__/utils/test-utils';
 import MemorySearch from '../MemorySearch';
 
 vi.mock('@chakra-ui/react', async () => {
@@ -13,14 +18,12 @@ vi.mock('@chakra-ui/react', async () => {
 });
 
 vi.mock('@/services/api', () => ({
-  mcpApi: {
-    memory: {
-      searchGraph: vi.fn(),
-    },
+  memoryApi: {
+    searchGraph: vi.fn(),
   },
 }));
 
-const { mcpApi } = await import('@/services/api');
+const { memoryApi } = await import('@/services/api');
 
 describe('MemorySearch', () => {
   const user = userEvent.setup();
@@ -30,11 +33,9 @@ describe('MemorySearch', () => {
   });
 
   it('sends search request and renders results', async () => {
-    (mcpApi.memory.searchGraph as any).mockResolvedValue({
-      data: [
-        { id: 1, entity_type: 'file', content: 'doc', created_at: '2024' },
-      ],
-    });
+    (memoryApi.searchGraph as any).mockResolvedValue([
+      { id: 1, entity_type: 'file', content: 'doc', created_at: '2024' },
+    ]);
 
     render(
       <TestWrapper>
@@ -47,8 +48,10 @@ describe('MemorySearch', () => {
     await user.click(screen.getByTestId('memory-search-button'));
 
     await waitFor(() =>
-      expect(mcpApi.memory.searchGraph).toHaveBeenCalledWith('query')
+      expect(memoryApi.searchGraph).toHaveBeenCalledWith('query')
     );
-    await waitFor(() => expect(screen.getByRole('link')).toHaveAttribute('href', '/memory/1'));
+    await waitFor(() =>
+      expect(screen.getByRole('link')).toHaveAttribute('href', '/memory/1')
+    );
   });
 });

--- a/frontend/src/components/memory/MemorySearch.tsx
+++ b/frontend/src/components/memory/MemorySearch.tsx
@@ -1,6 +1,6 @@
-"use client";
+'use client';
 
-import React, { useState } from "react";
+import React, { useState } from 'react';
 import {
   Box,
   Button,
@@ -10,13 +10,13 @@ import {
   Spinner,
   Text,
   Link,
-} from "@chakra-ui/react";
-import NextLink from "next/link";
-import { mcpApi } from "@/services/api";
-import type { MemoryEntity } from "@/types/memory";
+} from '@chakra-ui/react';
+import NextLink from 'next/link';
+import { memoryApi } from '@/services/api';
+import type { MemoryEntity } from '@/types/memory';
 
 const MemorySearch: React.FC = () => {
-  const [query, setQuery] = useState("");
+  const [query, setQuery] = useState('');
   const [results, setResults] = useState<MemoryEntity[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -27,18 +27,23 @@ const MemorySearch: React.FC = () => {
     setLoading(true);
     setError(null);
     try {
-      const resp = await mcpApi.memory.searchGraph(query);
-      const data = (resp as any).data as MemoryEntity[];
+      const data = await memoryApi.searchGraph(query);
       setResults(data || []);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Search failed");
+      setError(err instanceof Error ? err.message : 'Search failed');
     } finally {
       setLoading(false);
     }
   };
 
   return (
-    <Box as="form" onSubmit={handleSearch} p={4} borderWidth="1px" borderRadius="md">
+    <Box
+      as="form"
+      onSubmit={handleSearch}
+      p={4}
+      borderWidth="1px"
+      borderRadius="md"
+    >
       <Input
         placeholder="Search memory"
         value={query}
@@ -46,7 +51,12 @@ const MemorySearch: React.FC = () => {
         mb={2}
         data-testid="memory-search-input"
       />
-      <Button type="submit" isLoading={loading} mb={4} data-testid="memory-search-button">
+      <Button
+        type="submit"
+        isLoading={loading}
+        mb={4}
+        data-testid="memory-search-button"
+      >
         Search
       </Button>
       {error && (

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,25 +1,22 @@
-export * from "./project";
-export * from "./agent";
-export * from "./agents";
-export * from "./task";
-export * from "./user";
-export * from "./audit_log";
-export * from "./memory";
-export * from "./comment";
-export * from "./rules";
-export * from "./mcp";
-export * from "./project_template";
-export * from "./agent_prompt_template";
-<<<<<<< HEAD
-export * from "./handoff";
-=======
-export * from "./verification_requirement";
-export * from "./error_protocol";
->>>>>>> dbf07afe89e4a68f816243b7e80701b4e1995167
+export * from './project';
+export * from './agent';
+export * from './agents';
+export * from './task';
+export * from './user';
+export * from './audit_log';
+export * from './memory';
+export * from './comment';
+export * from './rules';
+export * from './mcp';
+export * from './project_template';
+export * from './agent_prompt_template';
+export * from './handoff';
+export * from './verification_requirement';
+export * from './error_protocol';
 
 // Common types used across the application
 // Canonical shared sort direction type for all entities
-export type SortDirection = "asc" | "desc";
+export type SortDirection = 'asc' | 'desc';
 
 export interface PaginationParams {
   page: number;
@@ -42,10 +39,10 @@ export interface ApiListResponse<T> extends ApiResponse<T[]> {
 }
 
 // Theme types
-export type ThemeMode = "light" | "dark" | "system";
+export type ThemeMode = 'light' | 'dark' | 'system';
 
 // Toast types
-export type ToastType = "success" | "error" | "warning" | "info";
+export type ToastType = 'success' | 'error' | 'warning' | 'info';
 
 export interface ToastMessage {
   id: string;
@@ -55,7 +52,13 @@ export interface ToastMessage {
 }
 
 // Canonical task sort field type (should match all UI/usage fields)
-export type TaskSortField = "created_at" | "title" | "status" | "agent" | "project_id" | "updated_at";
+export type TaskSortField =
+  | 'created_at'
+  | 'title'
+  | 'status'
+  | 'agent'
+  | 'project_id'
+  | 'updated_at';
 
 // Canonical task sort options type
 export interface TaskSortOptions {
@@ -64,5 +67,5 @@ export interface TaskSortOptions {
 }
 
 // Add shared types for group by and view mode
-export type GroupByType = "status" | "project" | "agent" | "parent";
-export type ViewMode = "list" | "kanban";
+export type GroupByType = 'status' | 'project' | 'agent' | 'parent';
+export type ViewMode = 'list' | 'kanban';


### PR DESCRIPTION
## Summary
- update MemorySearch to use `memoryApi.searchGraph`
- adjust MemorySearch tests for new API
- fix merge markers in `src/types/index.ts`

## Testing
- `npm run lint`
- `npm test` *(fails: Failed to resolve imports and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841adcc1924832c8e1519ec73931762