### PR TITLE
Add enum endpoint and integrate frontend

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 def include_app_routers(app: FastAPI):
     from .routers import (
         users, projects, tasks, comments, agents, memory,
-        mcp, rules, project_templates, audit_logs
+        mcp, rules, project_templates, audit_logs, enums
     )
     from .routers.admin import router as admin_router
     from .routers.users.auth.auth import router as auth_router
@@ -66,6 +66,7 @@ def include_app_routers(app: FastAPI):
         tags=["templates"],
     )
     app.include_router(audit_logs.router, prefix="/api/audit-logs", tags=["audit-logs"])
+    app.include_router(enums.router, prefix="/api", tags=["enums"])
 
 
 @asynccontextmanager

--- a/backend/routers/enums.py
+++ b/backend/routers/enums.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter
+
+from ..enums import TaskStatusEnum
+from ..schemas.api_responses import ListResponse
+
+router = APIRouter(prefix="/enums", tags=["enums"])
+
+
+@router.get("/task-status", response_model=ListResponse[str])
+async def get_task_status() -> ListResponse[str]:
+    """Return list of task status enum values."""
+    statuses = [status.value for status in TaskStatusEnum]
+    return ListResponse[str](
+        data=statuses,
+        total=len(statuses),
+        page=1,
+        page_size=len(statuses),
+        has_more=False,
+        message="Task status enums"
+    )

--- a/backend/tests/test_enum_endpoint.py
+++ b/backend/tests/test_enum_endpoint.py
@@ -1,0 +1,21 @@
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient, ASGITransport
+
+from backend.routers.enums import router
+from backend.enums import TaskStatusEnum
+
+app = FastAPI()
+app.include_router(router)
+
+
+@pytest.mark.asyncio
+async def test_task_status_enum_endpoint():
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.get("/enums/task-status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert set(data["data"]) == {status.value for status in TaskStatusEnum}

--- a/frontend/src/components/BulkActionsBar.tsx
+++ b/frontend/src/components/BulkActionsBar.tsx
@@ -14,6 +14,7 @@ import {
 } from "@chakra-ui/react";
 import { ChevronDownIcon, DeleteIcon } from "@chakra-ui/icons";
 import * as statusUtils from "@/lib/statusUtils";
+import { enumApi } from "@/services/api";
 import AppIcon from "./common/AppIcon";
 import { typography } from "../tokens";
 
@@ -36,11 +37,19 @@ const BulkActionsBar: React.FC<BulkActionsBarProps> = ({
   bulkSetStatusTasks,
   loading = false,
 }) => {
-  const availableStatuses = React.useMemo(() => {
-    return statusUtils.getAllStatusIds().filter((id) => {
-      const attrs = statusUtils.getStatusAttributes(id);
-      return !attrs?.isTerminal && !attrs?.isDynamic;
-    });
+  const [availableStatuses, setAvailableStatuses] = React.useState<string[]>([]);
+
+  React.useEffect(() => {
+    enumApi
+      .getTaskStatuses()
+      .then((list) => {
+        const filtered = list.filter((id) => {
+          const attrs = statusUtils.getStatusAttributes(id as statusUtils.StatusID);
+          return !attrs?.isTerminal && !attrs?.isDynamic;
+        });
+        setAvailableStatuses(filtered);
+      })
+      .catch((err) => console.error('Failed to fetch task statuses', err));
   }, []);
 
   if (selectedTaskIds.length === 0 && allFilterableTaskIds.length === 0) {

--- a/frontend/src/components/forms/TaskForm.tsx
+++ b/frontend/src/components/forms/TaskForm.tsx
@@ -13,6 +13,7 @@ import {
 } from "@chakra-ui/react";
 import { useTaskStore } from "@/store/taskStore";
 import { TaskCreateData, TaskUpdateData, TaskStatus } from "@/types";
+import { enumApi } from "@/services/api";
 import AppIcon from "../common/AppIcon";
 
 interface TaskFormProps {
@@ -44,10 +45,20 @@ const TaskForm: React.FC<TaskFormProps> = ({
   const [projectId, setProjectId] = useState(initialData.project_id || "");
   const [agentId, setAgentId] = useState(initialData.agent_id || "");
   const [status, setStatus] = useState(initialData.status || TaskStatus.TO_DO);
+  const [availableStatuses, setAvailableStatuses] = useState<string[]>(
+    Object.values(TaskStatus)
+  );
 
   useEffect(() => {
     fetchProjectsAndAgents();
   }, [fetchProjectsAndAgents]);
+
+  useEffect(() => {
+    enumApi
+      .getTaskStatuses()
+      .then((list) => setAvailableStatuses(list))
+      .catch((err) => console.error('Failed to fetch task statuses', err));
+  }, []);
 
   useEffect(() => {
     setTitle(initialData.title || "");
@@ -59,6 +70,15 @@ const TaskForm: React.FC<TaskFormProps> = ({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!availableStatuses.includes(status)) {
+      toast({
+        title: 'Invalid status',
+        status: 'error',
+        duration: 3000,
+        isClosable: true,
+      });
+      return;
+    }
     try {
       await onSubmit({
         title,
@@ -221,9 +241,9 @@ const TaskForm: React.FC<TaskFormProps> = ({
             _focus={{ borderColor: "borderFocused", boxShadow: "outline" }}
             _placeholder={{ color: "textPlaceholder" }}
           >
-            {Object.values(TaskStatus).map((s) => (
+            {availableStatuses.map((s) => (
               <option key={s} value={s}>
-                {s.replace(/_/g, " ").toUpperCase()}
+                {s.replace(/_/g, ' ').toUpperCase()}
               </option>
             ))}
           </Select>

--- a/frontend/src/services/api/config.ts
+++ b/frontend/src/services/api/config.ts
@@ -18,6 +18,7 @@ export const API_CONFIG = {
     MEMORY: "/memory",
     RULES: "/rules",
     MCP_TOOLS: "/mcp-tools",
+    ENUMS: "/enums",
     VERIFICATION_REQUIREMENTS: "/verification-requirements",
   },
 } as const;

--- a/frontend/src/services/api/enumApi.ts
+++ b/frontend/src/services/api/enumApi.ts
@@ -1,0 +1,10 @@
+import { request } from './request';
+import { buildApiUrl, API_CONFIG } from './config';
+
+export const enumApi = {
+  async getTaskStatuses(): Promise<string[]> {
+    return request<string[]>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.ENUMS, '/task-status')
+    );
+  },
+};

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -18,3 +18,4 @@ export * from './verification_requirements';
 export * from './error_protocols';
 export * from './agent_capabilities';
 export * from './user_roles';
+export * from './enumApi';


### PR DESCRIPTION
## Summary
- expose backend `/api/enums/task-status` for enumerations
- fetch task statuses from the new endpoint
- use fetched statuses in TaskForm and BulkActionsBar

## Testing
- `flake8 routers/enums.py tests/test_enum_endpoint.py`
- `pytest -q tests/test_enum_endpoint.py` *(fails: ModuleNotFoundError: Cannot import name 'Undefined' from 'pydantic.fields')*
- `npm run lint`
- `npm run type-check` *(fails with multiple TS errors)*
- `npm test` *(fails with several test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6841b834c454832cb90201a9839741a1