### PR TITLE
Implement memory relation updates

### DIFF
--- a/backend/routers/memory/relations/relations.py
+++ b/backend/routers/memory/relations/relations.py
@@ -21,14 +21,14 @@ def create_relation(
 ):
     """Create a relationship between two memory entities."""
     try:
-    return memory_service.create_relation(relation)
+        return memory_service.create_memory_relation(relation)
     except (EntityNotFoundError, DuplicateEntityError) as e:
-    raise HTTPException(status_code=400, detail=str(e))  # Use 400 for bad request if entities not found or duplicate
+        raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
-    raise HTTPException(
-    status_code=500,
-    detail=f"Internal server error: {e}"
-    )
+        raise HTTPException(
+            status_code=500,
+            detail=f"Internal server error: {e}",
+        )
 
 @router.get("/relations/by-type/{relation_type}", response_model=List[MemoryRelation])
 
@@ -42,12 +42,14 @@ def read_relations_by_type(
 ):
     """Retrieve a list of memory relations filtered by type."""
     try:
-    return memory_service.get_relations_by_type(relation_type=relation_type, skip=skip, limit=limit)
+        return memory_service.get_memory_relations_by_type(
+            relation_type=relation_type, skip=skip, limit=limit
+        )
     except Exception as e:
-    raise HTTPException(
-    status_code=500,
-    detail=f"Internal server error: {e}"
-    )
+        raise HTTPException(
+            status_code=500,
+            detail=f"Internal server error: {e}",
+        )
 @router.get("/entities/{from_entity_id}/relations/{to_entity_id}", response_model=List[MemoryRelation])
 
 
@@ -62,12 +64,18 @@ def read_relations_between_entities(
 ):
     """Retrieve relations between two specific memory entities."""
     try:
-    return memory_service.get_relations_between_entities(from_entity_id=from_entity_id, to_entity_id=to_entity_id, relation_type=relation_type, skip=skip, limit=limit)
+        return memory_service.get_memory_relations_between_entities(
+            from_entity_id=from_entity_id,
+            to_entity_id=to_entity_id,
+            relation_type=relation_type,
+            skip=skip,
+            limit=limit,
+        )
     except Exception as e:
-    raise HTTPException(
-    status_code=500,
-    detail=f"Internal server error: {e}"
-    )
+        raise HTTPException(
+            status_code=500,
+            detail=f"Internal server error: {e}",
+        )
 
 @router.get("/entities/{entity_id}/relations/", response_model=List[MemoryRelation])
 
@@ -79,14 +87,37 @@ def get_entity_relations(
 ):
     """Get all relations for a specific entity (where it is either the source or target)."""
     try:
-    return memory_service.get_entity_relations(entity_id=entity_id, relation_type=relation_type)
+        return memory_service.get_relations_for_entity(
+            entity_id=entity_id, relation_type=relation_type
+        )
     except EntityNotFoundError as e:
-    raise HTTPException(status_code=404, detail=str(e))
+        raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
-    raise HTTPException(
-    status_code=500,
-    detail=f"Internal server error: {e}"
-    )
+        raise HTTPException(
+            status_code=500,
+            detail=f"Internal server error: {e}",
+        )
+
+@router.put("/relations/{relation_id}", response_model=MemoryRelation)
+
+
+def update_relation(
+    relation: MemoryRelationCreate,
+    relation_id: int = Path(..., description="ID of the relation to update."),
+    memory_service: MemoryService = Depends(get_memory_service),
+):
+    """Update an existing memory relation."""
+    try:
+        return memory_service.update_memory_relation(relation_id, relation)
+    except EntityNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except DuplicateEntityError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Internal server error: {e}",
+        )
 
 @router.delete("/relations/{relation_id}", status_code=status.HTTP_204_NO_CONTENT)
 
@@ -97,14 +128,14 @@ def delete_relation(
 ):
     """Delete a memory relation."""
     try:
-    success = memory_service.delete_relation(relation_id)
-    if not success:
-    raise EntityNotFoundError("MemoryRelation", relation_id)
-    return {"message": "Memory relation deleted successfully"}
+        success = memory_service.delete_memory_relation(relation_id)
+        if not success:
+            raise EntityNotFoundError("MemoryRelation", relation_id)
+        return {"message": "Memory relation deleted successfully"}
     except EntityNotFoundError as e:
-    raise HTTPException(status_code=404, detail=str(e))
+        raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
-    raise HTTPException(
-    status_code=500,
-    detail=f"Internal server error: {e}"
-    )
+        raise HTTPException(
+            status_code=500,
+            detail=f"Internal server error: {e}",
+        )

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -331,6 +331,62 @@ class MemoryService:
                 detail="Error creating memory relation",
             )
 
