### PR TITLE
Add MemoryObservationEditor

### DIFF
--- a/frontend/src/components/memory/MemoryObservationEditor.tsx
+++ b/frontend/src/components/memory/MemoryObservationEditor.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import React, { useState } from 'react';
+import {
+  Box,
+  Text,
+  IconButton,
+  Textarea,
+  HStack,
+  useToast,
+  Flex,
+} from '@chakra-ui/react';
+import { EditIcon, CheckIcon, CloseIcon, DeleteIcon } from '@chakra-ui/icons';
+import { memoryApi } from '@/services/api';
+import type {
+  MemoryObservation,
+  MemoryObservationUpdateData,
+} from '@/types/memory';
+
+interface MemoryObservationEditorProps {
+  observation: MemoryObservation;
+  onUpdated?: (obs: MemoryObservation) => void;
+  onDeleted?: (id: number) => void;
+}
+
+const MemoryObservationEditor: React.FC<MemoryObservationEditorProps> = ({
+  observation,
+  onUpdated,
+  onDeleted,
+}) => {
+  const toast = useToast();
+  const [isEditing, setIsEditing] = useState(false);
+  const [content, setContent] = useState(observation.content);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      const data: MemoryObservationUpdateData = { content };
+      const updated = await memoryApi.updateObservation(observation.id, data);
+      toast({
+        title: 'Observation updated',
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+      });
+      setIsEditing(false);
+      onUpdated?.(updated);
+    } catch (err) {
+      toast({
+        title: 'Failed to update observation',
+        description: err instanceof Error ? err.message : 'Error',
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    try {
+      await memoryApi.deleteObservation(observation.id);
+      toast({
+        title: 'Observation deleted',
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+      });
+      onDeleted?.(observation.id);
+    } catch (err) {
+      toast({
+        title: 'Failed to delete observation',
+        description: err instanceof Error ? err.message : 'Error',
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <Box
+      borderWidth="1px"
+      borderRadius="md"
+      p={2}
+      bg="bg.surface"
+      data-testid="memory-observation-editor"
+    >
+      {isEditing ? (
+        <>
+          <Textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            size="sm"
+            mb={2}
+          />
+          <HStack justifyContent="flex-end">
+            <IconButton
+              aria-label="Save observation"
+              icon={<CheckIcon />}
+              size="sm"
+              onClick={handleSave}
+              isLoading={isSaving}
+            />
+            <IconButton
+              aria-label="Cancel edit"
+              icon={<CloseIcon />}
+              size="sm"
+              onClick={() => {
+                setIsEditing(false);
+                setContent(observation.content);
+              }}
+            />
+          </HStack>
+        </>
+      ) : (
+        <Flex justify="space-between" align="flex-start">
+          <Text>{observation.content}</Text>
+          <HStack spacing={1} ml={2}>
+            <IconButton
+              aria-label="Edit observation"
+              icon={<EditIcon />}
+              size="xs"
+              variant="ghost"
+              onClick={() => setIsEditing(true)}
+            />
+            <IconButton
+              aria-label="Delete observation"
+              icon={<DeleteIcon />}
+              size="xs"
+              variant="ghost"
+              colorScheme="red"
+              onClick={handleDelete}
+              isLoading={isDeleting}
+            />
+          </HStack>
+        </Flex>
+      )}
+    </Box>
+  );
+};
+
+export default MemoryObservationEditor;

--- a/frontend/src/components/memory/__tests__/MemoryObservationEditor.test.tsx
+++ b/frontend/src/components/memory/__tests__/MemoryObservationEditor.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import {
+  render,
+  screen,
+  waitFor,
+  TestWrapper,
+} from '@/__tests__/utils/test-utils';
+import MemoryObservationEditor from '../MemoryObservationEditor';
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual('@chakra-ui/react');
+  return {
+    ...actual,
+    useToast: () => vi.fn(),
+    useColorModeValue: (l: any, d: any) => l,
+  };
+});
+
+vi.mock('@/services/api', () => ({
+  memoryApi: {
+    updateObservation: vi.fn(),
+    deleteObservation: vi.fn(),
+  },
+}));
+
+const { memoryApi } = await import('@/services/api');
+
+const observation = {
+  id: 1,
+  entity_id: 1,
+  content: 'initial',
+  created_at: '2024-01-01T00:00:00Z',
+};
+
+describe('MemoryObservationEditor', () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls update and delete handlers', async () => {
+    (memoryApi.updateObservation as any).mockResolvedValue({
+      ...observation,
+      content: 'updated',
+    });
+    render(
+      <TestWrapper>
+        <MemoryObservationEditor observation={observation} />
+      </TestWrapper>
+    );
+    await user.click(screen.getByRole('button', { name: /edit observation/i }));
+    const input = screen.getByRole('textbox');
+    await user.clear(input);
+    await user.type(input, 'updated');
+    await user.click(screen.getByRole('button', { name: /save observation/i }));
+    await waitFor(() =>
+      expect(memoryApi.updateObservation).toHaveBeenCalledWith(1, {
+        content: 'updated',
+      })
+    );
+
+    await user.click(
+      screen.getByRole('button', { name: /delete observation/i })
+    );
+    await waitFor(() =>
+      expect(memoryApi.deleteObservation).toHaveBeenCalledWith(1)
+    );
+  });
+});

