### PR TITLE
Add API integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,11 @@ jobs:
           cd frontend
           npm run type-check
 
+      - name: Integration tests
+        run: |
+          cd frontend
+          npm run test:integration
+
       - name: Test with coverage
         run: |
           cd frontend

--- a/backend/tests/integration/README.md
+++ b/backend/tests/integration/README.md
@@ -19,6 +19,9 @@ graph TD
 ## File List
 
 - `test_project_task_flow.py`
+- `test_project_template_endpoints.py`
+- `test_audit_log_endpoints.py`
+- `test_project_file_associations.py`
 
 <!-- File List End -->
 

--- a/backend/tests/integration/test_audit_log_endpoints.py
+++ b/backend/tests/integration/test_audit_log_endpoints.py
@@ -1,0 +1,45 @@
+import pytest
+from httpx import AsyncClient
+from backend.main import create_app
+from backend.database import get_db
+from backend.auth import create_access_token
+
+
+@pytest.mark.asyncio
+async def test_audit_log_endpoints(async_db_session, test_project, test_user):
+    app = create_app()
+
+    async def override_db():
+        yield async_db_session
+
+    app.dependency_overrides[get_db] = override_db
+
+    token = create_access_token(data={"sub": test_user.username})
+    headers = {"Authorization": f"Bearer {token}"}
+
+    payload = {
+        "entity_type": "project",
+        "entity_id": str(test_project.id),
+        "action": "create",
+        "user_id": "u123",
+        "details": {"info": "test"},
+    }
+
+    async with AsyncClient(app=app, base_url="http://test", headers=headers) as client:
+        create_resp = await client.post("/api/audit-logs/", json=payload)
+        assert create_resp.status_code == 201
+        log_id = create_resp.json()["id"]
+
+        get_resp = await client.get(f"/api/audit-logs/{log_id}")
+        assert get_resp.status_code == 200
+        assert get_resp.json()["id"] == log_id
+
+        entity_resp = await client.get(
+            f"/api/audit-logs/entity/project/{test_project.id}"
+        )
+        assert entity_resp.status_code == 200
+        assert any(log["id"] == log_id for log in entity_resp.json())
+
+        user_resp = await client.get(f"/api/audit-logs/user/{payload['user_id']}")
+        assert user_resp.status_code == 200
+        assert any(log["id"] == log_id for log in user_resp.json())

--- a/backend/tests/integration/test_project_file_associations.py
+++ b/backend/tests/integration/test_project_file_associations.py
@@ -1,0 +1,51 @@
+import pytest
+from httpx import AsyncClient
+from backend.main import create_app
+from backend.database import get_db
+from backend.auth import create_access_token
+
+
+@pytest.mark.asyncio
+async def test_project_file_association_flow(async_db_session, test_project, test_user):
+    app = create_app()
+
+    async def override_db():
+        yield async_db_session
+
+    app.dependency_overrides[get_db] = override_db
+
+    token = create_access_token(data={"sub": test_user.username})
+    headers = {"Authorization": f"Bearer {token}"}
+
+    async with AsyncClient(app=app, base_url="http://test", headers=headers) as client:
+        mem_resp = await client.post(
+            "/api/memory/entities/",
+            json={"entity_type": "file", "content": "data", "source": "test"},
+        )
+        assert mem_resp.status_code == 201
+        memory_id = mem_resp.json()["id"]
+
+        assoc_resp = await client.post(
+            f"/api/v1/projects/{test_project.id}/files",
+            json={"file_id": memory_id},
+        )
+        assert assoc_resp.status_code == 200
+        assert assoc_resp.json()["data"]["file_memory_entity_id"] == memory_id
+
+        list_resp = await client.get(
+            f"/api/v1/projects/{test_project.id}/files"
+        )
+        assert list_resp.status_code == 200
+        assert any(f["file_memory_entity_id"] == memory_id for f in list_resp.json()["data"])
+
+        del_resp = await client.delete(
+            f"/api/v1/projects/{test_project.id}/files/{memory_id}"
+        )
+        assert del_resp.status_code == 200
+
+        list_resp2 = await client.get(
+            f"/api/v1/projects/{test_project.id}/files"
+        )
+        assert all(
+            f["file_memory_entity_id"] != memory_id for f in list_resp2.json()["data"]
+        )

--- a/backend/tests/integration/test_project_template_endpoints.py
+++ b/backend/tests/integration/test_project_template_endpoints.py
@@ -1,0 +1,46 @@
+import pytest
+from httpx import AsyncClient
+from backend.main import create_app
+from backend.database import get_db
+from backend.auth import create_access_token
+
+
+@pytest.mark.asyncio
+async def test_project_template_crud_flow(async_db_session, test_user):
+    app = create_app()
+
+    async def override_db():
+        yield async_db_session
+
+    app.dependency_overrides[get_db] = override_db
+
+    token = create_access_token(data={"sub": test_user.username})
+    headers = {"Authorization": f"Bearer {token}"}
+
+    payload = {"name": "Temp1", "description": "desc", "template_data": {}}
+
+    async with AsyncClient(app=app, base_url="http://test", headers=headers) as client:
+        create_resp = await client.post("/api/templates/", json=payload)
+        assert create_resp.status_code == 201
+        template_id = create_resp.json()["id"]
+
+        list_resp = await client.get("/api/templates/")
+        assert list_resp.status_code == 200
+        ids = [t["id"] for t in list_resp.json()]
+        assert template_id in ids
+
+        get_resp = await client.get(f"/api/templates/{template_id}")
+        assert get_resp.status_code == 200
+
+        update_resp = await client.put(
+            f"/api/templates/{template_id}", json={"description": "updated"}
+        )
+        assert update_resp.status_code == 200
+        assert update_resp.json()["description"] == "updated"
+
+        del_resp = await client.delete(f"/api/templates/{template_id}")
+        assert del_resp.status_code == 200
+        assert "deleted" in del_resp.json()["message"].lower()
+
+        missing_resp = await client.get(f"/api/templates/{template_id}")
+        assert missing_resp.status_code == 404

