### PR TITLE
Add updateRelation support

### DIFF
--- a/frontend/src/services/api/memory.ts
+++ b/frontend/src/services/api/memory.ts
@@ -11,6 +11,7 @@ import type {
   MemoryObservationCreateData,
   MemoryRelation,
   MemoryRelationCreateData,
+  MemoryRelationUpdateData,
   MemoryRelationFilters,
   KnowledgeGraph,
 } from "@/types/memory";
@@ -169,6 +170,21 @@ export const memoryApi = {
     }
     const response = await request<{ data: MemoryRelation[] }>(
       buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/relations?${params.toString()}`)
+    );
+    return response.data;
+  },
+
+  // Update a relation
+  updateRelation: async (
+    relationId: number,
+    data: MemoryRelationUpdateData
+  ): Promise<MemoryRelation> => {
+    const response = await request<{ data: MemoryRelation }>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/relations/${relationId}`),
+      {
+        method: "PUT",
+        body: JSON.stringify(data),
+      }
     );
     return response.data;
   },

--- a/frontend/src/types/memory.ts
+++ b/frontend/src/types/memory.ts
@@ -59,6 +59,12 @@ export type MemoryRelationCreateData = z.infer<
   typeof memoryRelationCreateSchema
 >;
 
+export const memoryRelationUpdateSchema = memoryRelationBaseSchema.partial();
+
+export type MemoryRelationUpdateData = z.infer<
+  typeof memoryRelationUpdateSchema
+>;
+
 export const memoryRelationSchema = memoryRelationBaseSchema.extend({
   id: z.number(),
   created_at: z.string().datetime({ message: 'Invalid ISO datetime string' }),


### PR DESCRIPTION
## Summary
- extend memory types with update schema
- allow updating relations via `memoryApi`

## Testing
- `npm --prefix frontend run lint` *(fails: next not found)*
- `npm --prefix frontend test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a9cc7674832c901caaaa9eb6d136