### PR TITLE
Add pagination parameters for project file listing

### DIFF
--- a/backend/crud/project_file_associations.py
+++ b/backend/crud/project_file_associations.py
@@ -37,14 +37,20 @@ async def get_project_file_association(db: AsyncSession, project_id: str, file_m
     return association
 
 
-async def get_project_files(db: AsyncSession, project_id: str, skip: int = 0, limit: int = 100) -> List[ProjectFileAssociation]:
+async def get_project_files(
+    db: AsyncSession,
+    project_id: str,
+    skip: int = 0,
+    limit: Optional[int] = 100,
+) -> List[ProjectFileAssociation]:
     """Get all files associated with a project."""
     logger.debug(f"[DEBUG] get_project_files called with project_id: {project_id}, skip: {skip}, limit: {limit}")  # Debug print
-    result = await db.execute(
-    select(ProjectFileAssociation).filter(
-    ProjectFileAssociation.project_id == project_id
-    ).offset(skip).limit(limit)
-    )
+    query = select(ProjectFileAssociation).filter(
+        ProjectFileAssociation.project_id == project_id
+    ).offset(skip)
+    if limit is not None:
+        query = query.limit(limit)
+    result = await db.execute(query)
     files = result.scalars().all()
     logger.debug(f"[DEBUG] get_project_files returned {len(files)} files")  # Debug print
     return files

--- a/backend/mcp_tools/project_file_tools.py
+++ b/backend/mcp_tools/project_file_tools.py
@@ -43,7 +43,7 @@ async def list_project_files_tool(
     """List files associated with a project."""
     try:
         service = _get_service(db)
-        files = service.get_files_for_project(project_id, skip=skip, limit=limit)
+        files = await service.get_project_files(project_id, skip=skip, limit=limit)
         return {
             "success": True,
             "files": [

--- a/backend/routers/mcp/core.py
+++ b/backend/routers/mcp/core.py
@@ -353,7 +353,7 @@ async def mcp_list_project_files(
 ):
     """MCP Tool: List files associated with a project."""
     try:
-        associations = service.get_files_for_project(project_id, skip, limit)
+        associations = await service.get_project_files(project_id, skip, limit)
         return {
             "success": True,
             "files": [

--- a/backend/services/project_file_association_service.py
+++ b/backend/services/project_file_association_service.py
@@ -17,14 +17,16 @@ class ProjectFileAssociationService:
     def get_association(self, project_id: str, file_memory_entity_id: int):
         return get_project_file_association(self.db, project_id, file_memory_entity_id)
 
-    def get_files_for_project(self, project_id: str, skip: int = 0, limit: int = 100):
-        return get_project_files(self.db, project_id, skip=skip, limit=limit)
+    async def get_files_for_project(
+        self, project_id: str, skip: int = 0, limit: Optional[int] = 100
+    ):
+        return await get_project_files(self.db, project_id, skip=skip, limit=limit)
 
     async def get_project_files(
-        self, project_id: str, skip: int = 0, limit: int = 100
+        self, project_id: str, skip: int = 0, limit: Optional[int] = 100
     ):
         """Async wrapper for get_files_for_project with pagination."""
-        return self.get_files_for_project(project_id, skip=skip, limit=limit)
+        return await self.get_files_for_project(project_id, skip=skip, limit=limit)
 
     def associate_file_with_project(self, project_id: str, file_memory_entity_id: int):
         project_file = ProjectFileAssociationCreate(

--- a/backend/tests/test_project_file_service.py
+++ b/backend/tests/test_project_file_service.py
@@ -52,6 +52,10 @@ import pytest
 async def test_get_project_files_passes_pagination():
     session = MagicMock()
     service = ProjectFileAssociationService(session)
-    service.get_files_for_project = MagicMock(return_value=[])
-    await service.get_project_files("p1", skip=5, limit=10)
-    service.get_files_for_project.assert_called_once_with("p1", skip=5, limit=10)
+    with patch(
+        "backend.services.project_file_association_service.get_project_files",
+        new_callable=MagicMock,
+    ) as mock_crud:
+        mock_crud.return_value = []
+        await service.get_project_files("p1", skip=5, limit=10)
+        mock_crud.assert_called_once_with(session, "p1", skip=5, limit=10)


### PR DESCRIPTION
## Summary
- enable skip/limit in CRUD `get_project_files`
- expose pagination through `ProjectFileAssociationService`
- update MCP tools and routers to await new method
- adjust unit tests for new behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a9d36a00832cba414fd4ffedfa47