### PR TITLE
Add npm test hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,12 @@ repos:
         language: system
         pass_filenames: false
 
+      - id: npm-test
+        name: Run frontend tests
+        entry: npm test --prefix frontend
+        language: system
+        pass_filenames: false
+
       - id: frontend-format
         name: Format frontend with Prettier
         entry: npm run format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ This project uses [pre-commit](https://pre-commit.com/) to automatically check c
 pip install pre-commit
 pre-commit install
 ```
+Run this command once after cloning (and again if `.pre-commit-config.yaml` changes) to ensure the hooks run.
 
 ### What gets checked:
 


### PR DESCRIPTION
## Summary
- run frontend tests during pre-commit
- clarify how to enable hooks in CONTRIBUTING

## Testing
- `flake8 backend`
- `npm run lint --prefix frontend` *(fails: `next` not found)*
- `npm test --prefix frontend` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841be1f6104832c886632d34fad8a11