### PR TITLE
Enforce lint & coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,17 +30,18 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r backend/requirements.txt
 
+      - name: Test with coverage
+        run: |
+          cd backend
+          pytest --cov=. --cov-report=xml --cov-fail-under=90
+
       - name: Lint
         run: |
           cd backend
           flake8 .
 
-      - name: Test with coverage
-        run: |
-          cd backend
-          pytest --cov=. --cov-report=xml
-
       - name: Upload Python coverage artifact
+        if: ${{ success() }}
         uses: actions/upload-artifact@v4
         with:
           name: backend-coverage
@@ -73,7 +74,18 @@ jobs:
           cd frontend
           npm run test:coverage
 
+      - name: Prettier check
+        run: |
+          cd frontend
+          npx prettier --check "src/**/*.{js,jsx,ts,tsx,json,css,md}"
+
+      - name: Lint
+        run: |
+          cd frontend
+          npm run lint
+
       - name: Upload frontend coverage artifact
+        if: ${{ success() }}
         uses: actions/upload-artifact@v4
         with:
           name: frontend-coverage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,17 @@ All tests and linters must pass locally before submitting a PR.
 
 ---
 
+## 🛰️ Continuous Integration
+
+The CI pipeline mirrors the local workflow and enforces quality gates:
+
+1. Backend tests run with `pytest --cov=. --cov-report=xml --cov-fail-under=90`.
+2. Frontend tests run with `npm run test:coverage` using Vitest's V8 coverage provider and a 90% global threshold.
+3. After tests pass, `flake8` is executed in `backend/` and `prettier --check` followed by `npm run lint` in `frontend/`.
+4. Coverage reports are uploaded only if all prior steps succeed.
+
+---
+
 ## 🤝 Thank You
 
 Your contributions help make this project better.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
     "export": "next build && next export",
     "test": "vitest",
     "test:ui": "vitest --ui",
-    "test:coverage": "vitest --coverage",
+    "test:coverage": "vitest run --coverage --coverage.v8",
     "test:watch": "vitest --watch",
     "test:run": "vitest run",
     "test:ci": "vitest run --coverage --reporter=json --reporter=default",

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -33,10 +33,10 @@ export default defineConfig({
       reportsDirectory: './coverage',
       threshold: {
         global: {
-          branches: 80,
-          functions: 80,
-          lines: 80,
-          statements: 80
+          branches: 90,
+          functions: 90,
+          lines: 90,
+          statements: 90
         }
       },
       include: [


### PR DESCRIPTION
## Summary
- enforce coverage thresholds and add lint after tests
- run prettier and lint for the frontend
- document the CI pipeline

## Testing
- `pytest --cov=. --cov-report=xml --cov-fail-under=90` *(fails: Required test coverage of 90% not reached)*
- `flake8 .` *(fails: line too long and unused imports)*
- `npx prettier --check "src/**/*.{js,jsx,ts,tsx,json,css,md}"` *(fails: code style issues)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841bde82da4832cbf1ce5ed1e73104b