### PR TITLE
feat: add memory relation editor

### DIFF
--- a/frontend/src/components/memory/MemoryRelationEditor.tsx
+++ b/frontend/src/components/memory/MemoryRelationEditor.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Textarea,
+  useToast,
+} from '@chakra-ui/react';
+import { memoryApi } from '@/services/api';
+import type { MemoryRelation, MemoryRelationUpdateData } from '@/types/memory';
+
+interface MemoryRelationEditorProps {
+  relation: MemoryRelation | null;
+  onUpdated?: (relation: MemoryRelation) => void;
+}
+
+const MemoryRelationEditor: React.FC<MemoryRelationEditorProps> = ({
+  relation,
+  onUpdated,
+}) => {
+  const toast = useToast();
+  const [relationType, setRelationType] = useState('');
+  const [metadata, setMetadata] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (relation) {
+      setRelationType(relation.relation_type);
+      setMetadata(
+        relation.metadata ? JSON.stringify(relation.metadata, null, 2) : ''
+      );
+    }
+  }, [relation]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!relation) return;
+    setLoading(true);
+    try {
+      const data: MemoryRelationUpdateData = {
+        relation_type: relationType,
+        metadata: metadata ? JSON.parse(metadata) : undefined,
+      };
+      const updated = await memoryApi.updateRelation(relation.id, data);
+      toast({
+        title: 'Relation updated',
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+      });
+      onUpdated?.(updated);
+    } catch (err) {
+      toast({
+        title: 'Update failed',
+        description: err instanceof Error ? err.message : 'Failed to update',
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!relation) return null;
+
+  return (
+    <Box
+      as="form"
+      onSubmit={handleSubmit}
+      p={4}
+      borderWidth="1px"
+      borderRadius="md"
+      bg="bg.surface"
+    >
+      <FormControl mb={2}>
+        <FormLabel>From Entity ID</FormLabel>
+        <Input value={relation.from_entity_id} isReadOnly />
+      </FormControl>
+      <FormControl mb={2}>
+        <FormLabel>To Entity ID</FormLabel>
+        <Input value={relation.to_entity_id} isReadOnly />
+      </FormControl>
+      <FormControl mb={2}>
+        <FormLabel>Relation Type</FormLabel>
+        <Input
+          value={relationType}
+          onChange={(e) => setRelationType(e.target.value)}
+        />
+      </FormControl>
+      <FormControl mb={2}>
+        <FormLabel>Metadata (JSON)</FormLabel>
+        <Textarea
+          value={metadata}
+          onChange={(e) => setMetadata(e.target.value)}
+          placeholder="{}"
+        />
+      </FormControl>
+      <Button type="submit" colorScheme="blue" isLoading={loading}>
+        Save
+      </Button>
+    </Box>
+  );
+};
+
+export default MemoryRelationEditor;

--- a/frontend/src/components/memory/__tests__/MemoryRelationEditor.test.tsx
+++ b/frontend/src/components/memory/__tests__/MemoryRelationEditor.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import {
+  render,
+  screen,
+  waitFor,
+  TestWrapper,
+} from '@/__tests__/utils/test-utils';
+import MemoryRelationEditor from '../MemoryRelationEditor';
+import type { MemoryRelation } from '@/types/memory';
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual('@chakra-ui/react');
+  return {
+    ...actual,
+    useToast: () => vi.fn(),
+    useColorModeValue: (l: any, d: any) => l,
+  };
+});
+
+vi.mock('@/services/api', () => ({
+  memoryApi: {
+    updateRelation: vi.fn(),
+  },
+}));
+
+const { memoryApi } = await import('@/services/api');
+
+describe('MemoryRelationEditor', () => {
+  const user = userEvent.setup();
+  const relation: MemoryRelation = {
+    id: 1,
+    from_entity_id: 2,
+    to_entity_id: 3,
+    relation_type: 'related',
+    metadata: null,
+    created_at: new Date().toISOString(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders and updates relation', async () => {
+    (memoryApi.updateRelation as any).mockResolvedValue(relation);
+    render(
+      <TestWrapper>
+        <MemoryRelationEditor relation={relation} />
+      </TestWrapper>
+    );
+
+    const typeInput = screen.getByLabelText(/Relation Type/i);
+    const metaInput = screen.getByLabelText(/Metadata/i);
+    const button = screen.getByRole('button', { name: /save/i });
+
+    await user.clear(typeInput);
+    await user.type(typeInput, 'updated');
+    await user.clear(metaInput);
+    await user.type(metaInput, '{}');
+    await user.click(button);
+
+    await waitFor(() => expect(memoryApi.updateRelation).toHaveBeenCalled());
+  });
+});

