### PR TITLE
Add flake8 artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,15 @@ jobs:
 
       - name: Lint
         run: |
+          set -o pipefail
           cd backend
-          flake8 .
+          flake8 . | tee flake8.log
+
+      - name: Upload flake8 log
+        uses: actions/upload-artifact@v4
+        with:
+          name: flake8-output
+          path: backend/flake8.log
 
       - name: Test with coverage
         run: |


### PR DESCRIPTION
## Summary
- output flake8 results to `flake8.log`
- upload flake8 output as an artifact in CI

## Testing
- `flake8 .`
- `pytest -q`
- `npm run lint`
- `npm test -- -w 1`

------
https://chatgpt.com/codex/tasks/task_e_6841be2a13a8832cb5dfbef118e06b81