### PR TITLE
Sync status enums and add unit test

### DIFF
--- a/frontend/src/lib/__tests__/utils.test.tsx
+++ b/frontend/src/lib/__tests__/utils.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { formatDisplayName, mapStatusToStatusID } from '../utils';
+import { getAllStatusIds } from '../statusUtils';
+import { TaskStatus } from '@/types/task';
 
 describe('Utils', () => {
   beforeEach(() => {
@@ -103,6 +105,18 @@ describe('Utils', () => {
       expect(mapStatusToStatusID(123)).toBe('TO_DO');
       // @ts-expect-error - testing runtime behavior with invalid types
       expect(mapStatusToStatusID({})).toBe('TO_DO');
+    });
+  });
+
+  describe('getAllStatusIds', () => {
+    it('returns the same enum values as TaskStatusEnum', () => {
+      const result = getAllStatusIds();
+      const enumIds = Object.keys(TaskStatus);
+      const filtered = result.filter((id) => enumIds.includes(id));
+      expect(filtered.length).toBe(enumIds.length);
+      enumIds.forEach((id) => {
+        expect(result).toContain(id);
+      });
     });
   });
 });

--- a/frontend/src/lib/statusUtils.ts
+++ b/frontend/src/lib/statusUtils.ts
@@ -43,6 +43,7 @@ export type StatusID =
   | "VERIFICATION_COMPLETE"
   | "VERIFICATION_FAILED"
   | "COMPLETED_AWAITING_PROJECT_MANAGER"
+  | "COMPLETED_HANDOFF"
   | "COMPLETED_HANDOFF_TO_..."
   | "FAILED"
   | "IN_PROGRESS_AWAITING_SUBTASK"
@@ -80,7 +81,6 @@ export interface DisplayableStatus {
 /* ────────────────────────────────────────────────────────────── */
 
 const STATUS_MAP = {
-  /* ---------- TODO ---------- */
   "To Do": {
     id: "To Do",
     displayName: "To Do",
@@ -328,6 +328,18 @@ const STATUS_MAP = {
     isDynamic: false,
   },
   "Completed Handoff": {
+    id: "Completed Handoff",
+    displayName: "Completed Handoff",
+    category: "completed",
+    description: "Completed with handoff to another task.",
+    colorScheme: "green",
+    icon: "ArrowForwardIcon",
+    isTerminal: true,
+    isDynamic: true,
+    dynamicPartsExtractor: /^COMPLETED_HANDOFF_TO_(([a-zA-Z0-9-]+(?:\s*,\s*[a-zA-Z0-9-]+)*))$/,
+    dynamicDisplayNamePattern: "Handoff to: {value}",
+  },
+  COMPLETED_HANDOFF: {
     id: "Completed Handoff",
     displayName: "Completed Handoff",
     category: "completed",


### PR DESCRIPTION
## Summary
- map COMPLETED_HANDOFF enum in `statusUtils`
- remove stray TODO comment
- test that `getAllStatusIds()` matches backend status enum values

## Testing
- `npm run lint --silent`
- `npx vitest run src/lib/__tests__/utils.test.tsx --silent`


------
https://chatgpt.com/codex/tasks/task_e_6841bdd7b40c832cb50ef780b3d7c78f