### PR TITLE
Add typed params for MCP rule API

### DIFF
--- a/frontend/src/services/api/mcp.ts
+++ b/frontend/src/services/api/mcp.ts
@@ -19,6 +19,8 @@ import type {
   MCPProjectFileRemoveRequest,
   MCPProjectTemplateCreateRequest,
   MCPProjectTemplateDeleteRequest,
+  MCPRuleMandateCreateRequest,
+  MCPAgentRuleCreateRequest,
   MCPToolInfo,
 } from '@/types/mcp';
 import type { ProjectFileAssociation } from './projects';
@@ -322,12 +324,9 @@ export const mcpApi = {
 
   // --- Rule MCP Tools ---
   rule: {
-    createMandate: async (data: {
-      title: string;
-      description: string;
-      priority?: number;
-      is_active?: boolean;
-    }): Promise<MCPToolResponse> => {
+    createMandate: async (
+      data: MCPRuleMandateCreateRequest
+    ): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
         buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/rule/mandate/create'),
         {
@@ -337,12 +336,9 @@ export const mcpApi = {
       );
     },
 
-    createAgentRule: async (data: {
-      agent_id: string;
-      rule_type: string;
-      rule_content: string;
-      is_active?: boolean;
-    }): Promise<MCPToolResponse> => {
+    createAgentRule: async (
+      data: MCPAgentRuleCreateRequest
+    ): Promise<MCPToolResponse> => {
       return await request<MCPToolResponse>(
         buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/rule/agent/create'),
         {

--- a/frontend/src/types/mcp.ts
+++ b/frontend/src/types/mcp.ts
@@ -185,3 +185,26 @@ export interface MCPToolInfo {
   parameters: Record<string, any>;
   example?: Record<string, any>;
 }
+
+// --- MCP Rule Tool Schemas ---
+export const mcpRuleMandateCreateRequestSchema = z.object({
+  title: z.string(),
+  description: z.string(),
+  priority: z.number().optional(),
+  is_active: z.boolean().optional(),
+});
+
+export type MCPRuleMandateCreateRequest = z.infer<
+  typeof mcpRuleMandateCreateRequestSchema
+>;
+
+export const mcpAgentRuleCreateRequestSchema = z.object({
+  agent_id: z.string(),
+  rule_type: z.string(),
+  rule_content: z.string(),
+  is_active: z.boolean().optional(),
+});
+
+export type MCPAgentRuleCreateRequest = z.infer<
+  typeof mcpAgentRuleCreateRequestSchema
+>;


### PR DESCRIPTION
## Summary
- define `MCPRuleMandateCreateRequest` and `MCPAgentRuleCreateRequest` interfaces
- use these interfaces in the MCP API service

## Testing
- `npm run type-check` *(fails: numerous existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841be1df468832cb63d4a470e68f557