### PR TITLE
Add SSE event streaming

### DIFF
--- a/backend/services/audit_log_service.py
+++ b/backend/services/audit_log_service.py
@@ -11,7 +11,7 @@ from backend.crud import audit_logs as audit_log_crud
 from backend.models.audit import AuditLog as AuditLogModel
 from backend.schemas.audit_log import AuditLogCreate, AuditLogUpdate
 
-from sqlalchemy.ext.asyncio import AsyncSession  # Import AsyncSession
+from .event_publisher import publisher
 
 
 class AuditLogService:
@@ -41,6 +41,9 @@ class AuditLogService:
         # Create the audit log entry using the CRUD function
         # Pass the async session to the CRUD function
         await audit_log_crud.create_audit_log(self.db, audit_log_create)
+        await publisher.publish(
+            {"type": "audit_log", "log": audit_log_create.model_dump()}
+        )
         return audit_log_create
 
     async def get_log(self, audit_log_id: str) -> Optional[AuditLogModel]:

--- a/backend/services/event_publisher.py
+++ b/backend/services/event_publisher.py
@@ -1,0 +1,29 @@
+import asyncio
+from typing import Any, Dict, List
+
+
+class EventPublisher:
+    """Simple pub-sub event broadcaster for in-process events."""
+
+    def __init__(self) -> None:
+        self.subscribers: List[asyncio.Queue] = []
+
+    def subscribe(self) -> asyncio.Queue:
+        """Register a new subscriber and return its queue."""
+        queue: asyncio.Queue = asyncio.Queue()
+        self.subscribers.append(queue)
+        return queue
+
+    def unsubscribe(self, queue: asyncio.Queue) -> None:
+        """Remove a subscriber's queue."""
+        if queue in self.subscribers:
+            self.subscribers.remove(queue)
+
+    async def publish(self, event: Dict[str, Any]) -> None:
+        """Publish an event to all subscribers."""
+        for queue in list(self.subscribers):
+            await queue.put(event)
+
+
+# Global publisher instance used across the application
+publisher = EventPublisher()

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -38,6 +38,21 @@ Run `npm run type-check` to ensure the TypeScript codebase compiles without erro
 
 At the repository root there is a matching `type-check` script that simply invokes the frontend command, allowing you to execute the check from either location.
 
+### Real-time Events
+
+The backend exposes a Server-Sent Events (SSE) endpoint at `/mcp-tools/stream`. You can listen to
+tool executions, audit log entries, and task updates using the `useEventSource` hook:
+
+```tsx
+import useEventSource from '@/hooks/useEventSource';
+
+const { lastEvent } = useEventSource('/mcp-tools/stream', (e) => {
+  console.log('event received', e);
+});
+```
+
+Each event is JSON encoded with a `type` field describing the payload.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/frontend/src/hooks/__tests__/useEventSource.test.tsx
+++ b/frontend/src/hooks/__tests__/useEventSource.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useEventSource } from '../useEventSource';
+
+class MockEventSource {
+  url: string;
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+  close() {
+    /* noop */
+  }
+  emit(data: any) {
+    this.onmessage?.({ data: JSON.stringify(data) } as MessageEvent);
+  }
+  static instances: MockEventSource[] = [];
+}
+
+describe('useEventSource', () => {
+  beforeEach(() => {
+    vi.stubGlobal('EventSource', MockEventSource as any);
+    MockEventSource.instances = [];
+  });
+
+  it('receives events and updates state', () => {
+    const { result } = renderHook(() => useEventSource<{ a: number }>('/stream'));
+    const instance = MockEventSource.instances[0];
+
+    act(() => {
+      instance.emit({ a: 1 });
+    });
+
+    expect(result.current.lastEvent).toEqual({ a: 1 });
+  });
+});

--- a/frontend/src/hooks/useEventSource.ts
+++ b/frontend/src/hooks/useEventSource.ts
@@ -1,0 +1,41 @@
+import { useEffect, useRef, useState } from 'react';
+
+export interface UseEventSourceResult<T> {
+  lastEvent: T | null;
+}
+
+/**
+ * Connect to a Server-Sent Events stream and handle incoming messages.
+ * @param url - SSE endpoint URL
+ * @param onEvent - Optional callback invoked for each parsed event
+ */
+export const useEventSource = <T = any>(
+  url: string,
+  onEvent?: (data: T) => void,
+): UseEventSourceResult<T> => {
+  const [lastEvent, setLastEvent] = useState<T | null>(null);
+  const sourceRef = useRef<EventSource>();
+
+  useEffect(() => {
+    const es = new EventSource(url);
+    sourceRef.current = es;
+
+    es.onmessage = (e) => {
+      try {
+        const data = JSON.parse(e.data) as T;
+        setLastEvent(data);
+        onEvent?.(data);
+      } catch (err) {
+        console.warn('Failed to parse SSE message', err);
+      }
+    };
+
+    return () => {
+      es.close();
+    };
+  }, [url, onEvent]);
+
+  return { lastEvent };
+};
+
+export default useEventSource;


### PR DESCRIPTION
## Summary
- publish internal events via new event_publisher
- expose `/mcp-tools/stream` endpoint that streams tool usage and service events
- send audit log and task events to the publisher
- add `useEventSource` React hook with tests
- document real-time event usage in the frontend README

## Testing
- `flake8 services/audit_log_service.py` *(fails: no issues)*
- `npm run lint` *(fails: `next` not found)*
- `npm test --silent` *(fails: `vitest` not found)*
- `pytest -q` *(fails: ModuleNotFoundError: 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6841bde29b30832c887cd4fc3b7548ab