### PR TITLE
Add memory observation update/delete api calls

### DIFF
--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -5,6 +5,7 @@ export * from './planning';
 export * from './request';
 export * from './config';
 export * from './memory';
+export { updateObservation, deleteObservation } from './memory';
 export * from './comments';
 export * from './rules';
 export * from './mcp';

--- a/frontend/src/services/api/memory.ts
+++ b/frontend/src/services/api/memory.ts
@@ -1,5 +1,5 @@
-import { request } from "./request";
-import { buildApiUrl, API_CONFIG } from "./config";
+import { request } from './request';
+import { buildApiUrl, API_CONFIG } from './config';
 import type {
   MemoryEntity,
   MemoryEntityCreateData,
@@ -9,11 +9,35 @@ import type {
   MemoryEntityFilters,
   MemoryObservation,
   MemoryObservationCreateData,
+  MemoryObservationUpdateData,
   MemoryRelation,
   MemoryRelationCreateData,
   MemoryRelationFilters,
   KnowledgeGraph,
-} from "@/types/memory";
+} from '@/types/memory';
+
+export const updateObservation = async (
+  observationId: number,
+  data: MemoryObservationUpdateData
+): Promise<MemoryObservation> => {
+  const response = await request<{ data: MemoryObservation }>(
+    buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/observations/${observationId}`),
+    {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    }
+  );
+  return response.data;
+};
+
+export const deleteObservation = async (
+  observationId: number
+): Promise<void> => {
+  await request(
+    buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/observations/${observationId}`),
+    { method: 'DELETE' }
+  );
+};
 
 // --- Memory Entity APIs ---
 export const memoryApi = {
@@ -22,7 +46,7 @@ export const memoryApi = {
     const response = await request<MemoryEntityResponse>(
       buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify(data),
       }
     );
@@ -61,7 +85,7 @@ export const memoryApi = {
     const response = await request<MemoryEntityResponse>(
       buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/${entityId}`),
       {
-        method: "PUT",
+        method: 'PUT',
         body: JSON.stringify(data),
       }
     );
@@ -70,20 +94,17 @@ export const memoryApi = {
 
   // Delete a memory entity
   deleteEntity: async (entityId: number): Promise<void> => {
-    await request(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/${entityId}`),
-      {
-        method: "DELETE",
-      }
-    );
+    await request(buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/${entityId}`), {
+      method: 'DELETE',
+    });
   },
 
   // Ingest a file from the server filesystem
   ingestFile: async (filePath: string): Promise<MemoryEntity> => {
     const response = await request<MemoryEntityResponse>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/entities/ingest/file"),
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/entities/ingest/file'),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify({ file_path: filePath }),
       }
     );
@@ -93,9 +114,9 @@ export const memoryApi = {
   // Ingest content directly from a URL
   ingestUrl: async (url: string): Promise<MemoryEntity> => {
     const response = await request<MemoryEntityResponse>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/ingest-url"),
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/ingest-url'),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify({ url }),
       }
     );
@@ -105,9 +126,9 @@ export const memoryApi = {
   // Ingest a raw text snippet
   ingestText: async (text: string): Promise<MemoryEntity> => {
     const response = await request<MemoryEntityResponse>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/ingest-text"),
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/ingest-text'),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify({ text }),
       }
     );
@@ -116,11 +137,13 @@ export const memoryApi = {
 
   // --- Memory Observation APIs ---
   // Add an observation to an entity
-  addObservation: async (data: MemoryObservationCreateData): Promise<MemoryObservation> => {
+  addObservation: async (
+    data: MemoryObservationCreateData
+  ): Promise<MemoryObservation> => {
     const response = await request<{ data: MemoryObservation }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/observations"),
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/observations'),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify(data),
       }
     );
@@ -130,27 +153,25 @@ export const memoryApi = {
   // Get observations for an entity
   getObservations: async (entityId: number): Promise<MemoryObservation[]> => {
     const response = await request<{ data: MemoryObservation[] }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/entities/${entityId}/observations`)
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.MEMORY,
+        `/entities/${entityId}/observations`
+      )
     );
     return response.data;
   },
 
-  // Delete an observation
-  deleteObservation: async (observationId: number): Promise<void> => {
-    await request(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/observations/${observationId}`),
-      {
-        method: "DELETE",
-      }
-    );
-  },
+  updateObservation,
+  deleteObservation,
   // --- Memory Relation APIs ---
   // Create a relation between entities
-  createRelation: async (data: MemoryRelationCreateData): Promise<MemoryRelation> => {
+  createRelation: async (
+    data: MemoryRelationCreateData
+  ): Promise<MemoryRelation> => {
     const response = await request<{ data: MemoryRelation }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/relations"),
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/relations'),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify(data),
       }
     );
@@ -158,7 +179,9 @@ export const memoryApi = {
   },
 
   // Get relations with filters
-  getRelations: async (filters?: MemoryRelationFilters): Promise<MemoryRelation[]> => {
+  getRelations: async (
+    filters?: MemoryRelationFilters
+  ): Promise<MemoryRelation[]> => {
     const params = new URLSearchParams();
     if (filters) {
       Object.entries(filters).forEach(([key, value]) => {
@@ -168,7 +191,10 @@ export const memoryApi = {
       });
     }
     const response = await request<{ data: MemoryRelation[] }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/relations?${params.toString()}`)
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.MEMORY,
+        `/relations?${params.toString()}`
+      )
     );
     return response.data;
   },
@@ -178,7 +204,7 @@ export const memoryApi = {
     await request(
       buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/relations/${relationId}`),
       {
-        method: "DELETE",
+        method: 'DELETE',
       }
     );
   },
@@ -187,7 +213,7 @@ export const memoryApi = {
   // Get the full knowledge graph
   getKnowledgeGraph: async (): Promise<KnowledgeGraph> => {
     const response = await request<{ data: KnowledgeGraph }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/graph")
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/graph')
     );
     return response.data;
   },
@@ -195,7 +221,10 @@ export const memoryApi = {
   // Search the knowledge graph
   searchGraph: async (query: string): Promise<MemoryEntity[]> => {
     const response = await request<{ data: MemoryEntity[] }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/search?q=${encodeURIComponent(query)}`)
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.MEMORY,
+        `/search?q=${encodeURIComponent(query)}`
+      )
     );
     return response.data;
   },

--- a/frontend/src/types/memory.ts
+++ b/frontend/src/types/memory.ts
@@ -45,6 +45,13 @@ export const memoryObservationSchema = memoryObservationBaseSchema.extend({
 
 export type MemoryObservation = z.infer<typeof memoryObservationSchema>;
 
+export const memoryObservationUpdateSchema =
+  memoryObservationBaseSchema.partial();
+
+export type MemoryObservationUpdateData = z.infer<
+  typeof memoryObservationUpdateSchema
+>;
+
 // --- Memory Relation Schemas ---
 export const memoryRelationBaseSchema = z.object({
   from_entity_id: z.number(),


### PR DESCRIPTION
## Summary
- add `updateObservation` and `deleteObservation` services
- export new functions from API index
- define `MemoryObservationUpdateData` type

## Testing
- `npm run lint`
- `npx prettier frontend/src/services/api/memory.ts frontend/src/services/api/index.ts frontend/src/types/memory.ts --write`
- `npm test` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6841ad8f0820832c822c35660b52f124