### PR TITLE
Add MCP error protocol management

### DIFF
--- a/frontend/src/components/__tests__/ErrorProtocolManager.test.tsx
+++ b/frontend/src/components/__tests__/ErrorProtocolManager.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@/__tests__/utils/test-utils';
+import ErrorProtocolManager from '../ErrorProtocolManager';
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual('@chakra-ui/react');
+  return {
+    ...actual,
+    useToast: () => vi.fn(),
+    useColorModeValue: (l: any, d: any) => l,
+  };
+});
+
+vi.mock('@/services/api/error_protocols', () => ({
+  errorProtocolsApi: {
+    create: vi.fn().mockResolvedValue({}),
+    list: vi.fn().mockResolvedValue([]),
+    remove: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+describe('ErrorProtocolManager', () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders component', () => {
+    render(<ErrorProtocolManager agentRoleId="role1" />, {
+      wrapper: ({ children }) => <div>{children}</div>,
+    });
+    expect(document.body).toBeInTheDocument();
+  });
+
+  it('handles create flow', async () => {
+    render(<ErrorProtocolManager agentRoleId="role1" />, {
+      wrapper: ({ children }) => <div>{children}</div>,
+    });
+
+    await user.type(screen.getByPlaceholderText('Error Type'), 'Type');
+    await user.type(screen.getByPlaceholderText('Protocol'), 'Handle');
+    const addButton = screen.getByRole('button', { name: /add/i });
+    await user.click(addButton);
+
+    expect(document.body).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/agents/ErrorProtocolManager.tsx
+++ b/frontend/src/components/agents/ErrorProtocolManager.tsx
@@ -1,0 +1,182 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Flex,
+  Input,
+  Spinner,
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+  TableContainer,
+  Text,
+  useToast,
+  Checkbox,
+} from "@chakra-ui/react";
+import { errorProtocolsApi } from "@/services/api/error_protocols";
+import type { ErrorProtocol, ErrorProtocolCreateData } from "@/types/agents";
+
+interface ErrorProtocolManagerProps {
+  agentRoleId: string;
+}
+
+const defaultForm: Omit<ErrorProtocolCreateData, "agent_role_id"> = {
+  error_type: "",
+  protocol: "",
+  priority: 5,
+  is_active: true,
+};
+
+const ErrorProtocolManager: React.FC<ErrorProtocolManagerProps> = ({ agentRoleId }) => {
+  const toast = useToast();
+  const [protocols, setProtocols] = useState<ErrorProtocol[] | null>(null);
+  const [form, setForm] = useState(defaultForm);
+  const [loading, setLoading] = useState(false);
+
+  const loadProtocols = async () => {
+    try {
+      const data = await errorProtocolsApi.list(agentRoleId);
+      setProtocols(data);
+    } catch (err) {
+      toast({
+        title: "Failed to load protocols",
+        description: err instanceof Error ? err.message : String(err),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  useEffect(() => {
+    loadProtocols();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agentRoleId]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value, type, checked } = e.target;
+    setForm((f) => ({
+      ...f,
+      [name]: type === "checkbox" ? checked : value,
+    }));
+  };
+
+  const handleCreate = async () => {
+    if (!form.error_type.trim() || !form.protocol.trim()) return;
+    setLoading(true);
+    try {
+      await errorProtocolsApi.create({ agent_role_id: agentRoleId, ...form });
+      setForm(defaultForm);
+      await loadProtocols();
+      toast({ title: "Protocol added", status: "success", duration: 3000, isClosable: true });
+    } catch (err) {
+      toast({
+        title: "Failed to add protocol",
+        description: err instanceof Error ? err.message : String(err),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    setLoading(true);
+    try {
+      await errorProtocolsApi.remove(id);
+      await loadProtocols();
+      toast({ title: "Protocol removed", status: "success", duration: 3000, isClosable: true });
+    } catch (err) {
+      toast({
+        title: "Failed to remove protocol",
+        description: err instanceof Error ? err.message : String(err),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!protocols) {
+    return (
+      <Flex justify="center" align="center" p="4" minH="100px">
+        <Spinner />
+      </Flex>
+    );
+  }
+
+  return (
+    <Box>
+      <Flex mb={2} gap={2} flexWrap="wrap">
+        <Input
+          placeholder="Error Type"
+          name="error_type"
+          value={form.error_type}
+          onChange={handleChange}
+        />
+        <Input
+          placeholder="Protocol"
+          name="protocol"
+          value={form.protocol}
+          onChange={handleChange}
+        />
+        <Input
+          placeholder="Priority"
+          name="priority"
+          type="number"
+          value={form.priority}
+          onChange={handleChange}
+          width="90px"
+        />
+        <Checkbox name="is_active" isChecked={form.is_active} onChange={handleChange}>
+          Is Active
+        </Checkbox>
+        <Button onClick={handleCreate} isLoading={loading} disabled={!form.error_type.trim() || !form.protocol.trim()}>
+          Add
+        </Button>
+      </Flex>
+      {protocols.length === 0 ? (
+        <Text>No error protocols.</Text>
+      ) : (
+        <TableContainer>
+          <Table size="sm" variant="simple">
+            <Thead>
+              <Tr>
+                <Th>Error Type</Th>
+                <Th>Protocol</Th>
+                <Th>Priority</Th>
+                <Th>Active</Th>
+                <Th>Actions</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {protocols.map((p) => (
+                <Tr key={p.id}>
+                  <Td>{p.error_type}</Td>
+                  <Td>{p.protocol}</Td>
+                  <Td>{p.priority}</Td>
+                  <Td>{p.is_active ? 'Yes' : 'No'}</Td>
+                  <Td>
+                    <Button size="sm" colorScheme="red" onClick={() => handleDelete(p.id)}>
+                      Delete
+                    </Button>
+                  </Td>
+                </Tr>
+              ))}
+            </Tbody>
+          </Table>
+        </TableContainer>
+      )}
+    </Box>
+  );
+};
+
+export default ErrorProtocolManager;

--- a/frontend/src/services/api/__tests__/error_protocols.test.tsx
+++ b/frontend/src/services/api/__tests__/error_protocols.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { errorProtocolsApi } from '../error_protocols';
+import { mockFetchResponse } from '@/__tests__/utils/test-utils';
+
+describe('errorProtocolsApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates protocol', async () => {
+    const payload = {
+      agent_role_id: 'role1',
+      error_type: 'Type',
+      protocol: 'Handle',
+      priority: 1,
+      is_active: true,
+    };
+    const created = { ...payload, id: '1', created_at: '2024-01-01T00:00:00Z' };
+    mockFetchResponse({ success: true, protocol: created });
+
+    const result = await errorProtocolsApi.create(payload);
+    expect(global.fetch).toHaveBeenCalled();
+    expect(result).toEqual(created);
+  });
+
+  it('lists protocols', async () => {
+    const list = [
+      {
+        id: '1',
+        agent_role_id: 'role1',
+        error_type: 'Type',
+        protocol: 'Handle',
+        priority: 1,
+        is_active: true,
+        created_at: '2024-01-01T00:00:00Z',
+      },
+    ];
+    mockFetchResponse({ success: true, protocols: list });
+
+    const result = await errorProtocolsApi.list('role1');
+    expect(global.fetch).toHaveBeenCalled();
+    expect(result).toEqual(list);
+  });
+
+  it('deletes protocol', async () => {
+    mockFetchResponse({ success: true });
+    await errorProtocolsApi.remove('1');
+    expect(global.fetch).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/services/api/error_protocols.ts
+++ b/frontend/src/services/api/error_protocols.ts
@@ -1,62 +1,54 @@
-import { request } from "./request";
-import { buildApiUrl } from "./config";
-import type {
-  ErrorProtocol,
-  ErrorProtocolCreateData,
-  ErrorProtocolUpdateData,
-} from "@/types/agents";
+import { request } from './request';
+import { buildApiUrl, API_CONFIG } from './config';
+import type { ErrorProtocol, ErrorProtocolCreateData } from '@/types/agents';
 
 /**
- * CRUD wrapper for /error-protocols endpoints
+ * MCP wrappers for error protocol management
  */
 export const errorProtocolsApi = {
-  /** List error protocols optionally filtered by role */
-  async list(
-    agentRoleId?: string,
-    skip = 0,
-    limit = 100,
-  ): Promise<ErrorProtocol[]> {
-    const params = new URLSearchParams({ skip: String(skip), limit: String(limit) });
-    if (agentRoleId) params.append("agent_role_id", agentRoleId);
-    return request<ErrorProtocol[]>(
-      buildApiUrl("/error-protocols", `?${params.toString()}`),
-    );
-  },
-
-  /** Retrieve a single error protocol */
-  async get(protocolId: string): Promise<ErrorProtocol> {
-    return request<ErrorProtocol>(
-      buildApiUrl("/error-protocols", `/${protocolId}`),
-    );
-  },
-
-  /** Create a new error protocol */
+  /** Create a new error protocol via MCP */
   async create(data: ErrorProtocolCreateData): Promise<ErrorProtocol> {
-    return request<ErrorProtocol>(buildApiUrl("/error-protocols"), {
-      method: "POST",
-      body: JSON.stringify(data),
-    });
-  },
-
-  /** Update an existing error protocol */
-  async update(
-    protocolId: string,
-    data: ErrorProtocolUpdateData,
-  ): Promise<ErrorProtocol> {
-    return request<ErrorProtocol>(
-      buildApiUrl("/error-protocols", `/${protocolId}`),
+    const { agent_role_id, ...payload } = data;
+    const params = new URLSearchParams({ role_id: agent_role_id });
+    const response = await request<{ success: boolean; protocol: ErrorProtocol }>(
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.MCP_TOOLS,
+        `/error-protocol/add?${params.toString()}`
+      ),
       {
-        method: "PUT",
-        body: JSON.stringify(data),
-      },
+        method: 'POST',
+        body: JSON.stringify(payload),
+      }
     );
+    return response.protocol;
   },
 
-  /** Delete an error protocol */
-  async delete(protocolId: string): Promise<{ message: string }> {
-    return request<{ message: string }>(
-      buildApiUrl("/error-protocols", `/${protocolId}`),
-      { method: "DELETE" },
+  /** List error protocols for an optional agent role */
+  async list(agentRoleId?: string): Promise<ErrorProtocol[]> {
+    const query = agentRoleId
+      ? `?role_id=${encodeURIComponent(agentRoleId)}`
+      : '';
+    const response = await request<{
+      success: boolean;
+      protocols: ErrorProtocol[];
+    }>(
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.MCP_TOOLS,
+        `/error-protocol/list${query}`
+      )
+    );
+    return response.protocols;
+  },
+
+  /** Delete an error protocol by ID */
+  async remove(protocolId: string): Promise<void> {
+    const params = new URLSearchParams({ protocol_id: protocolId });
+    await request<{ success: boolean }>(
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.MCP_TOOLS,
+        `/error-protocol/remove?${params.toString()}`
+      ),
+      { method: 'DELETE' }
     );
   },
 };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -10,12 +10,9 @@ export * from "./rules";
 export * from "./mcp";
 export * from "./project_template";
 export * from "./agent_prompt_template";
-<<<<<<< HEAD
 export * from "./handoff";
-=======
 export * from "./verification_requirement";
 export * from "./error_protocol";
->>>>>>> dbf07afe89e4a68f816243b7e80701b4e1995167
 
 // Common types used across the application
 // Canonical shared sort direction type for all entities


### PR DESCRIPTION
## Summary
- create MCP API wrapper for error protocols
- add ErrorProtocolManager component to manage protocols
- expose error protocol exports after resolving merge markers
- test API wrapper and component logic

## Testing
- `npm --prefix frontend install` *(fails: vitest not found before install)*
- `npx vitest run frontend/src/services/api/__tests__/error_protocols.test.tsx frontend/src/components/__tests__/ErrorProtocolManager.test.tsx --config frontend/vitest.config.ts` *(fails: environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6841addabd48832c98ec4b2f60ff7766