### PR TITLE
Add pagination support to knowledge graph

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -162,7 +162,7 @@ cd backend
 - ✅ **User Roles API**: Assign, list, and remove roles via `/api/v1/users/{user_id}/roles`.
 - ✅ **Agent Capability API**: Manage capabilities through `/api/v1/rules/roles/capabilities`.
 - ✅ **Forbidden Action API**: Manage actions via `/api/v1/rules/roles/forbidden-actions`.
-- ✅ **Knowledge Graph Endpoint**: Retrieve the full graph at `/api/v1/memory/entities/graph`.
+- ✅ **Knowledge Graph Endpoint**: Retrieve the graph at `/api/v1/memory/entities/graph` with optional `entity_type`, `relation_type`, `limit`, and `offset` query parameters for pagination.
 
 ### Server Won't Start
 1. Make sure you're in the correct directory (`D:\mcp\task-manager`)

--- a/backend/routers/memory/__init__.py
+++ b/backend/routers/memory/__init__.py
@@ -1,5 +1,6 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status, Query
 from sqlalchemy.orm import Session
+from typing import Optional
 
 from ...database import get_sync_db as get_db
 from ...services.memory_service import MemoryService
@@ -53,9 +54,18 @@ def ingest_text_root(
 @router.get("/graph", response_model=KnowledgeGraph)
 def get_knowledge_graph(
     memory_service: MemoryService = Depends(get_memory_service),
+    entity_type: Optional[str] = Query(None),
+    relation_type: Optional[str] = Query(None),
+    limit: int = Query(100, ge=1),
+    offset: int = Query(0, ge=0),
 ):
-    """Retrieve the entire knowledge graph."""
+    """Retrieve the knowledge graph with optional filters."""
     try:
-        return memory_service.get_knowledge_graph()
+        return memory_service.get_knowledge_graph(
+            entity_type=entity_type,
+            relation_type=relation_type,
+            limit=limit,
+            offset=offset,
+        )
     except Exception as e:  # pragma: no cover - pass through any service errors
         raise HTTPException(status_code=500, detail=f"Failed to retrieve graph: {e}")

--- a/backend/routers/memory/core/core.py
+++ b/backend/routers/memory/core/core.py
@@ -28,10 +28,19 @@ def get_memory_service(db: Session = Depends(get_db)) -> MemoryService:
 @router.get("/graph")
 def get_memory_graph(
     memory_service: MemoryService = Depends(get_memory_service),
+    entity_type: Optional[str] = Query(None),
+    relation_type: Optional[str] = Query(None),
+    limit: int = Query(100, ge=1),
+    offset: int = Query(0, ge=0),
 ):
-    """Retrieve the entire knowledge graph."""
+    """Retrieve the knowledge graph with optional filters."""
     try:
-        return memory_service.get_knowledge_graph()
+        return memory_service.get_knowledge_graph(
+            entity_type=entity_type,
+            relation_type=relation_type,
+            limit=limit,
+            offset=offset,
+        )
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
 

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -490,29 +490,27 @@ class MemoryService:
             .all()
         )
 
-    def get_knowledge_graph(self) -> Dict[str, List[Dict[str, Any]]]:
-        nodes = []
-        edges = []
+    def get_knowledge_graph(
+        self,
+        entity_type: Optional[str] = None,
+        relation_type: Optional[str] = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> Dict[str, List[Any]]:
+        """Retrieve entities and relations with optional filters."""
 
-        entities = self.db.query(models.MemoryEntity).all()
-        relations = self.db.query(models.MemoryRelation).all()
+        entity_query = self.db.query(models.MemoryEntity)
+        if entity_type:
+            entity_query = entity_query.filter(
+                models.MemoryEntity.entity_type == entity_type
+            )
+        entities = entity_query.offset(offset).limit(limit).all()
 
-        for entity in entities:
-            nodes.append({
-                "id": entity.id,
-                "type": entity.type,
-                "name": entity.name,
-                "description": entity.description,
-                "metadata": entity.metadata_
-            })
+        relation_query = self.db.query(models.MemoryRelation)
+        if relation_type:
+            relation_query = relation_query.filter(
+                models.MemoryRelation.relation_type == relation_type
+            )
+        relations = relation_query.offset(offset).limit(limit).all()
 
-        for relation in relations:
-            edges.append({
-                "id": relation.id,
-                "from": relation.from_entity_id,
-                "to": relation.to_entity_id,
-                "type": relation.relation_type,
-                "description": relation.metadata_,
-                "metadata": relation.metadata_
-            })
-        return {"nodes": nodes, "edges": edges}
+        return {"entities": entities, "relations": relations}

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -68,7 +68,7 @@ This frontend application provides a modern and responsive user interface for ma
 *   **Agent Capabilities:** Manage capabilities with `/api/rules/roles/capabilities`.
 *   **Error Protocol Management:** Add, list, and remove protocols through `/mcp-tools/error-protocol/*` routes.
 *   **User Role Assignment:** Assign or remove roles using `/api/users/{user_id}/roles`.
-*   **Knowledge Graph Visualization:** View the memory graph via `/api/memory/entities/graph`.
+*   **Knowledge Graph Visualization:** View the memory graph via `/api/memory/entities/graph`. The endpoint accepts `entity_type`, `relation_type`, `limit`, and `offset` to page through results.
 
 ---
 

--- a/frontend/src/hooks/__tests__/useKnowledgeGraph.test.tsx
+++ b/frontend/src/hooks/__tests__/useKnowledgeGraph.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useKnowledgeGraph } from '../useKnowledgeGraph';
+import { memoryApi } from '@/services/api';
+
+vi.mock('@/services/api', () => ({
+  memoryApi: {
+    getKnowledgeGraph: vi.fn(),
+  },
+}));
+
+const mockGraph = { entities: [], relations: [] };
+
+describe('useKnowledgeGraph', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (memoryApi.getKnowledgeGraph as any).mockResolvedValue(mockGraph);
+  });
+
+  it('fetches graph on mount', async () => {
+    const { result } = renderHook(() => useKnowledgeGraph({ limit: 5 }));
+
+    await waitFor(() => expect(result.current.graph).toEqual(mockGraph));
+    expect(memoryApi.getKnowledgeGraph).toHaveBeenCalledWith({
+      entity_type: undefined,
+      relation_type: undefined,
+      limit: 5,
+      offset: undefined,
+    });
+  });
+
+  it('loads more data', async () => {
+    const { result } = renderHook(() => useKnowledgeGraph({ limit: 5 }));
+    await waitFor(() => expect(result.current.graph).toEqual(mockGraph));
+
+    await act(async () => {
+      await result.current.loadMore();
+    });
+
+    expect(memoryApi.getKnowledgeGraph).toHaveBeenLastCalledWith({
+      entity_type: undefined,
+      relation_type: undefined,
+      limit: 5,
+      offset: 5,
+    });
+  });
+});

