### PR TITLE
Fix IntersectionObserver mock

### DIFF
--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -76,12 +76,18 @@ afterAll(() => {
   console.error = originalError;
 });
 
-// Mock IntersectionObserver
-global.IntersectionObserver = vi.fn().mockImplementation(() => ({
-  observe: vi.fn(),
-  unobserve: vi.fn(),
-  disconnect: vi.fn(),
-}));
+// Mock IntersectionObserver for components like next/link
+class MockIntersectionObserver {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+global.IntersectionObserver = MockIntersectionObserver as any;
+Object.defineProperty(window, 'IntersectionObserver', {
+  writable: true,
+  configurable: true,
+  value: MockIntersectionObserver,
+});
 
 // Mock ResizeObserver
 global.ResizeObserver = vi.fn().mockImplementation(() => ({


### PR DESCRIPTION
## Summary
- update IntersectionObserver mock to return real methods for use by next/link

## Testing
- `npx --yes vitest run src/__tests__/integration/not-found.test.tsx` *(fails: unable to find button)*

------
https://chatgpt.com/codex/tasks/task_e_6841be174040832c826e6da5ca36a051