--- a/frontend/src/services/api/memory.ts
+++ b/frontend/src/services/api/memory.ts
@@ -1,5 +1,5 @@
-import { request } from "./request";
-import { buildApiUrl, API_CONFIG } from "./config";
+import { request } from './request';
+import { buildApiUrl, API_CONFIG } from './config';
 import type {
   MemoryEntity,
   MemoryEntityCreateData,
@@ -11,9 +11,10 @@ import type {
   MemoryObservationCreateData,
   MemoryRelation,
   MemoryRelationCreateData,
+  MemoryRelationUpdateData,
   MemoryRelationFilters,
   KnowledgeGraph,
-} from "@/types/memory";
+} from '@/types/memory';
 
 // --- Memory Entity APIs ---
 export const memoryApi = {
@@ -22,7 +23,7 @@ export const memoryApi = {
     const response = await request<MemoryEntityResponse>(
       buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify(data),
       }
     );
@@ -61,7 +62,7 @@ export const memoryApi = {
     const response = await request<MemoryEntityResponse>(
       buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/${entityId}`),
       {
-        method: "PUT",
+        method: 'PUT',
         body: JSON.stringify(data),
       }
     );
@@ -70,20 +71,17 @@ export const memoryApi = {
 
   // Delete a memory entity
   deleteEntity: async (entityId: number): Promise<void> => {
-    await request(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/${entityId}`),
-      {
-        method: "DELETE",
-      }
-    );
+    await request(buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/${entityId}`), {
+      method: 'DELETE',
+    });
   },
 
   // Ingest a file from the server filesystem
   ingestFile: async (filePath: string): Promise<MemoryEntity> => {
     const response = await request<MemoryEntityResponse>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/entities/ingest/file"),
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/entities/ingest/file'),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify({ file_path: filePath }),
       }
     );
@@ -93,9 +91,9 @@ export const memoryApi = {
   // Ingest content directly from a URL
   ingestUrl: async (url: string): Promise<MemoryEntity> => {
     const response = await request<MemoryEntityResponse>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/ingest-url"),
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/ingest-url'),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify({ url }),
       }
     );
@@ -105,9 +103,9 @@ export const memoryApi = {
   // Ingest a raw text snippet
   ingestText: async (text: string): Promise<MemoryEntity> => {
     const response = await request<MemoryEntityResponse>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/ingest-text"),
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/ingest-text'),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify({ text }),
       }
     );
@@ -116,11 +114,13 @@ export const memoryApi = {
 
   // --- Memory Observation APIs ---
   // Add an observation to an entity
-  addObservation: async (data: MemoryObservationCreateData): Promise<MemoryObservation> => {
+  addObservation: async (
+    data: MemoryObservationCreateData
+  ): Promise<MemoryObservation> => {
     const response = await request<{ data: MemoryObservation }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/observations"),
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/observations'),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify(data),
       }
     );
@@ -130,7 +130,10 @@ export const memoryApi = {
   // Get observations for an entity
   getObservations: async (entityId: number): Promise<MemoryObservation[]> => {
     const response = await request<{ data: MemoryObservation[] }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/entities/${entityId}/observations`)
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.MEMORY,
+        `/entities/${entityId}/observations`
+      )
     );
     return response.data;
   },