--- a/frontend/src/services/api/memory.ts
+++ b/frontend/src/services/api/memory.ts
@@ -1,5 +1,5 @@
-import { request } from "./request";
-import { buildApiUrl, API_CONFIG } from "./config";
+import { request } from './request';
+import { buildApiUrl, API_CONFIG } from './config';
 import type {
   MemoryEntity,
   MemoryEntityCreateData,
@@ -9,11 +9,12 @@ import type {
   MemoryEntityFilters,
   MemoryObservation,
   MemoryObservationCreateData,
+  MemoryObservationUpdateData,
   MemoryRelation,
   MemoryRelationCreateData,
   MemoryRelationFilters,
   KnowledgeGraph,
-} from "@/types/memory";
+} from '@/types/memory';
 
 // --- Memory Entity APIs ---
 export const memoryApi = {
@@ -22,7 +23,7 @@ export const memoryApi = {
     const response = await request<MemoryEntityResponse>(
       buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify(data),
       }
     );
@@ -61,7 +62,7 @@ export const memoryApi = {
     const response = await request<MemoryEntityResponse>(
       buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/${entityId}`),
       {
-        method: "PUT",
+        method: 'PUT',
         body: JSON.stringify(data),
       }
     );
@@ -70,20 +71,17 @@ export const memoryApi = {
 
   // Delete a memory entity
   deleteEntity: async (entityId: number): Promise<void> => {
-    await request(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/${entityId}`),
-      {
-        method: "DELETE",
-      }
-    );
+    await request(buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/${entityId}`), {
+      method: 'DELETE',
+    });
   },
 
   // Ingest a file from the server filesystem
   ingestFile: async (filePath: string): Promise<MemoryEntity> => {
     const response = await request<MemoryEntityResponse>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/entities/ingest/file"),
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/entities/ingest/file'),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify({ file_path: filePath }),
       }
     );
@@ -93,9 +91,9 @@ export const memoryApi = {
   // Ingest content directly from a URL
   ingestUrl: async (url: string): Promise<MemoryEntity> => {
     const response = await request<MemoryEntityResponse>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/ingest-url"),
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/ingest-url'),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify({ url }),
       }
     );
@@ -105,9 +103,9 @@ export const memoryApi = {
   // Ingest a raw text snippet
   ingestText: async (text: string): Promise<MemoryEntity> => {
     const response = await request<MemoryEntityResponse>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/ingest-text"),
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/ingest-text'),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify({ text }),
       }
     );
@@ -116,11 +114,13 @@ export const memoryApi = {
 
   // --- Memory Observation APIs ---
   // Add an observation to an entity
-  addObservation: async (data: MemoryObservationCreateData): Promise<MemoryObservation> => {
+  addObservation: async (
+    data: MemoryObservationCreateData
+  ): Promise<MemoryObservation> => {
     const response = await request<{ data: MemoryObservation }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/observations"),
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/observations'),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify(data),
       }
     );
@@ -130,7 +130,27 @@ export const memoryApi = {
   // Get observations for an entity
   getObservations: async (entityId: number): Promise<MemoryObservation[]> => {
     const response = await request<{ data: MemoryObservation[] }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/entities/${entityId}/observations`)
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.MEMORY,
+        `/entities/${entityId}/observations`
+      )
+    );
+    return response.data;
+  },
+
+  updateObservation: async (
+    observationId: number,
+    data: MemoryObservationUpdateData
+  ): Promise<MemoryObservation> => {
+    const response = await request<{ data: MemoryObservation }>(
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.MEMORY,
+        `/observations/${observationId}`
+      ),
+      {
+        method: 'PUT',
+        body: JSON.stringify(data),
+      }
     );
     return response.data;
   },
@@ -138,19 +158,24 @@ export const memoryApi = {
   // Delete an observation
   deleteObservation: async (observationId: number): Promise<void> => {
     await request(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/observations/${observationId}`),
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.MEMORY,
+        `/observations/${observationId}`
+      ),
       {
-        method: "DELETE",
+        method: 'DELETE',
       }
     );
   },
   // --- Memory Relation APIs ---
   // Create a relation between entities
-  createRelation: async (data: MemoryRelationCreateData): Promise<MemoryRelation> => {
+  createRelation: async (
+    data: MemoryRelationCreateData
+  ): Promise<MemoryRelation> => {
     const response = await request<{ data: MemoryRelation }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/relations"),
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/relations'),
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify(data),
       }
     );
@@ -158,7 +183,9 @@ export const memoryApi = {
   },
 
   // Get relations with filters
-  getRelations: async (filters?: MemoryRelationFilters): Promise<MemoryRelation[]> => {
+  getRelations: async (
+    filters?: MemoryRelationFilters
+  ): Promise<MemoryRelation[]> => {
     const params = new URLSearchParams();
     if (filters) {
       Object.entries(filters).forEach(([key, value]) => {
@@ -168,7 +195,10 @@ export const memoryApi = {
       });
     }
     const response = await request<{ data: MemoryRelation[] }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/relations?${params.toString()}`)
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.MEMORY,
+        `/relations?${params.toString()}`
+      )
     );
     return response.data;
   },
