### PR TITLE
Add memory observation editor component

### DIFF
--- a/frontend/src/components/memory/MemoryObservationEditor.tsx
+++ b/frontend/src/components/memory/MemoryObservationEditor.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import React, { useState } from 'react';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  HStack,
+  Textarea,
+  useToast,
+} from '@chakra-ui/react';
+import { memoryApi } from '@/services/api';
+import type { MemoryObservation, MemoryObservationUpdateData } from '@/types/memory';
+
+interface MemoryObservationEditorProps {
+  observation: MemoryObservation;
+  onUpdated?: (observation: MemoryObservation) => void;
+  onDeleted?: () => void;
+}
+
+const MemoryObservationEditor: React.FC<MemoryObservationEditorProps> = ({
+  observation,
+  onUpdated,
+  onDeleted,
+}) => {
+  const toast = useToast();
+  const [content, setContent] = useState(observation.content);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    const data: MemoryObservationUpdateData = { content };
+    try {
+      const updated = await memoryApi.updateObservation(observation.id, data);
+      toast({ title: 'Observation updated', status: 'success', duration: 3000, isClosable: true });
+      onUpdated?.(updated);
+    } catch (err) {
+      toast({
+        title: 'Update failed',
+        description: err instanceof Error ? err.message : 'Failed to update observation',
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    try {
+      await memoryApi.deleteObservation(observation.id);
+      toast({ title: 'Observation deleted', status: 'info', duration: 3000, isClosable: true });
+      onDeleted?.();
+    } catch (err) {
+      toast({
+        title: 'Delete failed',
+        description: err instanceof Error ? err.message : 'Failed to delete observation',
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <Box>
+      <FormControl>
+        <FormLabel>Content</FormLabel>
+        <Textarea value={content} onChange={(e) => setContent(e.target.value)} />
+      </FormControl>
+      <HStack mt={2} spacing={2}>
+        <Button colorScheme="blue" onClick={handleSave} isLoading={isSaving}>
+          Save
+        </Button>
+        <Button colorScheme="red" onClick={handleDelete} isLoading={isDeleting}>
+          Delete
+        </Button>
+      </HStack>
+    </Box>
+  );
+};
+
+export default MemoryObservationEditor;

--- a/frontend/src/components/memory/__tests__/MemoryObservationEditor.test.tsx
+++ b/frontend/src/components/memory/__tests__/MemoryObservationEditor.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen, TestWrapper } from '@/__tests__/utils/test-utils';
+import MemoryObservationEditor from '../MemoryObservationEditor';
+import type { MemoryObservation } from '@/types/memory';
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual('@chakra-ui/react');
+  return {
+    ...actual,
+    useToast: () => vi.fn(),
+    useColorModeValue: (l: any, d: any) => l,
+  };
+});
+
+const updateMock = vi.fn();
+const deleteMock = vi.fn();
+
+vi.mock('@/services/api', () => ({
+  memoryApi: {
+    updateObservation: updateMock,
+    deleteObservation: deleteMock,
+  },
+}));
+
+describe('MemoryObservationEditor', () => {
+  const user = userEvent.setup();
+  const observation: MemoryObservation = {
+    id: 1,
+    entity_id: 1,
+    content: 'initial',
+    created_at: '2024-01-01T00:00:00Z',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders without crashing', () => {
+    render(
+      <TestWrapper>
+        <MemoryObservationEditor observation={observation} />
+      </TestWrapper>
+    );
+    expect(screen.getByText(/content/i)).toBeInTheDocument();
+  });
+
+  it('calls update and delete handlers', async () => {
+    render(
+      <TestWrapper>
+        <MemoryObservationEditor observation={observation} />
+      </TestWrapper>
+    );
+
+    const textarea = screen.getByRole('textbox');
+    await user.clear(textarea);
+    await user.type(textarea, 'updated');
+    await user.click(screen.getByRole('button', { name: /save/i }));
+    expect(updateMock).toHaveBeenCalledWith(1, { content: 'updated' });
+
+    await user.click(screen.getByRole('button', { name: /delete/i }));
+    expect(deleteMock).toHaveBeenCalledWith(1);
+  });
+});

--- a/frontend/src/services/api/memory.ts
+++ b/frontend/src/services/api/memory.ts
@@ -135,6 +135,21 @@ export const memoryApi = {
     return response.data;
   },
 
+  // Update an observation
+  updateObservation: async (
+    observationId: number,
+    data: MemoryObservationUpdateData
+  ): Promise<MemoryObservation> => {
+    const response = await request<{ data: MemoryObservation }>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/observations/${observationId}`),
+      {
+        method: 'PUT',
+        body: JSON.stringify(data),
+      }
+    );
+    return response.data;
+  },
+
   // Delete an observation
   deleteObservation: async (observationId: number): Promise<void> => {
     await request(

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -10,12 +10,8 @@ export * from "./rules";
 export * from "./mcp";
 export * from "./project_template";
 export * from "./agent_prompt_template";
-<<<<<<< HEAD
 export * from "./handoff";
-=======
 export * from "./verification_requirement";
-export * from "./error_protocol";
->>>>>>> dbf07afe89e4a68f816243b7e80701b4e1995167
 
 // Common types used across the application
 // Canonical shared sort direction type for all entities

--- a/frontend/src/types/memory.ts
+++ b/frontend/src/types/memory.ts
@@ -38,6 +38,13 @@ export type MemoryObservationCreateData = z.infer<
   typeof memoryObservationCreateSchema
 >;
 
+export const memoryObservationUpdateSchema =
+  memoryObservationBaseSchema.partial();
+
+export type MemoryObservationUpdateData = z.infer<
+  typeof memoryObservationUpdateSchema
+>;
+
 export const memoryObservationSchema = memoryObservationBaseSchema.extend({
   id: z.number(),
   created_at: z.string().datetime({ message: 'Invalid ISO datetime string' }),


### PR DESCRIPTION
## Summary
- add update and delete functionality for memory observations
- expose new `updateObservation` API
- handle merge conflicts in type exports
- provide MemoryObservationEditor unit test

## Testing
- `npm run lint`
- `npm run test:run -- -t MemoryObservationEditor` *(fails: Failed Suites 3)*

------
https://chatgpt.com/codex/tasks/task_e_6841ad8ef378832c8ceb42e8eb1c2ecd