+    def update_memory_relation(
+        self, relation_id: int, relation_update: MemoryRelationCreate
+    ) -> models.MemoryRelation:
+        """Update an existing memory relation."""
+        db_relation = self.get_memory_relation(relation_id)
+        if db_relation is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Relation not found",
+            )
+
+        # Validate referenced entities exist
+        from_entity = self.get_memory_entity_by_id(relation_update.from_entity_id)
+        if from_entity is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=(
+                    f"Source entity with ID {relation_update.from_entity_id} not found"
+                ),
+            )
+        to_entity = self.get_memory_entity_by_id(relation_update.to_entity_id)
+        if to_entity is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=(
+                    f"Target entity with ID {relation_update.to_entity_id} not found"
+                ),
+            )
+
+        db_relation.from_entity_id = relation_update.from_entity_id
+        db_relation.to_entity_id = relation_update.to_entity_id
+        db_relation.relation_type = relation_update.relation_type
+        db_relation.metadata_ = relation_update.metadata_
+
+        try:
+            self.db.commit()
+            self.db.refresh(db_relation)
+            return db_relation
+        except IntegrityError:
+            self.db.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Relation of type '{relation_update.relation_type}' already exists "
+                    f"between entity {relation_update.from_entity_id} "
+                    f"and entity {relation_update.to_entity_id}"
+                ),
+            )
+        except Exception as e:
+            self.db.rollback()
+            logger.error(f"Error updating memory relation: {e}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Error updating memory relation",
+            )
+
     def get_memory_relation(
         self, relation_id: int
     ) -> Optional[models.MemoryRelation]:

--- a/backend/tests/test_memory_relations.py
+++ b/backend/tests/test_memory_relations.py
@@ -1,0 +1,115 @@
+import types
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient, ASGITransport
+
+from backend.routers.memory.relations.relations import (
+    router,
+    get_memory_service,
+)
+from backend.schemas.memory import MemoryRelation, MemoryRelationCreate
+from backend.services.memory_service import MemoryService
+from backend.services.exceptions import EntityNotFoundError
+from datetime import datetime, timezone
+
+
+class DummyRelationService:
+    def __init__(self):
+        now = datetime.now(timezone.utc)
+        self.relations = {
+            1: MemoryRelation(
+                id=1,
+                from_entity_id=1,
+                to_entity_id=2,
+                relation_type="linked",
+                metadata_=None,
+                created_at=now,
+                updated_at=None,
+                from_entity=None,
+                to_entity=None,
+            )
+        }
+
+    def update_memory_relation(self, relation_id: int, relation: MemoryRelationCreate):
+        if relation_id not in self.relations:
+            raise EntityNotFoundError("MemoryRelation", relation_id)
+        updated = MemoryRelation(
+            id=relation_id,
+            from_entity_id=relation.from_entity_id,
+            to_entity_id=relation.to_entity_id,
+            relation_type=relation.relation_type,
+            metadata_=relation.metadata_,
+            created_at=self.relations[relation_id].created_at,
+            updated_at=None,
+            from_entity=None,
+            to_entity=None,
+        )
+        self.relations[relation_id] = updated
+        return updated
+
+
+dummy_service = DummyRelationService()
+
+
+def override_service():
+    return dummy_service
+
+
+app = FastAPI()
+app.include_router(router)
+app.dependency_overrides[get_memory_service] = override_service
+
+
+@pytest.mark.asyncio
+async def test_update_relation_endpoint():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.put(
+            "/relations/1",
+            json={
+                "from_entity_id": 1,
+                "to_entity_id": 2,
+                "relation_type": "updated",
+                "metadata_": {"foo": "bar"},
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["relation_type"] == "updated"
+        assert dummy_service.relations[1].relation_type == "updated"
+
+
+def test_update_memory_relation_service():
+    session = types.SimpleNamespace(commit=lambda: None, refresh=lambda obj: None)
+    service = MemoryService(session)
+    relation = types.SimpleNamespace()
+    service.get_memory_relation = lambda _id: relation
+    service.get_memory_entity_by_id = lambda _id: object()
+
+    update = MemoryRelationCreate(
+        from_entity_id=2,
+        to_entity_id=3,
+        relation_type="ref",
+        metadata_={"x": 1},
+    )
+
+    # monkeypatch commit and refresh to track calls
+    called = {}
+
+    def commit():
+        called["commit"] = True
+
+    def refresh(obj):
+        called["refresh"] = obj
+
+    service.db.commit = commit
+    service.db.refresh = refresh
+
+    result = service.update_memory_relation(5, update)
+
+    assert result is relation
+    assert relation.from_entity_id == 2
+    assert relation.to_entity_id == 3
+    assert relation.relation_type == "ref"
+    assert relation.metadata_ == {"x": 1}
+    assert called.get("commit")
+    assert called.get("refresh") is relation


### PR DESCRIPTION
## Summary
- implement `update_memory_relation` service logic
- add endpoint for updating relations
- cover relation update behavior with tests

## Testing
- `pytest tests/test_memory_relations.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a9cb46d8832c9c59e26b55538cd0