@@ -138,19 +141,24 @@ export const memoryApi = {
   // Delete an observation
   deleteObservation: async (observationId: number): Promise<void> => {
     await request(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/observations/${observationId}`),
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.MEMORY,
+        `/observations/${observationId}`
+      ),
       {
-        method: "DELETE",
+        method: 'DELETE',
       }
     );
   },
   // --- Memory Relation APIs ---
   // Create a relation between entities
-  createRelation: async (data: MemoryRelationCreateData): Promise<MemoryRelation> => {
+  createRelation: async (
+    data: MemoryRelationCreateData
+  ): Promise<MemoryRelation> => {
     const response = await request<{ data: MemoryRelation }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/relations"),
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/relations'),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify(data),
       }
     );
@@ -158,7 +166,9 @@ export const memoryApi = {
   },
 
   // Get relations with filters
-  getRelations: async (filters?: MemoryRelationFilters): Promise<MemoryRelation[]> => {
+  getRelations: async (
+    filters?: MemoryRelationFilters
+  ): Promise<MemoryRelation[]> => {
     const params = new URLSearchParams();
     if (filters) {
       Object.entries(filters).forEach(([key, value]) => {
@@ -168,7 +178,24 @@ export const memoryApi = {
       });
     }
     const response = await request<{ data: MemoryRelation[] }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/relations?${params.toString()}`)
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.MEMORY,
+        `/relations?${params.toString()}`
+      )
+    );
+    return response.data;
+  },
+
+  updateRelation: async (
+    relationId: number,
+    data: MemoryRelationUpdateData
+  ): Promise<MemoryRelation> => {
+    const response = await request<{ data: MemoryRelation }>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/relations/${relationId}`),
+      {
+        method: 'PUT',
+        body: JSON.stringify(data),
+      }
     );
     return response.data;
   },
@@ -178,7 +205,7 @@ export const memoryApi = {
     await request(
       buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/relations/${relationId}`),
       {
-        method: "DELETE",
+        method: 'DELETE',
       }
     );
   },
@@ -187,7 +214,7 @@ export const memoryApi = {
   // Get the full knowledge graph
   getKnowledgeGraph: async (): Promise<KnowledgeGraph> => {
     const response = await request<{ data: KnowledgeGraph }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/graph")
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/graph')
     );
     return response.data;
   },
@@ -195,7 +222,10 @@ export const memoryApi = {
   // Search the knowledge graph
   searchGraph: async (query: string): Promise<MemoryEntity[]> => {
     const response = await request<{ data: MemoryEntity[] }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/search?q=${encodeURIComponent(query)}`)
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.MEMORY,
+        `/search?q=${encodeURIComponent(query)}`
+      )
     );
     return response.data;
   },

--- a/frontend/src/types/memory.ts
+++ b/frontend/src/types/memory.ts
@@ -59,6 +59,12 @@ export type MemoryRelationCreateData = z.infer<
   typeof memoryRelationCreateSchema
 >;
 
+export const memoryRelationUpdateSchema = memoryRelationBaseSchema.partial();
+
+export type MemoryRelationUpdateData = z.infer<
+  typeof memoryRelationUpdateSchema
+>;
+
 export const memoryRelationSchema = memoryRelationBaseSchema.extend({
   id: z.number(),
   created_at: z.string().datetime({ message: 'Invalid ISO datetime string' }),


### PR DESCRIPTION
## Summary
- implement `MemoryRelationEditor` component
- add `updateRelation` API call
- add memory relation update types
- test MemoryRelationEditor interactions

## Testing
- `npm run lint --silent`
- `npm test --silent` *(fails: observer.observe is not a function, expected [] to deeply equal, TypeScript type check failed)*

------
https://chatgpt.com/codex/tasks/task_e_6841a9cde540832c87e7431d068f3f81