--- a/frontend/src/__tests__/integration/README.md
+++ b/frontend/src/__tests__/integration/README.md
@@ -24,6 +24,9 @@ graph TD
 - `templates-navigation.test.tsx`
 - `validate-frontend.test.ts`
 - `validate-testing-framework.test.ts`
+- `project_templates.api.test.ts`
+- `audit_logs.api.test.ts`
+- `project_file_association.api.test.ts`
 
 <!-- File List End -->
 

--- a/frontend/src/services/api/__tests__/audit_logs.api.test.ts
+++ b/frontend/src/services/api/__tests__/audit_logs.api.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { getAuditLogById, getAuditLogsByEntity, getAuditLogsByUser } from '../audit_logs'
+import { mockFetchResponse } from '@/__tests__/utils/test-utils'
+
+describe('audit_logs api', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('fetches logs', async () => {
+    const log = { id: '1', entity_type: 'project', entity_id: 'p1', action: 'a', user_id: 'u', details: null, created_at: '' }
+
+    mockFetchResponse(log)
+    const byId = await getAuditLogById('1')
+    expect(byId).toEqual(log)
+
+    mockFetchResponse([log])
+    const byEntity = await getAuditLogsByEntity('project', 'p1')
+    expect(byEntity).toEqual([log])
+
+    mockFetchResponse([log])
+    const byUser = await getAuditLogsByUser('u')
+    expect(byUser).toEqual([log])
+  })
+})

--- a/frontend/src/services/api/__tests__/project_file_association.api.test.ts
+++ b/frontend/src/services/api/__tests__/project_file_association.api.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { getProjectFiles, associateFileWithProject, disassociateFileFromProject } from '../projects'
+import { mockFetchResponse } from '@/__tests__/utils/test-utils'
+
+describe('project file association api', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('handles association flow', async () => {
+    const association = { project_id: 'p1', file_id: 'f1' }
+
+    mockFetchResponse([association])
+    const list = await getProjectFiles('p1')
+    expect(list).toEqual([association])
+
+    mockFetchResponse(association)
+    const created = await associateFileWithProject('p1', { file_id: 'f1' })
+    expect(created).toEqual(association)
+
+    mockFetchResponse({})
+    await disassociateFileFromProject('p1', 'f1')
+    expect(global.fetch).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/services/api/__tests__/project_templates.api.test.ts
+++ b/frontend/src/services/api/__tests__/project_templates.api.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { projectTemplatesApi } from '../project_templates'
+import { mockFetchResponse } from '@/__tests__/utils/test-utils'
+
+describe('projectTemplatesApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('handles CRUD flow', async () => {
+    const tpl = { id: '1', name: 'T', description: 'd', template_data: {}, created_at: '', updated_at: '' }
+    mockFetchResponse(tpl)
+    const created = await projectTemplatesApi.create({ name: 'T', description: 'd', template_data: {} })
+    expect(created).toEqual(tpl)
+
+    mockFetchResponse([tpl])
+    const list = await projectTemplatesApi.list()
+    expect(list).toEqual([tpl])
+
+    mockFetchResponse(tpl)
+    const got = await projectTemplatesApi.get('1')
+    expect(got).toEqual(tpl)
+
+    mockFetchResponse(tpl)
+    const updated = await projectTemplatesApi.update('1', { description: 'u' })
+    expect(updated).toEqual(tpl)
+
+    mockFetchResponse({ message: 'deleted' })
+    const del = await projectTemplatesApi.delete('1')
+    expect(del).toEqual({ message: 'deleted' })
+  })
+})

--- a/frontend/test-runner.js
+++ b/frontend/test-runner.js
@@ -55,7 +55,7 @@ async function runUnitTests() {
 async function runIntegrationTests() {
   console.log('🔗 Running Integration Tests...')
   try {
-    await runCommand('npm', ['run', 'test:run', '--', 'src/__tests__/integration'])
+    await runCommand('npm', ['run', 'test:integration'])
     console.log('✅ Integration tests completed successfully')
     return true
   } catch (error) {


### PR DESCRIPTION
## Summary
- add backend integration tests for templates, audit logs and project file associations
- add matching Vitest tests for API wrappers
- run new integration tests through test-runner and CI

## Testing
- `flake8 ..`
- `pytest tests/integration/test_project_template_endpoints.py tests/integration/test_audit_log_endpoints.py tests/integration/test_project_file_associations.py -q` *(fails: ModuleNotFoundError)*
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841bde685c8832c8325c46f66dc5949