### PR TITLE
Update CI setup script step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Run setup script
+        run: bash scripts/setup.sh
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -51,12 +54,23 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Run setup script
+        run: bash scripts/setup.sh
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
+
+      - name: Cache npm
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- run repository setup script in both CI jobs
- add npm cache for workflow

## Testing
- `flake8` *(fails: many style errors)*
- `pytest` *(fails: 12 failed)*
- `npm run type-check` *(fails: TypeScript errors)*
- `npm run test:coverage` *(fails: tests and typecheck errors)*
- `npm audit --audit-level=high`

------
https://chatgpt.com/codex/tasks/task_e_6841be0f2af0832c94f74ad59379ae32