### PR TITLE
Add tool metrics

### DIFF
--- a/frontend/src/app/mcp-tools/metrics/README.md
+++ b/frontend/src/app/mcp-tools/metrics/README.md
@@ -1,0 +1,12 @@
+# MCP Tool Metrics Page (`frontend/src/app/mcp-tools/metrics/`)
+
+This directory defines the route `/mcp-tools/metrics` which displays usage metrics for MCP tools.
+The `page.tsx` file renders the `MCPMetrics` component showing invocation counts returned from the backend.
+
+<!-- File List Start -->
+
+## File List
+
+- `page.tsx`
+
+<!-- File List End -->

--- a/frontend/src/app/mcp-tools/metrics/page.tsx
+++ b/frontend/src/app/mcp-tools/metrics/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+import React from 'react';
+import MCPMetrics from '@/components/MCPMetrics';
+
+const MCPMetricsPage: React.FC = () => {
+  return <MCPMetrics />;
+};
+
+export default MCPMetricsPage;

--- a/frontend/src/components/MCPMetrics.tsx
+++ b/frontend/src/components/MCPMetrics.tsx
@@ -1,0 +1,75 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Heading,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Spinner,
+  Text,
+} from '@chakra-ui/react';
+import { mcpApi } from '@/services/api';
+
+const MCPMetrics: React.FC = () => {
+  const [metrics, setMetrics] = useState<Record<string, number>>({});
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchMetrics = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await mcpApi.metrics();
+      setMetrics(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load metrics');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchMetrics();
+  }, []);
+
+  const metricEntries = Object.entries(metrics).sort((a, b) => b[1] - a[1]);
+
+  return (
+    <Box p={4}>
+      <Heading size="md" mb={4}>
+        MCP Tool Metrics
+      </Heading>
+      {loading && <Spinner />}
+      {error && (
+        <Text color="red.500" mb={2}>
+          {error}
+        </Text>
+      )}
+      {!loading && metricEntries.length > 0 && (
+        <Table variant="simple" size="sm">
+          <Thead>
+            <Tr>
+              <Th>Tool</Th>
+              <Th isNumeric>Count</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {metricEntries.map(([tool, count]) => (
+              <Tr key={tool}>
+                <Td>{tool}</Td>
+                <Td isNumeric>{count}</Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      )}
+      {!loading && metricEntries.length === 0 && <Text>No metrics yet.</Text>}
+    </Box>
+  );
+};
+
+export default MCPMetrics;

--- a/frontend/src/services/api/mcp.ts
+++ b/frontend/src/services/api/mcp.ts
@@ -369,4 +369,12 @@ export const mcpApi = {
       return response;
     },
   },
+
+  // --- Metrics ---
+  metrics: async (): Promise<Record<string, number>> => {
+    const response = await request<{ metrics: Record<string, number> }>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/metrics')
+    );
+    return response.metrics;
+  },
 };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -15,6 +15,7 @@ export * from "./handoff";
 =======
 export * from "./verification_requirement";
 export * from "./error_protocol";
+export type { MCPToolMetrics } from "./mcp";
 >>>>>>> dbf07afe89e4a68f816243b7e80701b4e1995167
 
 // Common types used across the application

--- a/frontend/src/types/mcp.ts
+++ b/frontend/src/types/mcp.ts
@@ -185,3 +185,7 @@ export interface MCPToolInfo {
   parameters: Record<string, any>;
   example?: Record<string, any>;
 }
+
+export interface MCPToolMetrics {
+  [tool: string]: number;
+}


### PR DESCRIPTION
## Summary
- track MCP tool invocations with in-memory counters
- expose `/mcp-tools/metrics` endpoint
- add API helper and React page to display metrics

## Testing
- `pytest backend/tests -k memory -q`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841a9d05d10832ca3005c9863da8d4b