--- a/frontend/src/hooks/useKnowledgeGraph.ts
+++ b/frontend/src/hooks/useKnowledgeGraph.ts
@@ -1,0 +1,69 @@
+import { useState, useEffect, useCallback } from 'react';
+import { memoryApi } from '@/services/api';
+import type { KnowledgeGraph } from '@/types/memory';
+
+export interface UseKnowledgeGraphOptions {
+  entityType?: string;
+  relationType?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface UseKnowledgeGraphResult {
+  graph: KnowledgeGraph | null;
+  loading: boolean;
+  error: string | null;
+  loadMore: () => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+/**
+ * Fetch the knowledge graph with pagination support.
+ */
+export const useKnowledgeGraph = (
+  options: UseKnowledgeGraphOptions = {}
+): UseKnowledgeGraphResult => {
+  const [graph, setGraph] = useState<KnowledgeGraph | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [params, setParams] = useState<UseKnowledgeGraphOptions>(options);
+
+  const fetchGraph = useCallback(
+    async (o: UseKnowledgeGraphOptions = params) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await memoryApi.getKnowledgeGraph({
+          entity_type: o.entityType,
+          relation_type: o.relationType,
+          limit: o.limit,
+          offset: o.offset,
+        });
+        setGraph(data);
+        setParams(o);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'Failed to load graph';
+        setError(msg);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [params]
+  );
+
+  useEffect(() => {
+    fetchGraph(options);
+  }, [options, fetchGraph]);
+
+  const loadMore = useCallback(async () => {
+    const next = {
+      ...params,
+      offset: (params.offset || 0) + (params.limit || 100),
+    };
+    await fetchGraph(next);
+  }, [params, fetchGraph]);
+
+  return { graph, loading, error, loadMore, refresh: () => fetchGraph(params) };
+};
+
+export default useKnowledgeGraph;

--- a/frontend/src/services/api/memory.ts
+++ b/frontend/src/services/api/memory.ts
@@ -247,10 +247,28 @@ export const memoryApi = {
   },
 
   // --- Knowledge Graph APIs ---
-  // Get the full knowledge graph
-  getKnowledgeGraph: async (): Promise<KnowledgeGraph> => {
+  // Get the knowledge graph with optional filters
+  getKnowledgeGraph: async (
+    params?: {
+      entity_type?: string;
+      relation_type?: string;
+      limit?: number;
+      offset?: number;
+    }
+  ): Promise<KnowledgeGraph> => {
+    const search = new URLSearchParams();
+    if (params) {
+      Object.entries(params).forEach(([k, v]) => {
+        if (v !== undefined && v !== null) {
+          search.append(k, String(v));
+        }
+      });
+    }
     const response = await request<{ data: KnowledgeGraph }>(
-      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/graph')
+      buildApiUrl(
+        API_CONFIG.ENDPOINTS.MEMORY,
+        `/graph${search.toString() ? `?${search.toString()}` : ''}`
+      )
     );
     return response.data;
   },


### PR DESCRIPTION
## Summary
- add filtering to `MemoryService.get_knowledge_graph`
- expose query params in memory graph endpoints
- update API client for optional graph filters
- implement `useKnowledgeGraph` hook with pagination helpers
- document new parameters in backend and frontend docs

## Testing
- `flake8 .`
- `pytest -q` *(fails: ModuleNotFoundError and assertion errors)*
- `npm run lint`
- `npm run test:run` *(fails: several test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6841c0f242a4832cb88b7f7dcbd22816