### PR TITLE
Add observation management tools

### DIFF
--- a/backend/docs/fastapi_mcp/README.md
+++ b/backend/docs/fastapi_mcp/README.md
@@ -91,6 +91,8 @@ FastAPI-MCP automatically exposes selected API endpoints as tools under the `/mc
 - `/mcp-tools/memory/add-entity` (POST)
 - `/mcp-tools/memory/update-entity` (POST)
 - `/mcp-tools/memory/add-observation` (POST)
+- `/mcp-tools/memory/update-observation` (POST)
+- `/mcp-tools/memory/delete-observation` (DELETE)
 - `/mcp-tools/memory/add-relation` (POST)
 - `/mcp-tools/memory/search` (GET)
 - `/mcp-tools/forbidden-action/create` (POST)

--- a/backend/mcp_tools/memory_tools.py
+++ b/backend/mcp_tools/memory_tools.py
@@ -202,3 +202,54 @@ async def get_memory_metadata_tool(
     except Exception as e:
         logger.error(f"MCP get memory metadata failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+
+async def update_observation_tool(
+    observation_id: int,
+    update_data: Dict[str, Any],
+    db: Session,
+) -> dict:
+    """MCP Tool: Update a memory observation."""
+    try:
+        service = MemoryService(db)
+        observation = service.update_observation(observation_id, update_data)
+        return {
+            "success": True,
+            "observation": {
+                "id": observation.id,
+                "entity_id": observation.entity_id,
+                "content": observation.content,
+                "metadata": observation.metadata_,
+                "source": observation.source,
+                "timestamp": observation.timestamp.isoformat(),
+            },
+        }
+    except HTTPException as e:
+        logger.error(
+            f"MCP update observation failed with HTTP exception: {e.detail}"
+        )
+        raise e
+    except Exception as e:
+        logger.error(f"MCP update observation failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+async def delete_observation_tool(
+    observation_id: int,
+    db: Session,
+) -> dict:
+    """MCP Tool: Delete a memory observation."""
+    try:
+        service = MemoryService(db)
+        success = service.delete_observation(observation_id)
+        if not success:
+            raise HTTPException(status_code=404, detail="Observation not found")
+        return {"success": True}
+    except HTTPException as e:
+        logger.error(
+            f"MCP delete observation failed with HTTP exception: {e.detail}"
+        )
+        raise e
+    except Exception as e:
+        logger.error(f"MCP delete observation failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/routers/mcp/core.py
+++ b/backend/routers/mcp/core.py
@@ -581,6 +581,61 @@ async def mcp_add_memory_observation(
 
 
 @router.post(
+    "/mcp-tools/memory/update-observation",
+    tags=["mcp-tools"],
+    operation_id="update_observation_tool",
+)
+async def mcp_update_memory_observation(
+    observation_id: int,
+    update_data: Dict[str, Any],
+    memory_service: MemoryService = Depends(get_memory_service),
+):
+    """MCP Tool: Update a memory observation."""
+    try:
+        observation = memory_service.update_observation(observation_id, update_data)
+        return {
+            "success": True,
+            "observation": {
+                "id": observation.id,
+                "entity_id": observation.entity_id,
+                "content": observation.content,
+                "metadata": observation.metadata_,
+                "source": observation.source,
+                "timestamp": observation.timestamp.isoformat(),
+            },
+        }
+    except HTTPException as e:
+        logger.error(f"MCP update memory observation failed: {e.detail}")
+        raise e
+    except Exception as e:
+        logger.error(f"MCP update memory observation failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.delete(
+    "/mcp-tools/memory/delete-observation",
+    tags=["mcp-tools"],
+    operation_id="delete_observation_tool",
+)
+async def mcp_delete_memory_observation(
+    observation_id: int,
+    memory_service: MemoryService = Depends(get_memory_service),
+):
+    """MCP Tool: Delete a memory observation."""
+    try:
+        success = memory_service.delete_observation(observation_id)
+        if not success:
+            raise HTTPException(status_code=404, detail="Observation not found")
+        return {"success": True}
+    except HTTPException as e:
+        logger.error(f"MCP delete memory observation failed: {e.detail}")
+        raise e
+    except Exception as e:
+        logger.error(f"MCP delete memory observation failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
     "/mcp-tools/memory/add-relation",
     tags=["mcp-tools"],
     operation_id="add_memory_relation_tool",

--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -69,6 +69,7 @@ from .memory import (
     MemoryEntity,
     MemoryObservationBase,
     MemoryObservationCreate,
+    MemoryObservationUpdate,
     MemoryObservation,
     MemoryRelationBase,
     MemoryRelationCreate,

--- a/backend/schemas/_schema_init.py
+++ b/backend/schemas/_schema_init.py
@@ -17,6 +17,7 @@ from .memory import (  # noqa: F401
     MemoryEntityUpdate,
     MemoryObservation,
     MemoryObservationCreate,
+    MemoryObservationUpdate,
     MemoryRelationCreate
 )
 from .project import (  # noqa: F401

--- a/backend/schemas/memory.py
+++ b/backend/schemas/memory.py
@@ -46,6 +46,14 @@ class MemoryObservationCreate(MemoryObservationBase):
     """Schema for creating a new memory observation."""
     entity_id: int = Field(..., description="The ID of the memory entity this observation belongs to.")
 
+class MemoryObservationUpdate(BaseModel):
+    """Schema for updating an existing memory observation."""
+    entity_id: Optional[int] = Field(None, description="Update the related entity ID.")
+    content: Optional[str] = Field(None, description="Update the observation content.")
+    metadata_: Optional[Dict[str, Any]] = Field(None, description="Update observation metadata.")
+    source: Optional[str] = Field(None, description="Update observation source.")
+    timestamp: Optional[datetime] = Field(None, description="Update observation timestamp.")
+
 class MemoryObservation(MemoryObservationBase):
     """Schema for representing a memory observation in API responses, including relationships."""
     id: int = Field(..., description="Unique integer ID of the observation.")


### PR DESCRIPTION
## Summary
- implement update/delete observation methods in memory service
- add observation management tools
- expose update/delete observation endpoints
- document new endpoints in FastAPI-MCP docs

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6841ad8dd590832c9bda28de65eb6d78