@@ -178,7 +208,7 @@ export const memoryApi = {
     await request(
       buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/relations/${relationId}`),
       {
-        method: "DELETE",
+        method: 'DELETE',
       }
     );
   },
@@ -187,7 +217,7 @@ export const memoryApi = {
   // Get the full knowledge graph
   getKnowledgeGraph: async (): Promise<KnowledgeGraph> => {
     const response = await request<{ data: KnowledgeGraph }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, "/graph")
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/graph')
     );
     return response.data;
   },
@@ -195,7 +225,10 @@ export const memoryApi = {
   // Search the knowledge graph
   searchGraph: async (query: string): Promise<MemoryEntity[]> => {
     const response = await request<{ data: MemoryEntity[] }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/search?q=${encodeURIComponent(query)}`)
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.MEMORY,
+        `/search?q=${encodeURIComponent(query)}`
+      )
     );
     return response.data;
   },

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,25 +1,21 @@
-export * from "./project";
-export * from "./agent";
-export * from "./agents";
-export * from "./task";
-export * from "./user";
-export * from "./audit_log";
-export * from "./memory";
-export * from "./comment";
-export * from "./rules";
-export * from "./mcp";
-export * from "./project_template";
-export * from "./agent_prompt_template";
-<<<<<<< HEAD
-export * from "./handoff";
-=======
-export * from "./verification_requirement";
-export * from "./error_protocol";
->>>>>>> dbf07afe89e4a68f816243b7e80701b4e1995167
+export * from './project';
+export * from './agent';
+export * from './agents';
+export * from './task';
+export * from './user';
+export * from './audit_log';
+export * from './memory';
+export * from './comment';
+export * from './rules';
+export * from './mcp';
+export * from './project_template';
+export * from './agent_prompt_template';
+export * from './handoff';
+export * from './verification_requirement';
 
 // Common types used across the application
 // Canonical shared sort direction type for all entities
-export type SortDirection = "asc" | "desc";
+export type SortDirection = 'asc' | 'desc';
 
 export interface PaginationParams {
   page: number;
@@ -42,10 +38,10 @@ export interface ApiListResponse<T> extends ApiResponse<T[]> {
 }
 
 // Theme types
-export type ThemeMode = "light" | "dark" | "system";
+export type ThemeMode = 'light' | 'dark' | 'system';
 
 // Toast types
-export type ToastType = "success" | "error" | "warning" | "info";
+export type ToastType = 'success' | 'error' | 'warning' | 'info';
 
 export interface ToastMessage {
   id: string;
@@ -55,7 +51,13 @@ export interface ToastMessage {
 }
 
 // Canonical task sort field type (should match all UI/usage fields)
-export type TaskSortField = "created_at" | "title" | "status" | "agent" | "project_id" | "updated_at";
+export type TaskSortField =
+  | 'created_at'
+  | 'title'
+  | 'status'
+  | 'agent'
+  | 'project_id'
+  | 'updated_at';
 
 // Canonical task sort options type
 export interface TaskSortOptions {
@@ -64,5 +66,5 @@ export interface TaskSortOptions {
 }
 
 // Add shared types for group by and view mode
-export type GroupByType = "status" | "project" | "agent" | "parent";
-export type ViewMode = "list" | "kanban";
+export type GroupByType = 'status' | 'project' | 'agent' | 'parent';
+export type ViewMode = 'list' | 'kanban';

--- a/frontend/src/types/memory.ts
+++ b/frontend/src/types/memory.ts
@@ -38,6 +38,13 @@ export type MemoryObservationCreateData = z.infer<
   typeof memoryObservationCreateSchema
 >;
 
+export const memoryObservationUpdateSchema =
+  memoryObservationBaseSchema.partial();
+
+export type MemoryObservationUpdateData = z.infer<
+  typeof memoryObservationUpdateSchema
+>;
+
 export const memoryObservationSchema = memoryObservationBaseSchema.extend({
   id: z.number(),
   created_at: z.string().datetime({ message: 'Invalid ISO datetime string' }),


### PR DESCRIPTION
## Summary
- create MemoryObservationEditor for updating and deleting observations
- expose updateObservation API
- extend memory types with update schema
- add unit test covering update and delete actions

## Testing
- `npm --prefix frontend run lint`
- `npx prettier --write frontend/src/components/memory/MemoryObservationEditor.tsx frontend/src/components/memory/__tests__/MemoryObservationEditor.test.tsx frontend/src/services/api/memory.ts frontend/src/types/memory.ts frontend/src/types/index.ts`
- `npx vitest run src/components/memory/__tests__/MemoryObservationEditor.test.tsx` *(fails: Could not run due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6841a9cabda8832ca42fe0b642b100f7