### PR TITLE
Enable vitest coverage and save results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
           npm run test:coverage
 
       - name: Upload frontend coverage artifact
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: frontend-coverage

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -19,6 +19,7 @@ const testConfig = defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/__tests__/setup.ts'],
     coverage: {
+      enabled: true,
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
       reportsDirectory: './coverage',

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
       'tests/**/*.test.ts'
     ],
     coverage: {
+      enabled: true,
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
       reportsDirectory: './coverage',


### PR DESCRIPTION
## Summary
- enable code coverage in vitest configs
- upload coverage artifact even when tests fail

## Testing
- `npm run test:coverage` *(fails: observer.observe is not a function)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6841be27ce6c832caf963a8216a1f5d4