### PR TITLE
Add pagination to memory observations

### DIFF
--- a/backend/routers/memory/observations/observations.py
+++ b/backend/routers/memory/observations/observations.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 from ....database import get_sync_db as get_db
 from ....services.memory_service import MemoryService  # Assuming observation management is part of memory service
 from ....schemas.memory import MemoryObservation, MemoryObservationCreate
+from ....schemas.api_responses import PaginationParams
 from ....services.exceptions import EntityNotFoundError
 
 router = APIRouter()
@@ -39,8 +40,7 @@ def read_observations(
     search_query: Optional[str] = Query(
         None, description="Optional text to search within observation content."
     ),
-    skip: int = Query(0, description="The number of items to skip before returning results."),
-    limit: int = Query(100, description="The maximum number of items to return."),
+    pagination: PaginationParams = Depends(),
     memory_service: MemoryService = Depends(get_memory_service),
 ):
     """Get observations, optionally filtered by entity or content search."""
@@ -48,8 +48,8 @@ def read_observations(
         return memory_service.get_observations(
             entity_id=entity_id,
             search_query=search_query,
-            skip=skip,
-            limit=limit,
+            skip=pagination.offset,
+            limit=pagination.page_size,
         )
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Internal server error: {e}")

--- a/backend/tests/test_memory_observations.py
+++ b/backend/tests/test_memory_observations.py
@@ -82,3 +82,23 @@ async def test_update_and_delete_observation():
 
         resp = await client.delete(f"/observations/{obs_id}")
         assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_read_observations_pagination():
+    dummy_service.observations = {}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        for i in range(3):
+            resp = await client.post(
+                "/entities/1/observations/",
+                json={"entity_id": 1, "content": f"obs {i}"},
+            )
+            assert resp.status_code == 200
+
+        resp = await client.get("/observations/?entity_id=1&page=1&page_size=2")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+
+        resp = await client.get("/observations/?entity_id=1&page=2&page_size=2")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1

--- a/frontend/src/services/api/memory.ts
+++ b/frontend/src/services/api/memory.ts
@@ -161,11 +161,19 @@ export const memoryApi = {
   },
 
   // Get observations for an entity
-  getObservations: async (entityId: number): Promise<MemoryObservation[]> => {
+  getObservations: async (
+    entityId: number,
+    page = 1,
+    pageSize = 100
+  ): Promise<MemoryObservation[]> => {
+    const params = new URLSearchParams();
+    params.append('entity_id', String(entityId));
+    params.append('page', String(page));
+    params.append('pageSize', String(pageSize));
     const response = await request<{ data: MemoryObservation[] }>(
       buildApiUrl(
         API_CONFIG.ENDPOINTS.MEMORY,
-        `/entities/${entityId}/observations`
+        `/observations?${params.toString()}`
       )
     );
     return response.data;


### PR DESCRIPTION
## Summary
- use `PaginationParams` in observations route
- update frontend memory API for pagination
- test observation pagination logic

## Testing
- `npm run lint`
- `pytest` *(fails: Module features not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_6841c0f1b1e0832c8c28288fbedb7d62