### PR TITLE
Add pagination dependency to memory and files endpoints

### DIFF
--- a/backend/routers/memory/core/core.py
+++ b/backend/routers/memory/core/core.py
@@ -6,6 +6,7 @@ from ....schemas.file_ingest import FileIngestInput
 
 from ....database import get_sync_db as get_db
 from ....services.memory_service import MemoryService
+from ....schemas.api_responses import PaginationParams
 from ....schemas.memory import MemoryEntity, MemoryEntityCreate, MemoryEntityUpdate
 from ....services.exceptions import (
     EntityNotFoundError,
@@ -75,12 +76,15 @@ def read_memory_entity_endpoint(
 def list_memory_entities_endpoint(
     type: Optional[str] = Query(None),
     name: Optional[str] = Query(None),
-    skip: int = Query(0),
-    limit: int = Query(100),
+    pagination: PaginationParams = Depends(),
     memory_service: MemoryService = Depends(get_memory_service),
 ):
     try:
-        return memory_service.get_entities(type=type, name=name, skip=skip, limit=limit)
+        return memory_service.get_entities(
+            type=type,
+            name=name,
+            pagination=pagination,
+        )
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
 
@@ -89,14 +93,12 @@ def list_memory_entities_endpoint(
 def read_entities_by_type(
     entity_type: str = Path(...),
     memory_service: MemoryService = Depends(get_memory_service),
-    skip: int = Query(0),
-    limit: int = Query(100),
+    pagination: PaginationParams = Depends(),
 ):
     try:
         return memory_service.get_entities_by_type(
             entity_type=entity_type,
-            skip=skip,
-            limit=limit,
+            pagination=pagination,
         )
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Internal server error: {e}")

--- a/backend/routers/memory/observations/observations.py
+++ b/backend/routers/memory/observations/observations.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 from ....database import get_sync_db as get_db
 from ....services.memory_service import MemoryService  # Assuming observation management is part of memory service
 from ....schemas.memory import MemoryObservation, MemoryObservationCreate
+from ....schemas.api_responses import PaginationParams
 from ....services.exceptions import EntityNotFoundError
 
 router = APIRouter()
@@ -39,8 +40,7 @@ def read_observations(
     search_query: Optional[str] = Query(
         None, description="Optional text to search within observation content."
     ),
-    skip: int = Query(0, description="The number of items to skip before returning results."),
-    limit: int = Query(100, description="The maximum number of items to return."),
+    pagination: PaginationParams = Depends(),
     memory_service: MemoryService = Depends(get_memory_service),
 ):
     """Get observations, optionally filtered by entity or content search."""
@@ -48,8 +48,7 @@ def read_observations(
         return memory_service.get_observations(
             entity_id=entity_id,
             search_query=search_query,
-            skip=skip,
-            limit=limit,
+            pagination=pagination,
         )
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Internal server error: {e}")

--- a/backend/routers/memory/relations/relations.py
+++ b/backend/routers/memory/relations/relations.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 from ....database import get_sync_db as get_db
 from ....services.memory_service import MemoryService  # Assuming relation management is part of memory service
 from ....schemas.memory import MemoryRelation, MemoryRelationCreate
+from ....schemas.api_responses import PaginationParams
 from ....services.exceptions import EntityNotFoundError, DuplicateEntityError
 
 router = APIRouter()
@@ -35,15 +36,14 @@ def create_relation(
 
 def read_relations_by_type(
     relation_type: str = Path(..., description="The type of relations to filter by."),
-    skip: int = Query(0, description="The number of items to skip before returning"
-        "results."),
-    limit: int = Query(100, description="The maximum number of items to return."),
+    pagination: PaginationParams = Depends(),
+    
     memory_service: MemoryService = Depends(get_memory_service)
 ):
     """Retrieve a list of memory relations filtered by type."""
     try:
         return memory_service.get_memory_relations_by_type(
-            relation_type=relation_type, skip=skip, limit=limit
+            relation_type=relation_type, pagination=pagination
         )
     except Exception as e:
         raise HTTPException(
@@ -57,9 +57,8 @@ def read_relations_between_entities(
     from_entity_id: int = Path(..., description="ID of the source entity."),
     to_entity_id: int = Path(..., description="ID of the target entity."),
     relation_type: Optional[str] = Query(None, description="Optional relation type to filter by."),
-    skip: int = Query(0, description="The number of items to skip before returning"
-        "results."),
-    limit: int = Query(100, description="The maximum number of items to return."),
+    pagination: PaginationParams = Depends(),
+    
     memory_service: MemoryService = Depends(get_memory_service)
 ):
     """Retrieve relations between two specific memory entities."""
@@ -68,8 +67,7 @@ def read_relations_between_entities(
             from_entity_id=from_entity_id,
             to_entity_id=to_entity_id,
             relation_type=relation_type,
-            skip=skip,
-            limit=limit,
+            pagination=pagination,
         )
     except Exception as e:
         raise HTTPException(

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -16,6 +16,7 @@ from ..schemas.memory import (
     MemoryEntity,
     MemoryRelation,
 )
+from ..schemas.api_responses import PaginationParams
 from ..schemas.file_ingest import FileIngestInput
 from ..crud.memory import (
     create_memory_entity,
@@ -213,24 +214,27 @@ class MemoryService:
         self,
         type: Optional[str] = None,
         name: Optional[str] = None,
-        skip: int = 0,
-        limit: int = 100,
+        pagination: PaginationParams = PaginationParams(),
     ) -> List[models.MemoryEntity]:
         query = self.db.query(models.MemoryEntity)
         if type:
             query = query.filter(models.MemoryEntity.type == type)
         if name:
             query = query.filter(models.MemoryEntity.name.ilike(f"%{name}%"))
-        return query.offset(skip).limit(limit).all()
+        return (
+            query.offset(pagination.offset)
+            .limit(pagination.limit)
+            .all()
+        )
 
     def get_memory_entities_by_type(
-        self, entity_type: str, skip: int = 0, limit: int = 100
+        self, entity_type: str, pagination: PaginationParams = PaginationParams()
     ) -> List[models.MemoryEntity]:
         return (
             self.db.query(models.MemoryEntity)
             .filter(models.MemoryEntity.type == entity_type)
-            .offset(skip)
-            .limit(limit)
+            .offset(pagination.offset)
+            .limit(pagination.limit)
             .all()
         )
 
@@ -269,8 +273,7 @@ class MemoryService:
         self,
         entity_id: Optional[int] = None,
         search_query: Optional[str] = None,
-        skip: int = 0,
-        limit: int = 100,
+        pagination: PaginationParams = PaginationParams(),
     ) -> List[models.MemoryObservation]:
         query = self.db.query(models.MemoryObservation)
         if entity_id is not None:
@@ -279,7 +282,11 @@ class MemoryService:
             query = query.filter(
                 models.MemoryObservation.content.ilike(f"%{search_query}%")
             )
-        return query.offset(skip).limit(limit).all()
+        return (
+            query.offset(pagination.offset)
+            .limit(pagination.limit)
+            .all()
+        )
 
     def update_observation(
         self, observation_id: int, observation_update: MemoryObservationCreate
@@ -454,13 +461,15 @@ class MemoryService:
         return db_relation
 
     def get_memory_relations_by_type(
-        self, relation_type: str, skip: int = 0, limit: int = 100
+        self,
+        relation_type: str,
+        pagination: PaginationParams = PaginationParams(),
     ) -> List[models.MemoryRelation]:
         return (
             self.db.query(models.MemoryRelation)
             .filter(models.MemoryRelation.relation_type == relation_type)
-            .offset(skip)
-            .limit(limit)
+            .offset(pagination.offset)
+            .limit(pagination.limit)
             .all()
         )
 
@@ -469,8 +478,7 @@ class MemoryService:
         from_entity_id: int,
         to_entity_id: int,
         relation_type: Optional[str] = None,
-        skip: int = 0,
-        limit: int = 100,
+        pagination: PaginationParams = PaginationParams(),
     ) -> List[models.MemoryRelation]:
         query = self.db.query(models.MemoryRelation).filter(
             models.MemoryRelation.from_entity_id == from_entity_id,
@@ -478,7 +486,11 @@ class MemoryService:
         )
         if relation_type:
             query = query.filter(models.MemoryRelation.relation_type == relation_type)
-        return query.offset(skip).limit(limit).all()
+        return (
+            query.offset(pagination.offset)
+            .limit(pagination.limit)
+            .all()
+        )
 
     def search_memory_entities(
         self, query: str, limit: int = 10

--- a/backend/services/project_file_association_service.py
+++ b/backend/services/project_file_association_service.py
@@ -1,6 +1,7 @@
 from sqlalchemy.orm import Session, joinedload
 from .. import models, schemas
 from typing import List, Optional
+from ..schemas.api_responses import PaginationParams
 from backend.crud.project_file_associations import (
     get_project_file_association,
     get_project_files,
@@ -17,14 +18,23 @@ class ProjectFileAssociationService:
     def get_association(self, project_id: str, file_memory_entity_id: int):
         return get_project_file_association(self.db, project_id, file_memory_entity_id)
 
-    def get_files_for_project(self, project_id: str, skip: int = 0, limit: int = 100):
-        return get_project_files(self.db, project_id, skip=skip, limit=limit)
+    def get_files_for_project(
+        self,
+        project_id: str,
+        pagination: PaginationParams = PaginationParams(),
+    ):
+        return get_project_files(
+            self.db,
+            project_id,
+            skip=pagination.offset,
+            limit=pagination.limit,
+        )
 
     async def get_project_files(
-        self, project_id: str, skip: int = 0, limit: int = 100
+        self, project_id: str, pagination: PaginationParams = PaginationParams()
     ):
         """Async wrapper for get_files_for_project with pagination."""
-        return self.get_files_for_project(project_id, skip=skip, limit=limit)
+        return self.get_files_for_project(project_id, pagination)
 
     def associate_file_with_project(self, project_id: str, file_memory_entity_id: int):
         project_file = ProjectFileAssociationCreate(

--- a/backend/tests/test_project_files_endpoint.py
+++ b/backend/tests/test_project_files_endpoint.py
@@ -1,0 +1,40 @@
+import types
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient, ASGITransport
+
+from backend.routers.projects.files import (
+    router,
+    get_project_file_association_service,
+    get_current_active_user,
+)
+from backend.schemas.api_responses import PaginationParams
+
+class DummyService:
+    def __init__(self):
+        self.calls = []
+    async def get_project_files(self, project_id: str, pagination: PaginationParams):
+        self.calls.append((project_id, pagination.page, pagination.page_size))
+        return []
+
+
+dummy_service = DummyService()
+
+def override_service():
+    return dummy_service
+
+def override_user():
+    return types.SimpleNamespace(id="u1")
+
+app = FastAPI()
+app.include_router(router)
+app.dependency_overrides[get_project_file_association_service] = override_service
+app.dependency_overrides[get_current_active_user] = override_user
+
+@pytest.mark.asyncio
+async def test_get_project_files_pagination():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/123/files?page=2&pageSize=5")
+        assert resp.status_code == 200
+    assert dummy_service.calls[1] == ("123", 2, 5)
+

--- a/frontend/src/components/devtools/MemoryViewer.tsx
+++ b/frontend/src/components/devtools/MemoryViewer.tsx
@@ -13,7 +13,10 @@ const MemoryViewer: React.FC = () => {
   useEffect(() => {
     const fetchEntities = async () => {
       try {
-        const resp = await memoryApi.listEntities({ skip: 0, limit: 20 });
+        const resp = await memoryApi.listEntities(undefined, {
+          page: 1,
+          pageSize: 20,
+        });
         setEntities(resp.data);
       } catch (err) {
         setError((err as Error).message);

--- a/frontend/src/services/api/__tests__/project_files.test.ts
+++ b/frontend/src/services/api/__tests__/project_files.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getProjectFiles } from '../projects';
+import { buildApiUrl, API_CONFIG } from '../config';
+import { request } from '../request';
+
+vi.mock('../request', () => ({ request: vi.fn() }));
+
+const requestMock = request as unknown as vi.Mock;
+
+describe('getProjectFiles', () => {
+  beforeEach(() => {
+    requestMock.mockResolvedValue(undefined);
+    vi.clearAllMocks();
+  });
+
+  it('calls correct URL with pagination', async () => {
+    await getProjectFiles('p1', { page: 2, pageSize: 5 });
+    expect(requestMock).toHaveBeenCalledWith(
+      buildApiUrl(API_CONFIG.ENDPOINTS.PROJECTS, '/p1/files?page=2&pageSize=5')
+    );
+  });
+});
+

--- a/frontend/src/services/api/memory.ts
+++ b/frontend/src/services/api/memory.ts
@@ -16,6 +16,7 @@ import type {
   MemoryRelationFilters,
   KnowledgeGraph,
 } from '@/types/memory';
+import type { PaginationParams } from '@/types';
 
 // --- Memory Entity APIs ---
 export const memoryApi = {
@@ -41,7 +42,8 @@ export const memoryApi = {
 
   // List memory entities with optional filters
   listEntities: async (
-    filters?: MemoryEntityFilters & { skip?: number; limit?: number }
+    filters?: MemoryEntityFilters,
+    pagination?: PaginationParams
   ): Promise<MemoryEntityListResponse> => {
     const params = new URLSearchParams();
     if (filters) {
@@ -50,6 +52,10 @@ export const memoryApi = {
           params.append(key, String(value));
         }
       });
+    }
+    if (pagination) {
+      params.append('page', String(pagination.page));
+      params.append('pageSize', String(pagination.pageSize));
     }
     return await request<MemoryEntityListResponse>(
       buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `?${params.toString()}`)
@@ -147,11 +153,21 @@ export const memoryApi = {
   },
 
   // Get observations for an entity
-  getObservations: async (entityId: number): Promise<MemoryObservation[]> => {
+  getObservations: async (
+    entityId: number,
+    pagination?: PaginationParams
+  ): Promise<MemoryObservation[]> => {
+    const params = new URLSearchParams();
+    if (pagination) {
+      params.append('page', String(pagination.page));
+      params.append('pageSize', String(pagination.pageSize));
+    }
+    const query = params.toString();
+    const suffix = query ? `?${query}` : '';
     const response = await request<{ data: MemoryObservation[] }>(
       buildApiUrl(
         API_CONFIG.ENDPOINTS.MEMORY,
-        `/entities/${entityId}/observations`
+        `/entities/${entityId}/observations${suffix}`
       )
     );
     return response.data;

--- a/frontend/src/services/api/projects.ts
+++ b/frontend/src/services/api/projects.ts
@@ -6,6 +6,7 @@ import {
   ProjectMember,
   ProjectMemberCreateData,
 } from '@/types';
+import type { PaginationParams } from '@/types';
 import { request } from './request';
 import { buildApiUrl, API_CONFIG } from './config';
 
@@ -220,15 +221,17 @@ export interface AssociateFileWithProjectData {
 
 export const getProjectFiles = async (
   projectId: string,
-  skip = 0,
-  limit = 100
+  pagination?: PaginationParams
 ): Promise<ProjectFileAssociation[]> => {
   const params = new URLSearchParams();
-  params.append('skip', String(skip));
-  params.append('limit', String(limit));
+  if (pagination) {
+    params.append('page', String(pagination.page));
+    params.append('pageSize', String(pagination.pageSize));
+  }
   const query = params.toString();
+  const suffix = query ? `?${query}` : '';
   return request<ProjectFileAssociation[]>(
-    buildApiUrl(API_CONFIG.ENDPOINTS.PROJECTS, `/${projectId}/files?${query}`)
+    buildApiUrl(API_CONFIG.ENDPOINTS.PROJECTS, `/${projectId}/files${suffix}`)
   );
 };
 

--- a/frontend/src/store/memoryStore.ts
+++ b/frontend/src/store/memoryStore.ts
@@ -30,11 +30,10 @@ const actionsCreator = (
   fetchEntities: async (filters?: MemoryEntityFilters) => {
     set({ loading: true, error: null });
     try {
-      const resp = await memoryApi.listEntities({
-        skip: 0,
-        limit: 100,
-        ...filters,
-      });
+      const resp = await memoryApi.listEntities(
+        filters,
+        { page: 1, pageSize: 100 }
+      );
       set({ entities: resp.data, loading: false });
     } catch (err) {
       set({ error: handleApiError(err), loading: false });


### PR DESCRIPTION
## Summary
- switch memory observations and entity routers to use `PaginationParams`
- support `PaginationParams` in memory services
- update project files router and service for new pagination
- adjust frontend API for pagination params
- add tests for updated endpoints

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841bde0eaa8832c8389405ecc20d0e0