### PR TITLE
Add error protocol types

### DIFF
--- a/frontend/src/components/agents/ErrorProtocolManager.tsx
+++ b/frontend/src/components/agents/ErrorProtocolManager.tsx
@@ -1,5 +1,5 @@
-"use client";
-import React, { useEffect, useState } from "react";
+'use client';
+import React, { useEffect, useState } from 'react';
 import {
   Box,
   Button,
@@ -16,22 +16,27 @@ import {
   Text,
   useToast,
   Checkbox,
-} from "@chakra-ui/react";
-import { errorProtocolsApi } from "@/services/api/error_protocols";
-import type { ErrorProtocol, ErrorProtocolCreateData } from "@/types/agents";
+} from '@chakra-ui/react';
+import { errorProtocolsApi } from '@/services/api/error_protocols';
+import type {
+  ErrorProtocol,
+  ErrorProtocolCreateData,
+} from '@/types/error_protocol';
 
 interface ErrorProtocolManagerProps {
   agentRoleId: string;
 }
 
-const defaultForm: Omit<ErrorProtocolCreateData, "agent_role_id"> = {
-  error_type: "",
-  protocol: "",
+const defaultForm: Omit<ErrorProtocolCreateData, 'agent_role_id'> = {
+  error_type: '',
+  protocol: '',
   priority: 5,
   is_active: true,
 };
 
-const ErrorProtocolManager: React.FC<ErrorProtocolManagerProps> = ({ agentRoleId }) => {
+const ErrorProtocolManager: React.FC<ErrorProtocolManagerProps> = ({
+  agentRoleId,
+}) => {
   const toast = useToast();
   const [protocols, setProtocols] = useState<ErrorProtocol[] | null>(null);
   const [form, setForm] = useState(defaultForm);
@@ -43,9 +48,9 @@ const ErrorProtocolManager: React.FC<ErrorProtocolManagerProps> = ({ agentRoleId
       setProtocols(data);
     } catch (err) {
       toast({
-        title: "Failed to load protocols",
+        title: 'Failed to load protocols',
         description: err instanceof Error ? err.message : String(err),
-        status: "error",
+        status: 'error',
         duration: 5000,
         isClosable: true,
       });
@@ -61,7 +66,7 @@ const ErrorProtocolManager: React.FC<ErrorProtocolManagerProps> = ({ agentRoleId
     const { name, value, type, checked } = e.target;
     setForm((f) => ({
       ...f,
-      [name]: type === "checkbox" ? checked : value,
+      [name]: type === 'checkbox' ? checked : value,
     }));
   };
 
@@ -72,12 +77,17 @@ const ErrorProtocolManager: React.FC<ErrorProtocolManagerProps> = ({ agentRoleId
       await errorProtocolsApi.create({ agent_role_id: agentRoleId, ...form });
       setForm(defaultForm);
       await loadProtocols();
-      toast({ title: "Protocol added", status: "success", duration: 3000, isClosable: true });
+      toast({
+        title: 'Protocol added',
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+      });
     } catch (err) {
       toast({
-        title: "Failed to add protocol",
+        title: 'Failed to add protocol',
         description: err instanceof Error ? err.message : String(err),
-        status: "error",
+        status: 'error',
         duration: 5000,
         isClosable: true,
       });
@@ -91,12 +101,17 @@ const ErrorProtocolManager: React.FC<ErrorProtocolManagerProps> = ({ agentRoleId
     try {
       await errorProtocolsApi.remove(id);
       await loadProtocols();
-      toast({ title: "Protocol removed", status: "success", duration: 3000, isClosable: true });
+      toast({
+        title: 'Protocol removed',
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+      });
     } catch (err) {
       toast({
-        title: "Failed to remove protocol",
+        title: 'Failed to remove protocol',
         description: err instanceof Error ? err.message : String(err),
-        status: "error",
+        status: 'error',
         duration: 5000,
         isClosable: true,
       });
@@ -136,10 +151,18 @@ const ErrorProtocolManager: React.FC<ErrorProtocolManagerProps> = ({ agentRoleId
           onChange={handleChange}
           width="90px"
         />
-        <Checkbox name="is_active" isChecked={form.is_active} onChange={handleChange}>
+        <Checkbox
+          name="is_active"
+          isChecked={form.is_active}
+          onChange={handleChange}
+        >
           Is Active
         </Checkbox>
-        <Button onClick={handleCreate} isLoading={loading} disabled={!form.error_type.trim() || !form.protocol.trim()}>
+        <Button
+          onClick={handleCreate}
+          isLoading={loading}
+          disabled={!form.error_type.trim() || !form.protocol.trim()}
+        >
           Add
         </Button>
       </Flex>
@@ -165,7 +188,11 @@ const ErrorProtocolManager: React.FC<ErrorProtocolManagerProps> = ({ agentRoleId
                   <Td>{p.priority}</Td>
                   <Td>{p.is_active ? 'Yes' : 'No'}</Td>
                   <Td>
-                    <Button size="sm" colorScheme="red" onClick={() => handleDelete(p.id)}>
+                    <Button
+                      size="sm"
+                      colorScheme="red"
+                      onClick={() => handleDelete(p.id)}
+                    >
                       Delete
                     </Button>
                   </Td>

--- a/frontend/src/services/api/error_protocols.ts
+++ b/frontend/src/services/api/error_protocols.ts
@@ -1,6 +1,9 @@
 import { request } from './request';
 import { buildApiUrl, API_CONFIG } from './config';
-import type { ErrorProtocol, ErrorProtocolCreateData } from '@/types/agents';
+import type {
+  ErrorProtocol,
+  ErrorProtocolCreateData,
+} from '@/types/error_protocol';
 
 /**
  * MCP wrappers for error protocol management
@@ -10,7 +13,10 @@ export const errorProtocolsApi = {
   async create(data: ErrorProtocolCreateData): Promise<ErrorProtocol> {
     const { agent_role_id, ...payload } = data;
     const params = new URLSearchParams({ role_id: agent_role_id });
-    const response = await request<{ success: boolean; protocol: ErrorProtocol }>(
+    const response = await request<{
+      success: boolean;
+      protocol: ErrorProtocol;
+    }>(
       buildApiUrl(
         API_CONFIG.ENDPOINTS.MCP_TOOLS,
         `/error-protocol/add?${params.toString()}`

--- a/frontend/src/types/error_protocol.ts
+++ b/frontend/src/types/error_protocol.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const errorProtocolBaseSchema = z.object({
+  agent_role_id: z.string(),
+  error_type: z.string(),
+  protocol: z.string(),
+  priority: z.number().optional(),
+  is_active: z.boolean().default(true),
+});
+
+export const errorProtocolCreateSchema = errorProtocolBaseSchema;
+export type ErrorProtocolCreateData = z.infer<typeof errorProtocolCreateSchema>;
+
+export const errorProtocolUpdateSchema = errorProtocolBaseSchema.partial();
+export type ErrorProtocolUpdateData = z.infer<typeof errorProtocolUpdateSchema>;
+
+export const errorProtocolSchema = errorProtocolBaseSchema.extend({
+  id: z.string(),
+  created_at: z.string().datetime({ message: 'Invalid ISO datetime string' }),
+});
+
+export type ErrorProtocol = z.infer<typeof errorProtocolSchema>;


### PR DESCRIPTION
## Summary
- define `ErrorProtocol` and `ErrorProtocolCreateData` in a new `error_protocol.ts`
- update API and components to use the new error protocol types

## Testing
- `npx prettier -w frontend/src/services/api/error_protocols.ts frontend/src/components/agents/ErrorProtocolManager.tsx frontend/src/types/error_protocol.ts`
- `npm run test:coverage` *(fails: vitest not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6841be121ef8832c83d62cca6fe4362a