### PR TITLE
Fix import paths for tests

### DIFF
--- a/frontend/src/services/api/__tests__/error_protocols.test.tsx
+++ b/frontend/src/services/api/__tests__/error_protocols.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { errorProtocolsApi } from '../error_protocols';
-import { mockFetchResponse } from '@/__tests__/utils/test-utils';
+import { mockFetchResponse } from '../../../__tests__/utils/test-utils';
 
 describe('errorProtocolsApi', () => {
   beforeEach(() => {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -12,7 +12,6 @@ export * from './project_template';
 export * from './agent_prompt_template';
 export * from './handoff';
 export * from './verification_requirement';
-export * from './error_protocol';
 
 // Common types used across the application
 // Canonical shared sort direction type for all entities


### PR DESCRIPTION
## Summary
- fix incorrect path for test utilities in error protocol tests
- remove stray export causing path resolution errors

## Testing
- `npx tsc -p frontend/tsconfig.json --noEmit`
- `node --test tests/cli/help.test.js` *(fails: expected exit code 0)*

------
https://chatgpt.com/codex/tasks/task_e_6841be294704832cb7c5109ddcd05061