### PR TITLE
Apply TestWrapper across component tests

### DIFF
--- a/frontend/src/components/ThemeToggleButton/__tests__/ThemeToggleButton.test.tsx
+++ b/frontend/src/components/ThemeToggleButton/__tests__/ThemeToggleButton.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import ThemeToggleButton from '../ThemeToggleButton';

--- a/frontend/src/components/__tests__/AgentList.test.tsx
+++ b/frontend/src/components/__tests__/AgentList.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, TestWrapper } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import AgentList from '../AgentList';
 
@@ -20,7 +20,7 @@ describe('AgentList', () => {
   });
 
   it('should render without crashing', () => {
-    render(<AgentList />);
+    render(<AgentList />, { wrapper: TestWrapper });
     expect(document.body).toBeInTheDocument();
   });
 
@@ -30,14 +30,14 @@ describe('AgentList', () => {
       'data-testid': 'test-component'
     };
     
-    render(<AgentList {...props} />);
+    render(<AgentList {...props} />, { wrapper: TestWrapper });
     
     const component = screen.queryByTestId('test-component');
     expect(component || document.body).toBeInTheDocument();
   });
 
   it('should handle user interactions', async () => {
-    render(<AgentList />);
+    render(<AgentList />, { wrapper: TestWrapper });
     
     const buttons = screen.queryAllByRole('button');
     const inputs = screen.queryAllByRole('textbox');

--- a/frontend/src/components/__tests__/ClientOnly.test.tsx
+++ b/frontend/src/components/__tests__/ClientOnly.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import ClientOnly from '../ClientOnly';

--- a/frontend/src/components/__tests__/Dashboard.test.tsx
+++ b/frontend/src/components/__tests__/Dashboard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import Dashboard from '../Dashboard';

--- a/frontend/src/components/__tests__/ErrorProtocolManager.test.tsx
+++ b/frontend/src/components/__tests__/ErrorProtocolManager.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
-import { render, screen } from '@/__tests__/utils/test-utils';
+import { render, screen, TestWrapper } from '@/__tests__/utils/test-utils';
 import ErrorProtocolManager from '../ErrorProtocolManager';
 
 vi.mock('@chakra-ui/react', async () => {
@@ -29,14 +29,14 @@ describe('ErrorProtocolManager', () => {
 
   it('renders component', () => {
     render(<ErrorProtocolManager agentRoleId="role1" />, {
-      wrapper: ({ children }) => <div>{children}</div>,
+      wrapper: TestWrapper,
     });
     expect(document.body).toBeInTheDocument();
   });
 
   it('handles create flow', async () => {
     render(<ErrorProtocolManager agentRoleId="role1" />, {
-      wrapper: ({ children }) => <div>{children}</div>,
+      wrapper: TestWrapper,
     });
 
     await user.type(screen.getByPlaceholderText('Error Type'), 'Type');

--- a/frontend/src/components/__tests__/LoadingSkeleton.test.tsx
+++ b/frontend/src/components/__tests__/LoadingSkeleton.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import LoadingSkeleton from '../LoadingSkeleton';

--- a/frontend/src/components/__tests__/MCPDevTools.test.tsx
+++ b/frontend/src/components/__tests__/MCPDevTools.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen } from "@/__tests__/utils/test-utils";
 import userEvent from "@testing-library/user-event";
 import { TestWrapper } from "@/__tests__/utils/test-utils";
 import MCPDevTools from "../MCPDevTools";

--- a/frontend/src/components/__tests__/NoTasks.test.tsx
+++ b/frontend/src/components/__tests__/NoTasks.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@/__tests__/utils/test-utils';
+import { render, screen, TestWrapper } from '@/__tests__/utils/test-utils';
 import NoTasks from '../NoTasks';
 
 vi.mock('@chakra-ui/react', async () => {
@@ -18,7 +18,7 @@ describe('NoTasks', () => {
 
   it('shows empty state and calls add', async () => {
     const add = vi.fn();
-    render(<NoTasks onAddTask={add} />);
+    render(<NoTasks onAddTask={add} />, { wrapper: TestWrapper });
     expect(screen.getByText('No Tasks Found')).toBeInTheDocument();
     await screen.getByRole('button', { name: /add your first task/i }).click();
     expect(add).toHaveBeenCalled();

--- a/frontend/src/components/__tests__/ProjectList.test.tsx
+++ b/frontend/src/components/__tests__/ProjectList.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import ProjectList from '../project/ProjectList';

--- a/frontend/src/components/__tests__/SettingsContent.test.tsx
+++ b/frontend/src/components/__tests__/SettingsContent.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import SettingsContent from '../SettingsContent';

--- a/frontend/src/components/__tests__/TaskAgentTag.test.tsx
+++ b/frontend/src/components/__tests__/TaskAgentTag.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import TaskAgentTag from '../TaskAgentTag';

--- a/frontend/src/components/__tests__/TaskControls.test.tsx
+++ b/frontend/src/components/__tests__/TaskControls.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import TaskControls from '../TaskControls';

--- a/frontend/src/components/__tests__/TaskError.test.tsx
+++ b/frontend/src/components/__tests__/TaskError.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@/__tests__/utils/test-utils';
+import { render, screen, TestWrapper } from '@/__tests__/utils/test-utils';
 import TaskError from '../TaskError';
 
 vi.mock('@chakra-ui/react', async () => {
@@ -18,7 +18,7 @@ describe('TaskError', () => {
 
   it('displays error and retry', async () => {
     const retry = vi.fn();
-    render(<TaskError error="Oops" onRetry={retry} />);
+    render(<TaskError error="Oops" onRetry={retry} />, { wrapper: TestWrapper });
     expect(screen.getByText('Oops')).toBeInTheDocument();
     await screen.getByRole('button', { name: /retry/i }).click();
     expect(retry).toHaveBeenCalled();

--- a/frontend/src/components/__tests__/TaskItemModals.test.tsx
+++ b/frontend/src/components/__tests__/TaskItemModals.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import TaskItemModals from '../TaskItemModals';

--- a/frontend/src/components/__tests__/TaskList.test.tsx
+++ b/frontend/src/components/__tests__/TaskList.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor, fireEvent } from '@/__tests__/utils/test-utils'
+import { render, screen, waitFor, fireEvent, TestWrapper } from '@/__tests__/utils/test-utils'
 import { createMockTask, createMockTasks } from '@/__tests__/factories'
 import TaskList from '../TaskList'
 import { useTaskStore } from '@/store/taskStore'
@@ -109,7 +109,7 @@ describe('TaskList', () => {
         selector({ ...defaultStoreState, loading: true } as any)
       )
 
-      render(<TaskList />)
+      render(<TaskList />, { wrapper: TestWrapper })
       
       expect(screen.getByTestId('task-loading')).toBeInTheDocument()
       expect(screen.getByText('Loading tasks...')).toBeInTheDocument()
@@ -123,7 +123,7 @@ describe('TaskList', () => {
         selector({ ...defaultStoreState, fetchTasks, fetchProjectsAndAgents } as any)
       )
 
-      render(<TaskList />)
+      render(<TaskList />, { wrapper: TestWrapper })
       
       expect(fetchTasks).toHaveBeenCalledOnce()
       expect(fetchProjectsAndAgents).toHaveBeenCalledOnce()
@@ -141,7 +141,7 @@ describe('TaskList', () => {
         } as any)
       )
 
-      render(<TaskList />)
+      render(<TaskList />, { wrapper: TestWrapper })
       
       expect(screen.getByTestId('task-error')).toBeInTheDocument()
       expect(screen.getByText('Error: Failed to fetch tasks')).toBeInTheDocument()
@@ -157,7 +157,7 @@ describe('TaskList', () => {
         } as any)
       )
 
-      render(<TaskList />)
+      render(<TaskList />, { wrapper: TestWrapper })
       
       fireEvent.click(screen.getByTestId('retry-button'))
       expect(fetchTasks).toHaveBeenCalled()
@@ -172,7 +172,7 @@ describe('TaskList', () => {
         selector({ ...defaultStoreState, tasks } as any)
       )
 
-      render(<TaskList />)
+      render(<TaskList />, { wrapper: TestWrapper })
       
       expect(screen.getByTestId('list-view')).toBeInTheDocument()
       expect(screen.getAllByTestId('task-item')).toHaveLength(3)
@@ -183,7 +183,7 @@ describe('TaskList', () => {
         selector({ ...defaultStoreState, tasks: [] } as any)
       )
 
-      render(<TaskList />)
+      render(<TaskList />, { wrapper: TestWrapper })
       
       expect(screen.getByTestId('no-tasks')).toBeInTheDocument()
       expect(screen.getByTestId('add-task-button')).toBeInTheDocument()
@@ -198,7 +198,7 @@ describe('TaskList', () => {
         selector({ ...defaultStoreState, tasks } as any)
       )
 
-      render(<TaskList />)
+      render(<TaskList />, { wrapper: TestWrapper })
       
       // Initially shows list view
       expect(screen.getByTestId('list-view')).toBeInTheDocument()
@@ -216,7 +216,7 @@ describe('TaskList', () => {
         selector({ ...defaultStoreState, tasks } as any)
       )
 
-      render(<TaskList />)
+      render(<TaskList />, { wrapper: TestWrapper })
       
       expect(screen.getByTestId('task-controls')).toBeInTheDocument()
       expect(screen.getByTestId('search-input')).toBeInTheDocument()
@@ -229,7 +229,7 @@ describe('TaskList', () => {
         selector({ ...defaultStoreState, tasks } as any)
       )
 
-      render(<TaskList />)
+      render(<TaskList />, { wrapper: TestWrapper })
       
       const searchInput = screen.getByTestId('search-input')
       fireEvent.change(searchInput, { target: { value: 'test search' } })
@@ -250,7 +250,7 @@ describe('TaskList', () => {
         } as any)
       )
 
-      render(<TaskList />)
+      render(<TaskList />, { wrapper: TestWrapper })
       
       // Toast should appear for polling error
       await waitFor(() => {
@@ -270,7 +270,7 @@ describe('TaskList', () => {
         } as any)
       )
 
-      render(<TaskList />)
+      render(<TaskList />, { wrapper: TestWrapper })
       
       await waitFor(() => {
         expect(clearMutationError).toHaveBeenCalledOnce()
@@ -284,7 +284,7 @@ describe('TaskList', () => {
         selector({ ...defaultStoreState, tasks: [] } as any)
       )
 
-      render(<TaskList />)
+      render(<TaskList />, { wrapper: TestWrapper })
       
       fireEvent.click(screen.getByTestId('add-task-button'))
       
@@ -309,7 +309,7 @@ describe('TaskList', () => {
         selector({ ...defaultStoreState, tasks } as any)
       )
 
-      render(<TaskList />)
+      render(<TaskList />, { wrapper: TestWrapper })
       
       expect(screen.getByText('Backend Task')).toBeInTheDocument()
     })
@@ -331,7 +331,7 @@ describe('TaskList', () => {
         selector({ ...defaultStoreState, tasks: [task] } as any)
       )
 
-      render(<TaskList />)
+      render(<TaskList />, { wrapper: TestWrapper })
       
       expect(screen.getByText('Complete Task')).toBeInTheDocument()
     })
@@ -355,7 +355,7 @@ skSet = createMockTasks(100)
       )
 
       const startTime = performance.now()
-      render(<TaskList />)
+      render(<TaskList />, { wrapper: TestWrapper })
       const endTime = performance.now()
       
       // Should render within reasonable time (< 100ms for 100 tasks)
@@ -372,7 +372,7 @@ skSet = createMockTasks(100)
         selector({ ...defaultStoreState, tasks } as any)
       )
 
-      render(<TaskList />)
+      render(<TaskList />, { wrapper: TestWrapper })
       
       // Should have proper landmark structure
       expect(screen.getByTestId('task-controls')).toBeInTheDocument()
@@ -386,7 +386,7 @@ skSet = createMockTasks(100)
         selector({ ...defaultStoreState, tasks } as any)
       )
 
-      render(<TaskList />)
+      render(<TaskList />, { wrapper: TestWrapper })
       
       // Search input should be focusable
       const searchInput = screen.getByTestId('search-input')
@@ -404,7 +404,7 @@ skSet = createMockTasks(100)
         selector({ ...defaultStoreState, tasks } as any)
       )
 
-      render(<TaskList />)
+      render(<TaskList />, { wrapper: TestWrapper })
       
       // Component should render successfully on mobile
       expect(screen.getByTestId('list-view')).toBeInTheDocument()
@@ -424,7 +424,7 @@ skSet = createMockTasks(100)
         } as any)
       )
 
-      render(<TaskList />)
+      render(<TaskList />, { wrapper: TestWrapper })
       
       expect(fetchTasks).toHaveBeenCalled()
       expect(fetchProjectsAndAgents).toHaveBeenCalled()
@@ -437,7 +437,7 @@ skSet = createMockTasks(100)
         selector(storeState as any)
       )
 
-      const { rerender } = render(<TaskList />)
+      const { rerender } = render(<TaskList />, { wrapper: TestWrapper })
       
       expect(screen.getByTestId('task-loading')).toBeInTheDocument()
       
@@ -447,7 +447,7 @@ skSet = createMockTasks(100)
         selector(storeState as any)
       )
       
-      rerender(<TaskList />)
+      rerender(<TaskList />, { wrapper: TestWrapper })
       
       expect(screen.queryByTestId('task-loading')).not.toBeInTheDocument()
       expect(screen.getAllByTestId('task-item')).toHaveLength(2)

--- a/frontend/src/components/__tests__/TaskList.utils.test.tsx
+++ b/frontend/src/components/__tests__/TaskList.utils.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import TaskListUtils from '../TaskList.utils';

--- a/frontend/src/components/__tests__/TaskLoading.test.tsx
+++ b/frontend/src/components/__tests__/TaskLoading.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@/__tests__/utils/test-utils';
+import { render, screen, TestWrapper } from '@/__tests__/utils/test-utils';
 import TaskLoading from '../TaskLoading';
 
 vi.mock('@chakra-ui/react', async () => {
@@ -17,7 +17,7 @@ describe('TaskLoading', () => {
   });
 
   it('renders loading text', () => {
-    render(<TaskLoading />);
+    render(<TaskLoading />, { wrapper: TestWrapper });
     expect(screen.getByText('Loading tasks...')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/__tests__/TaskProjectTag.test.tsx
+++ b/frontend/src/components/__tests__/TaskProjectTag.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import TaskProjectTag from '../TaskProjectTag';

--- a/frontend/src/components/__tests__/TaskStatusTag.test.tsx
+++ b/frontend/src/components/__tests__/TaskStatusTag.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { render, screen } from '@/__tests__/utils/test-utils'
+import { render, screen, TestWrapper } from '@/__tests__/utils/test-utils'
 import { CheckIcon, TimeIcon, WarningIcon } from '@chakra-ui/icons'
 import TaskStatusTag from '../TaskStatusTag'
 
@@ -22,19 +22,19 @@ describe('TaskStatusTag', () => {
 
   describe('Basic Rendering', () => {
     it('should render task status tag with display name', () => {
-      render(<TaskStatusTag {...defaultProps} />)
+      render(<TaskStatusTag {...defaultProps} />, { wrapper: TestWrapper })
       
       expect(screen.getByText('In Progress')).toBeInTheDocument()
     })
 
     it('should apply default font weight when not specified', () => {
-      render(<TaskStatusTag {...defaultProps} />)
+      render(<TaskStatusTag {...defaultProps} />, { wrapper: TestWrapper })
       
       expect(screen.getByText('In Progress')).toBeInTheDocument()
     })
 
     it('should apply custom font weight when specified', () => {
-      render(<TaskStatusTag {...defaultProps} fontWeight="bold" />)
+      render(<TaskStatusTag {...defaultProps} fontWeight="bold" />, { wrapper: TestWrapper })
       
       expect(screen.getByText('In Progress')).toBeInTheDocument()
     })
@@ -43,12 +43,13 @@ describe('TaskStatusTag', () => {
   describe('Status Variants', () => {
     it('should render "To Do" status correctly', () => {
       render(
-        <TaskStatusTag 
+        <TaskStatusTag
           displayName="To Do"
           tagBg="gray.100"
           tagColor="gray.800"
           icon={TimeIcon}
-        />
+        />,
+        { wrapper: TestWrapper },
       )
       
       expect(screen.getByText('To Do')).toBeInTheDocument()
@@ -56,12 +57,13 @@ describe('TaskStatusTag', () => {
 
     it('should render "Completed" status correctly', () => {
       render(
-        <TaskStatusTag 
+        <TaskStatusTag
           displayName="Completed"
           tagBg="green.100"
           tagColor="green.800"
           icon={CheckIcon}
-        />
+        />,
+        { wrapper: TestWrapper },
       )
       
       expect(screen.getByText('Completed')).toBeInTheDocument()
@@ -71,11 +73,12 @@ describe('TaskStatusTag', () => {
   describe('Edge Cases', () => {
     it('should handle empty display name gracefully', () => {
       render(
-        <TaskStatusTag 
+        <TaskStatusTag
           displayName=""
           tagBg="gray.100"
           tagColor="gray.800"
-        />
+        />,
+        { wrapper: TestWrapper },
       )
       
       // Should still render the tag structure
@@ -86,11 +89,12 @@ describe('TaskStatusTag', () => {
     it('should handle very long display names', () => {
       const longName = 'This is a very long status name that might wrap or overflow'
       render(
-        <TaskStatusTag 
+        <TaskStatusTag
           displayName={longName}
           tagBg="blue.100"
           tagColor="blue.800"
-        />
+        />,
+        { wrapper: TestWrapper },
       )
       
       expect(screen.getByText(longName)).toBeInTheDocument()
@@ -99,11 +103,12 @@ describe('TaskStatusTag', () => {
     it('should handle special characters in display name', () => {
       const specialName = 'Status & Progress (50%)'
       render(
-        <TaskStatusTag 
+        <TaskStatusTag
           displayName={specialName}
           tagBg="blue.100"
           tagColor="blue.800"
-        />
+        />,
+        { wrapper: TestWrapper },
       )
       
       expect(screen.getByText(specialName)).toBeInTheDocument()
@@ -119,12 +124,13 @@ describe('TaskStatusTag', () => {
           .replace(/\b\w/g, l => l.toUpperCase())
         
         render(
-          <TaskStatusTag 
+          <TaskStatusTag
             key={status}
             displayName={displayName}
             tagBg="blue.100"
             tagColor="blue.800"
-          />
+          />,
+          { wrapper: TestWrapper },
         )
         
         expect(screen.getByText(displayName)).toBeInTheDocument()

--- a/frontend/src/components/__tests__/ThemeToggleButton.test.tsx
+++ b/frontend/src/components/__tests__/ThemeToggleButton.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@/__tests__/utils/test-utils';
+import { render, screen, TestWrapper } from '@/__tests__/utils/test-utils';
 import ThemeToggleButton from '../ThemeToggleButton';
 
 vi.mock('@chakra-ui/react', async () => {
@@ -23,7 +23,7 @@ describe('ThemeToggleButton', () => {
       toggleColorMode: toggle,
     } as any);
 
-    render(<ThemeToggleButton />);
+    render(<ThemeToggleButton />, { wrapper: TestWrapper });
     await screen.getByRole('button').click();
     expect(toggle).toHaveBeenCalled();
   });

--- a/frontend/src/components/__tests__/useTaskItemStyles.test.tsx
+++ b/frontend/src/components/__tests__/useTaskItemStyles.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import useTaskItemStyles from '../useTaskItemStyles';
 

--- a/frontend/src/components/agent/__tests__/AddAgentModal.test.tsx
+++ b/frontend/src/components/agent/__tests__/AddAgentModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import AddAgentModal from '../AddAgentModal';

--- a/frontend/src/components/agent/__tests__/AgentCard.test.tsx
+++ b/frontend/src/components/agent/__tests__/AgentCard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import AgentCard from '../AgentCard';

--- a/frontend/src/components/agent/__tests__/AgentList.test.tsx
+++ b/frontend/src/components/agent/__tests__/AgentList.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import AgentList from '../AgentList';

--- a/frontend/src/components/agent/__tests__/AgentListHeader.test.tsx
+++ b/frontend/src/components/agent/__tests__/AgentListHeader.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import AgentListHeader from '../AgentListHeader';

--- a/frontend/src/components/agent/__tests__/CliPromptModal.test.tsx
+++ b/frontend/src/components/agent/__tests__/CliPromptModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import CliPromptModal from '../CliPromptModal';

--- a/frontend/src/components/agent/__tests__/EditAgentModal.test.tsx
+++ b/frontend/src/components/agent/__tests__/EditAgentModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import EditAgentModal from '../EditAgentModal';

--- a/frontend/src/components/agents/__tests__/AgentHandoffManager.test.tsx
+++ b/frontend/src/components/agents/__tests__/AgentHandoffManager.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
-import { render, screen } from '@/__tests__/utils/test-utils';
+import { render, screen, TestWrapper } from '@/__tests__/utils/test-utils';
 import AgentHandoffManager from '../AgentHandoffManager';
 import { mockFetchResponse } from '@/__tests__/utils/test-utils';
 
@@ -29,14 +29,14 @@ describe('AgentHandoffManager', () => {
 
   it('renders component', () => {
     render(<AgentHandoffManager agentRoleId="role1" />, {
-      wrapper: ({ children }) => <div>{children}</div>,
+      wrapper: TestWrapper,
     });
     expect(document.body).toBeInTheDocument();
   });
 
   it('handles user interactions and creates criteria', async () => {
     render(<AgentHandoffManager agentRoleId="role1" />, {
-      wrapper: ({ children }) => <div>{children}</div>,
+      wrapper: TestWrapper,
     });
 
     const input = screen.getByPlaceholderText('New criteria');

--- a/frontend/src/components/audit_logs/__tests__/AuditLogListForEntity.test.tsx
+++ b/frontend/src/components/audit_logs/__tests__/AuditLogListForEntity.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import AuditLogListForEntity from '../AuditLogListForEntity';

--- a/frontend/src/components/common/__tests__/AddFormBase.test.tsx
+++ b/frontend/src/components/common/__tests__/AddFormBase.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import AddFormBase from '../AddFormBase';

--- a/frontend/src/components/common/__tests__/AppIcon.test.tsx
+++ b/frontend/src/components/common/__tests__/AppIcon.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import AppIcon from '../AppIcon';

--- a/frontend/src/components/common/__tests__/ConfirmationModal.test.tsx
+++ b/frontend/src/components/common/__tests__/ConfirmationModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import ConfirmationModal from '../ConfirmationModal';

--- a/frontend/src/components/common/__tests__/EditModalBase.test.tsx
+++ b/frontend/src/components/common/__tests__/EditModalBase.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import EditModalBase from '../EditModalBase';

--- a/frontend/src/components/common/__tests__/FilterPanel.test.tsx
+++ b/frontend/src/components/common/__tests__/FilterPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import FilterPanel from '../FilterPanel';

--- a/frontend/src/components/common/__tests__/FilterSidebar.test.tsx
+++ b/frontend/src/components/common/__tests__/FilterSidebar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import FilterSidebar from '../FilterSidebar';

--- a/frontend/src/components/common/__tests__/TaskActionsMenu.test.tsx
+++ b/frontend/src/components/common/__tests__/TaskActionsMenu.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import TaskActionsMenu from '../TaskActionsMenu';

--- a/frontend/src/components/common/__tests__/TaskAgentTag.test.tsx
+++ b/frontend/src/components/common/__tests__/TaskAgentTag.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import TaskAgentTag from '../TaskAgentTag';

--- a/frontend/src/components/common/__tests__/TaskDependencyTag.test.tsx
+++ b/frontend/src/components/common/__tests__/TaskDependencyTag.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import TaskDependencyTag from '../TaskDependencyTag';

--- a/frontend/src/components/common/__tests__/TaskDescriptionEditor.test.tsx
+++ b/frontend/src/components/common/__tests__/TaskDescriptionEditor.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import TaskDescriptionEditor from '../TaskDescriptionEditor';

--- a/frontend/src/components/common/__tests__/TaskProjectTag.test.tsx
+++ b/frontend/src/components/common/__tests__/TaskProjectTag.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import TaskProjectTag from '../TaskProjectTag';

--- a/frontend/src/components/common/__tests__/TaskStatusTag.test.tsx
+++ b/frontend/src/components/common/__tests__/TaskStatusTag.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import TaskStatusTag from '../TaskStatusTag';

--- a/frontend/src/components/common/__tests__/TaskTitleEditor.test.tsx
+++ b/frontend/src/components/common/__tests__/TaskTitleEditor.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import TaskTitleEditor from '../TaskTitleEditor';

--- a/frontend/src/components/dashboard/__tests__/AgentWorkloadChart.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/AgentWorkloadChart.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import AgentWorkloadChart from '../AgentWorkloadChart';

--- a/frontend/src/components/dashboard/__tests__/CreateProjectModal.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/CreateProjectModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import CreateProjectModal from '../CreateProjectModal';

--- a/frontend/src/components/dashboard/__tests__/DashboardError.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/DashboardError.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import DashboardError from '../DashboardError';

--- a/frontend/src/components/dashboard/__tests__/DashboardHeader.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/DashboardHeader.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import DashboardHeader from '../DashboardHeader';

--- a/frontend/src/components/dashboard/__tests__/DashboardLoading.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/DashboardLoading.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import DashboardLoading from '../DashboardLoading';

--- a/frontend/src/components/dashboard/__tests__/DashboardSection.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/DashboardSection.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import DashboardSection from '../DashboardSection';

--- a/frontend/src/components/dashboard/__tests__/DashboardSidebar.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/DashboardSidebar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import DashboardSidebar from '../DashboardSidebar';

--- a/frontend/src/components/dashboard/__tests__/DashboardStatsGrid.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/DashboardStatsGrid.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import DashboardStatsGrid from '../DashboardStatsGrid';

--- a/frontend/src/components/dashboard/__tests__/DashboardViews.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/DashboardViews.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import DashboardViews from '../DashboardViews';

--- a/frontend/src/components/dashboard/__tests__/EditProjectModal.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/EditProjectModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import EditProjectModal from '../EditProjectModal';

--- a/frontend/src/components/dashboard/__tests__/ProjectProgressChart.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/ProjectProgressChart.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import ProjectProgressChart from '../ProjectProgressChart';

--- a/frontend/src/components/dashboard/__tests__/RecentActivityList.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/RecentActivityList.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import RecentActivityList from '../RecentActivityList';

--- a/frontend/src/components/dashboard/__tests__/TaskStatusChart.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/TaskStatusChart.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import TaskStatusChart from '../TaskStatusChart';

--- a/frontend/src/components/dashboard/__tests__/TasksOverTimeChart.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/TasksOverTimeChart.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import TasksOverTimeChart from '../TasksOverTimeChart';

--- a/frontend/src/components/dashboard/__tests__/TopPerformersLists.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/TopPerformersLists.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import TopPerformersLists from '../TopPerformersLists';

--- a/frontend/src/components/dashboard/__tests__/UnassignedTasksList.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/UnassignedTasksList.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import UnassignedTasksList from '../UnassignedTasksList';

--- a/frontend/src/components/dashboard/__tests__/useDashboardData.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/useDashboardData.test.tsx
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-// import { screen, fireEvent, waitFor } from '@testing-library/react';
+// import { screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import useDashboardData from '../useDashboardData';
-// import { renderHook } from '@testing-library/react';
+// import { renderHook } from '@/__tests__/utils/test-utils';
 
 vi.mock('@chakra-ui/react', async () => {
   const actual = await vi.importActual('@chakra-ui/react');

--- a/frontend/src/components/forms/__tests__/AddAgentForm.test.tsx
+++ b/frontend/src/components/forms/__tests__/AddAgentForm.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import AddAgentForm from '../AddAgentForm';

--- a/frontend/src/components/forms/__tests__/AddProjectForm.test.tsx
+++ b/frontend/src/components/forms/__tests__/AddProjectForm.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import AddProjectForm from '../AddProjectForm';

--- a/frontend/src/components/forms/__tests__/AddProjectTemplateForm.test.tsx
+++ b/frontend/src/components/forms/__tests__/AddProjectTemplateForm.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
-import { render, screen } from '@/__tests__/utils/test-utils';
+import { render, screen, TestWrapper } from '@/__tests__/utils/test-utils';
 import AddProjectTemplateForm from '../AddProjectTemplateForm';
 
 vi.mock('@chakra-ui/react', async () => {
@@ -20,12 +20,12 @@ describe('AddProjectTemplateForm', () => {
   });
 
   it('renders without crashing', () => {
-    render(<AddProjectTemplateForm onSubmit={vi.fn()} onCancel={vi.fn()} />);
+    render(<AddProjectTemplateForm onSubmit={vi.fn()} onCancel={vi.fn()} />, { wrapper: TestWrapper });
     expect(document.body).toBeInTheDocument();
   });
 
   it('handles user input', async () => {
-    render(<AddProjectTemplateForm onSubmit={vi.fn()} onCancel={vi.fn()} />);
+    render(<AddProjectTemplateForm onSubmit={vi.fn()} onCancel={vi.fn()} />, { wrapper: TestWrapper });
     const inputs = screen.getAllByRole('textbox');
     if (inputs.length) {
       await user.type(inputs[0], 'test');

--- a/frontend/src/components/forms/__tests__/AddTaskForm.test.tsx
+++ b/frontend/src/components/forms/__tests__/AddTaskForm.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import AddTaskForm from '../AddTaskForm';

--- a/frontend/src/components/forms/__tests__/EditAgentForm.test.tsx
+++ b/frontend/src/components/forms/__tests__/EditAgentForm.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import EditAgentForm from '../EditAgentForm';

--- a/frontend/src/components/forms/__tests__/TaskForm.test.tsx
+++ b/frontend/src/components/forms/__tests__/TaskForm.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import TaskForm from '../TaskForm';

--- a/frontend/src/components/layout/__tests__/MainContent.test.tsx
+++ b/frontend/src/components/layout/__tests__/MainContent.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import MainContent from '../MainContent';

--- a/frontend/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/frontend/src/components/layout/__tests__/Sidebar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import Sidebar from '../Sidebar';

--- a/frontend/src/components/modals/__tests__/AddAgentModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/AddAgentModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import AddAgentModal from '../AddAgentModal';

--- a/frontend/src/components/modals/__tests__/AddProjectModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/AddProjectModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import AddProjectModal from '../AddProjectModal';

--- a/frontend/src/components/modals/__tests__/AddTaskModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/AddTaskModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import AddTaskModal from '../AddTaskModal';

--- a/frontend/src/components/modals/__tests__/AgentAssignmentModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/AgentAssignmentModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import AgentAssignmentModal from '../AgentAssignmentModal';

--- a/frontend/src/components/modals/__tests__/CreateProjectModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/CreateProjectModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import CreateProjectModal from '../CreateProjectModal';

--- a/frontend/src/components/modals/__tests__/DevToolsDrawer.test.tsx
+++ b/frontend/src/components/modals/__tests__/DevToolsDrawer.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import DevToolsDrawer from '../DevToolsDrawer';

--- a/frontend/src/components/modals/__tests__/EditAgentModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/EditAgentModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import EditAgentModal from '../EditAgentModal';

--- a/frontend/src/components/modals/__tests__/EditProjectModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/EditProjectModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import EditProjectModal from '../EditProjectModal';

--- a/frontend/src/components/modals/__tests__/EditTaskModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/EditTaskModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import EditTaskModal from '../EditTaskModal';

--- a/frontend/src/components/modals/__tests__/ImportPlanModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/ImportPlanModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import ImportPlanModal from '../ImportPlanModal';

--- a/frontend/src/components/modals/__tests__/TaskDetailsModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/TaskDetailsModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import TaskDetailsModal from '../TaskDetailsModal';

--- a/frontend/src/components/project/__tests__/ProjectDetail.test.tsx
+++ b/frontend/src/components/project/__tests__/ProjectDetail.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import ProjectDetail from '../ProjectDetail';

--- a/frontend/src/components/project/__tests__/ProjectFiles.test.tsx
+++ b/frontend/src/components/project/__tests__/ProjectFiles.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@/__tests__/utils/test-utils';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import ProjectFiles from '../ProjectFiles';
 

--- a/frontend/src/components/project/__tests__/ProjectList.test.tsx
+++ b/frontend/src/components/project/__tests__/ProjectList.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import ProjectList from '../ProjectList';

--- a/frontend/src/components/project/__tests__/ProjectMembers.test.tsx
+++ b/frontend/src/components/project/__tests__/ProjectMembers.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import ProjectMembers from '../ProjectMembers';

--- a/frontend/src/components/task/__tests__/TaskFilters.test.tsx
+++ b/frontend/src/components/task/__tests__/TaskFilters.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent } from '@/__tests__/utils/test-utils';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import TaskFilters from '../TaskFilters';
 

--- a/frontend/src/components/task/__tests__/TaskItem.styles.test.tsx
+++ b/frontend/src/components/task/__tests__/TaskItem.styles.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import TaskItemStyles from '../TaskItem.styles';

--- a/frontend/src/components/task/__tests__/TaskItem.test.tsx
+++ b/frontend/src/components/task/__tests__/TaskItem.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import TaskItem from '../TaskItem';

--- a/frontend/src/components/task/__tests__/TaskItem.types.test.tsx
+++ b/frontend/src/components/task/__tests__/TaskItem.types.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import TaskItemTypes from '../TaskItem.types';

--- a/frontend/src/components/task/__tests__/TaskItem.utils.test.tsx
+++ b/frontend/src/components/task/__tests__/TaskItem.utils.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import TaskItemUtils from '../TaskItem.utils';

--- a/frontend/src/components/task/__tests__/TaskItemDetailsSection.test.tsx
+++ b/frontend/src/components/task/__tests__/TaskItemDetailsSection.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import TaskItemDetailsSection from '../TaskItemDetailsSection';

--- a/frontend/src/components/task/__tests__/TaskItemMainSection.test.tsx
+++ b/frontend/src/components/task/__tests__/TaskItemMainSection.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import TaskItemMainSection from '../TaskItemMainSection';

--- a/frontend/src/components/task/__tests__/TaskPagination.test.tsx
+++ b/frontend/src/components/task/__tests__/TaskPagination.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent } from '@/__tests__/utils/test-utils';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import TaskPagination from '../TaskPagination';
 

--- a/frontend/src/components/task/__tests__/TaskRow.test.tsx
+++ b/frontend/src/components/task/__tests__/TaskRow.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent } from '@/__tests__/utils/test-utils';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import { createMockTask } from '@/__tests__/factories';
 import TaskRow from '../TaskRow';

--- a/frontend/src/components/template/__tests__/TemplateList.test.tsx
+++ b/frontend/src/components/template/__tests__/TemplateList.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, fireEvent } from '@/__tests__/utils/test-utils';
+import { render, screen, fireEvent, TestWrapper } from '@/__tests__/utils/test-utils';
 import TemplateList from '../TemplateList';
 import { useTemplateStore } from '@/store/templateStore';
 
@@ -35,7 +35,7 @@ describe('TemplateList', () => {
       selector(state as any)
     );
 
-    render(<TemplateList />);
+    render(<TemplateList />, { wrapper: TestWrapper });
 
     const deleteBtn = screen.getByLabelText('Delete');
     fireEvent.click(deleteBtn);

--- a/frontend/src/components/user/__tests__/LoginForm.test.tsx
+++ b/frontend/src/components/user/__tests__/LoginForm.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@/__tests__/utils/test-utils";
 import userEvent from "@testing-library/user-event";
 import { TestWrapper } from "@/__tests__/utils/test-utils";
 import { useAuthStore } from "@/store/authStore";

--- a/frontend/src/components/user/__tests__/UserProfile.test.tsx
+++ b/frontend/src/components/user/__tests__/UserProfile.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import UserProfile from '../UserProfile';

--- a/frontend/src/components/views/__tests__/KanbanColumn.test.tsx
+++ b/frontend/src/components/views/__tests__/KanbanColumn.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import KanbanColumn from '../KanbanColumn';

--- a/frontend/src/components/views/__tests__/KanbanView.test.tsx
+++ b/frontend/src/components/views/__tests__/KanbanView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import KanbanView from '../KanbanView';

--- a/frontend/src/components/views/__tests__/ListGroup.test.tsx
+++ b/frontend/src/components/views/__tests__/ListGroup.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import ListGroup from '../ListGroup';

--- a/frontend/src/components/views/__tests__/ListSubgroup.test.tsx
+++ b/frontend/src/components/views/__tests__/ListSubgroup.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import ListSubgroup from '../ListSubgroup';

--- a/frontend/src/components/views/__tests__/ListTaskItem.test.tsx
+++ b/frontend/src/components/views/__tests__/ListTaskItem.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import ListTaskItem from '../ListTaskItem';

--- a/frontend/src/components/views/__tests__/ListTaskMobile.test.tsx
+++ b/frontend/src/components/views/__tests__/ListTaskMobile.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import ListTaskMobile from '../ListTaskMobile';

--- a/frontend/src/components/views/__tests__/ListView.test.tsx
+++ b/frontend/src/components/views/__tests__/ListView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import ListView from '../ListView';

--- a/frontend/src/components/views/__tests__/ListView.types.test.tsx
+++ b/frontend/src/components/views/__tests__/ListView.types.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import { ListViewTypes } from '../ListView.types';

--- a/frontend/src/contexts/__tests__/ThemeContext.test.tsx
+++ b/frontend/src/contexts/__tests__/ThemeContext.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { TestWrapper } from '@/__tests__/utils/test-utils';
 import { ThemeContext } from '../ThemeContext';

--- a/frontend/src/hooks/__tests__/useFilteredProjects.test.tsx
+++ b/frontend/src/hooks/__tests__/useFilteredProjects.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { renderHook } from '@testing-library/react';
+import { renderHook } from '@/__tests__/utils/test-utils';
 import { useFilteredProjects } from '../useFilteredProjects';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/hooks/__tests__/useFilteredTasks.test.tsx
+++ b/frontend/src/hooks/__tests__/useFilteredTasks.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { renderHook } from '@testing-library/react';
+import { renderHook } from '@/__tests__/utils/test-utils';
 import { useFilteredTasks } from '../useFilteredTasks';
 
 vi.mock('@chakra-ui/react', async () => {

--- a/frontend/src/hooks/__tests__/useProjectData.test.tsx
+++ b/frontend/src/hooks/__tests__/useProjectData.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { renderHook, act, waitFor } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@/__tests__/utils/test-utils';
 import { useProjectData } from '../useProjectData';
 import { TaskStatus } from '@/types/task';
 import * as api from '@/services/api';

--- a/frontend/src/providers/__tests__/ChakraProviderWrapper.test.tsx
+++ b/frontend/src/providers/__tests__/ChakraProviderWrapper.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import ChakraProviderWrapper from '../ChakraProviderWrapper';
 import { useTheme } from '../../contexts/ThemeContext';

--- a/frontend/src/providers/__tests__/ModalProvider.test.tsx
+++ b/frontend/src/providers/__tests__/ModalProvider.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen } from '@/__tests__/utils/test-utils';
 import ModalProvider from '../ModalProvider';
 import Modal from 'react-modal';
 

--- a/frontend/src/services/api/__tests__/memory.test.tsx
+++ b/frontend/src/services/api/__tests__/memory.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import memory from '../memory';
 

--- a/frontend/src/services/api/__tests__/planning.test.tsx
+++ b/frontend/src/services/api/__tests__/planning.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import planning from '../planning';
 

--- a/frontend/src/theme/__tests__/chakra-theme.test.tsx
+++ b/frontend/src/theme/__tests__/chakra-theme.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import chakraTheme from '../chakra-theme';
 

--- a/frontend/src/tokens/__tests__/blur.test.tsx
+++ b/frontend/src/tokens/__tests__/blur.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import blur from '../blur';
 

--- a/frontend/src/tokens/__tests__/breakpoints.test.tsx
+++ b/frontend/src/tokens/__tests__/breakpoints.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import breakpoints from '../breakpoints';
 

--- a/frontend/src/tokens/__tests__/colors.test.tsx
+++ b/frontend/src/tokens/__tests__/colors.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import colors from '../colors';
 

--- a/frontend/src/tokens/__tests__/opacity.test.tsx
+++ b/frontend/src/tokens/__tests__/opacity.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import opacity from '../opacity';
 

--- a/frontend/src/tokens/__tests__/shadows.test.tsx
+++ b/frontend/src/tokens/__tests__/shadows.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import shadows from '../shadows';
 

--- a/frontend/src/tokens/__tests__/sizing.test.tsx
+++ b/frontend/src/tokens/__tests__/sizing.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import sizing from '../sizing';
 

--- a/frontend/src/tokens/__tests__/transitions.test.tsx
+++ b/frontend/src/tokens/__tests__/transitions.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import transitions from '../transitions';
 

--- a/frontend/src/tokens/__tests__/typography.test.tsx
+++ b/frontend/src/tokens/__tests__/typography.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import typography from '../typography';
 

--- a/frontend/src/tokens/__tests__/zIndex.test.tsx
+++ b/frontend/src/tokens/__tests__/zIndex.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@/__tests__/utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import zIndex from '../zIndex';
 


### PR DESCRIPTION
## Summary
- update all component test imports to use `render` from `src/__tests__/utils/test-utils`
- wrap direct `render` calls with `TestWrapper`

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend run test:run` *(fails: Cannot read properties of undefined / observer.observe is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6841be266490832caab0afc64d44cf8c