### PR TITLE
Add frontend logger utility

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,2 +1,3 @@
 # Example environment configuration for the frontend
 NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+NEXT_PUBLIC_LOG_LEVEL=info

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -13,6 +13,7 @@ cp .env.local.example .env.local
 ```
 
 `NEXT_PUBLIC_API_BASE_URL` points to your backend server and defaults to `http://localhost:8000`.
+`NEXT_PUBLIC_LOG_LEVEL` controls client-side logging. Set to `info`, `warn`, or `error` (default `info`).
 
 First, run the development server:
 
@@ -37,6 +38,10 @@ This project uses [`next/font`](https://nextjs.org/docs/app/building-your-applic
 Run `npm run type-check` to ensure the TypeScript codebase compiles without errors. This command runs `tsc --noEmit` using the configuration in `tsconfig.json`.
 
 At the repository root there is a matching `type-check` script that simply invokes the frontend command, allowing you to execute the check from either location.
+### Logging
+
+Use the utilities in `src/utils/logger.ts` for log output. The log level is controlled by `NEXT_PUBLIC_LOG_LEVEL` in your `.env.local`.
+
 
 ## Learn More
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,6 @@
 // D:\mcp\task-manager\frontend\src\app\page.tsx
 "use client";
+import * as logger from '@/utils/logger';
 
 import React, { useEffect, useState } from "react";
 import { Box, useDisclosure, useToast, useColorMode } from "@chakra-ui/react";
@@ -263,7 +264,7 @@ export default function Home() {
           onClose={onAddAgentClose}
           onSubmit={async (name: string) => {
             if (!name.trim()) {
-              console.error("Agent name cannot be empty.");
+              logger.error("Agent name cannot be empty.");
               return;
             }
             try {
@@ -271,7 +272,7 @@ export default function Home() {
               fetchAgents(0, 100);
               onAddAgentClose();
             } catch (error) {
-              console.error("Failed to create agent:", error);
+              logger.error("Failed to create agent:", error);
             }
           }}
         />

--- a/frontend/src/components/AgentList.tsx
+++ b/frontend/src/components/AgentList.tsx
@@ -1,4 +1,5 @@
 "use client";
+import * as logger from '@/utils/logger';
 
 import React, { useEffect, useState } from "react";
 import {
@@ -70,7 +71,7 @@ const AgentList: React.FC = () => {
       });
       onAddClose();
     } catch (error) {
-      console.error("[AgentList] Failed to add agent:", error);
+      logger.error("[AgentList] Failed to add agent:", error);
       toast({
         title: "Error Adding Agent",
         description:
@@ -96,7 +97,7 @@ const AgentList: React.FC = () => {
       });
       onEditClose();
     } catch (error) {
-      console.error("[AgentList] Failed to edit agent:", error);
+      logger.error("[AgentList] Failed to edit agent:", error);
       toast({
         title: "Error Editing Agent",
         description:

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 "use client";
+import * as logger from '@/utils/logger';
 
 import React from "react";
 import { Box, Heading, Text } from "@chakra-ui/react";
@@ -23,7 +24,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    console.error("ErrorBoundary caught an error", error, errorInfo);
+    logger.error("ErrorBoundary caught an error", error, errorInfo);
   }
 
   render() {

--- a/frontend/src/components/MCPMetrics.tsx
+++ b/frontend/src/components/MCPMetrics.tsx
@@ -1,4 +1,5 @@
 "use client";
+import * as logger from '@/utils/logger';
 
 import React, { useEffect, useState } from "react";
 import { Box, Table, Thead, Tbody, Tr, Th, Td } from "@chakra-ui/react";
@@ -13,7 +14,7 @@ const MCPMetrics: React.FC = () => {
         const data = await mcpApi.metrics();
         setMetrics(data);
       } catch (err) {
-        console.error("Failed to fetch metrics", err);
+        logger.error("Failed to fetch metrics", err);
       }
     };
     load();

--- a/frontend/src/components/agent/AgentList.tsx
+++ b/frontend/src/components/agent/AgentList.tsx
@@ -1,3 +1,4 @@
+import * as logger from '@/utils/logger';
 import React, { useState, useEffect } from "react";
 import {
   Box,
@@ -48,7 +49,7 @@ const AgentList: React.FC = () => {
         const agentData = await getAgents(skip, itemsPerPage, searchQuery);
         setAgents(agentData);
       } catch (err: any) {
-        console.error("Failed to fetch agents:", err);
+        logger.error("Failed to fetch agents:", err);
         setError(err.message || "An error occurred while fetching agents.");
       } finally {
         setIsLoading(false);

--- a/frontend/src/components/audit/AuditLogViewer.tsx
+++ b/frontend/src/components/audit/AuditLogViewer.tsx
@@ -1,4 +1,5 @@
 'use client';
+import * as logger from '@/utils/logger';
 
 import React, { useEffect, useState } from 'react';
 import {
@@ -31,7 +32,7 @@ const AuditLogViewer: React.FC = () => {
       });
       setLogs(data);
     } catch (err) {
-      console.error('Failed to fetch audit logs', err);
+      logger.error('Failed to fetch audit logs', err);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/audit_logs/AuditLogListForEntity.tsx
+++ b/frontend/src/components/audit_logs/AuditLogListForEntity.tsx
@@ -1,3 +1,4 @@
+import * as logger from '@/utils/logger';
 import React, { useState, useEffect } from "react";
 import {
   Box,
@@ -38,7 +39,7 @@ const AuditLogListForEntity: React.FC<AuditLogListForEntityProps> = ({
         const auditLogs = await getAuditLogsByEntity(entityType, entityId);
         setLogs(auditLogs);
       } catch (err: any) {
-        console.error("Failed to fetch audit logs:", err);
+        logger.error("Failed to fetch audit logs:", err);
         setError(err.message || "An error occurred while fetching audit logs.");
       } finally {
         setIsLoading(false);

--- a/frontend/src/components/common/AppIcon.tsx
+++ b/frontend/src/components/common/AppIcon.tsx
@@ -1,3 +1,4 @@
+import * as logger from '@/utils/logger';
 // Centralized icon component for consistent icon usage across the app.
 // Usage:
 // <AppIcon name="add" ...chakraProps /> // for standard icons
@@ -71,7 +72,7 @@ const AppIcon: React.FC<AppIconProps> = ({ name, component, ...props }) => {
     (name && standardIcons[name.toLowerCase()]) || component;
   if (!IconComponent) {
     if (name) {
-      console.warn(
+      logger.warn(
         `AppIcon: Standard icon "${name}" not found. Ensure it's mapped in AppIcon.tsx or pass a component prop.`,
       );
     }

--- a/frontend/src/components/common/EditModalBase.tsx
+++ b/frontend/src/components/common/EditModalBase.tsx
@@ -1,3 +1,4 @@
+import * as logger from '@/utils/logger';
 import React, { useRef } from "react";
 import {
   Modal,
@@ -117,7 +118,7 @@ function EditModalBase<T extends EntityWithIdAndName>({
     try {
       await onSave();
     } catch (error: unknown) {
-      console.error(`Failed to update ${entityName}:`, error);
+      logger.error(`Failed to update ${entityName}:`, error);
     }
   };
 
@@ -127,7 +128,7 @@ function EditModalBase<T extends EntityWithIdAndName>({
       await onDelete();
       onAlertClose();
     } catch (error: unknown) {
-      console.error(`Failed to delete ${entityName}:`, error);
+      logger.error(`Failed to delete ${entityName}:`, error);
     }
   };
 

--- a/frontend/src/components/common/TaskActionsMenu.tsx
+++ b/frontend/src/components/common/TaskActionsMenu.tsx
@@ -1,3 +1,4 @@
+import * as logger from '@/utils/logger';
 import React from "react";
 import {
   IconButton,
@@ -55,11 +56,11 @@ const ArchiveIcon = (props: React.ComponentProps<typeof LucideArchive>) => (
  *
  * @example
  * <TaskActionsMenu
- *   onEdit={() => console.log('Edit clicked')}
- *   onDelete={() => console.log('Delete clicked')}
- *   onDuplicate={() => console.log('Duplicate clicked')}
- *   onArchive={() => console.log('Archive clicked')}
- *   onStatusChange={(newStatus) => console.log('Change status to', newStatus)}
+ *   onEdit={() => logger.info('Edit clicked')}
+ *   onDelete={() => logger.info('Delete clicked')}
+ *   onDuplicate={() => logger.info('Duplicate clicked')}
+ *   onArchive={() => logger.info('Archive clicked')}
+ *   onStatusChange={(newStatus) => logger.info('Change status to', newStatus)}
  *   availableStatuses={['TO_DO', 'IN_PROGRESS', 'COMPLETED']}
  *   isArchived={false}
  *   isLoading={false}

--- a/frontend/src/components/dashboard/CreateProjectModal.tsx
+++ b/frontend/src/components/dashboard/CreateProjectModal.tsx
@@ -1,4 +1,5 @@
 "use client";
+import * as logger from '@/utils/logger';
 
 import React from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
@@ -65,7 +66,7 @@ const CreateProjectModal: React.FC<CreateProjectModalProps> = ({
       reset();
       onClose();
     } catch (error) {
-      console.error("Failed to create project:", error);
+      logger.error("Failed to create project:", error);
       toast({
         title: "Error creating project",
         description:

--- a/frontend/src/components/dashboard/EditProjectModal.tsx
+++ b/frontend/src/components/dashboard/EditProjectModal.tsx
@@ -1,4 +1,5 @@
 "use client";
+import * as logger from '@/utils/logger';
 
 import React, { useEffect } from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
@@ -87,7 +88,7 @@ const EditProjectModal: React.FC<EditProjectModalProps> = ({
       fetchProjects(); // Refresh the project list
       onClose(); // Close modal after successful submission
     } catch (error) {
-      console.error("Failed to update project:", error);
+      logger.error("Failed to update project:", error);
       toast({
         title: "Error updating project",
         description:

--- a/frontend/src/components/dashboard/useDashboardData.ts
+++ b/frontend/src/components/dashboard/useDashboardData.ts
@@ -1,3 +1,4 @@
+import * as logger from '@/utils/logger';
 import { useEffect, useState, useCallback } from "react";
 import { handleApiError } from "@/lib/apiErrorHandler";
 import { Project } from "@/types/project";
@@ -21,7 +22,7 @@ export function useDashboardData() {
       setAllProjects(projectsFromApi || []);
       setAllTasks(tasksFromApi || []);
     } catch (error) {
-      console.error(
+      logger.error(
         "Error fetching all projects/tasks for dashboard totals:",
         error,
       );

--- a/frontend/src/components/modals/CreateProjectModal.tsx
+++ b/frontend/src/components/modals/CreateProjectModal.tsx
@@ -1,3 +1,4 @@
+import * as logger from '@/utils/logger';
 import {
   Button,
   FormControl,
@@ -64,7 +65,7 @@ const CreateProjectModal: React.FC<CreateProjectModalProps> = ({
       setProjectName(""); // Reset form
       setProjectDescription("");
     } catch (error) {
-      console.error("Failed to create project:", error);
+      logger.error("Failed to create project:", error);
       toast({
         title: "Failed to create project.",
         description:

--- a/frontend/src/components/modals/EditAgentModal.tsx
+++ b/frontend/src/components/modals/EditAgentModal.tsx
@@ -1,3 +1,4 @@
+import * as logger from '@/utils/logger';
 import React, { useState, useEffect } from "react";
 import {
   FormControl,
@@ -57,7 +58,7 @@ const EditAgentModal: React.FC<EditAgentModalProps> = ({
       });
       onClose();
     } catch (error: unknown) {
-      console.error("Failed to update agent:", error);
+      logger.error("Failed to update agent:", error);
       const message =
         error instanceof Error ? error.message : "Could not update the agent.";
       toast({
@@ -85,7 +86,7 @@ const EditAgentModal: React.FC<EditAgentModalProps> = ({
       });
       onClose();
     } catch (error: unknown) {
-      console.error("Failed to delete agent:", error);
+      logger.error("Failed to delete agent:", error);
       const message =
         error instanceof Error ? error.message : "Could not delete the agent.";
       toast({

--- a/frontend/src/components/modals/EditProjectModal.tsx
+++ b/frontend/src/components/modals/EditProjectModal.tsx
@@ -1,3 +1,4 @@
+import * as logger from '@/utils/logger';
 import React, { useState, useEffect } from "react";
 import {
   FormControl,
@@ -61,7 +62,7 @@ const EditProjectModal: React.FC<EditProjectModalProps> = ({
       });
       onClose();
     } catch (error: unknown) {
-      console.error("Failed to update project:", error);
+      logger.error("Failed to update project:", error);
       const message =
         error instanceof Error
           ? error.message
@@ -91,7 +92,7 @@ const EditProjectModal: React.FC<EditProjectModalProps> = ({
       });
       onClose();
     } catch (error: unknown) {
-      console.error("Failed to delete project:", error);
+      logger.error("Failed to delete project:", error);
       const message =
         error instanceof Error
           ? error.message

--- a/frontend/src/components/modals/TaskDetailsModal.tsx
+++ b/frontend/src/components/modals/TaskDetailsModal.tsx
@@ -1,4 +1,5 @@
 "use client";
+import * as logger from '@/utils/logger';
 
 import React, { useEffect, useState, useRef } from "react";
 import {
@@ -87,13 +88,13 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({
               const fetchedTask = await getTaskById(project_id, task_number);
               setTask(fetchedTask);
             } catch (fetchError) {
-              console.error("Failed to fetch task by ID:", fetchError);
+              logger.error("Failed to fetch task by ID:", fetchError);
               setError("Failed to load task details.");
               setTask(null);
             }
           }
         } catch (e) {
-          console.error("Failed to load task details:", e);
+          logger.error("Failed to load task details:", e);
           const message =
             e instanceof Error ? e.message : "Could not load task details.";
           setError(message);

--- a/frontend/src/components/project/ProjectDetail.tsx
+++ b/frontend/src/components/project/ProjectDetail.tsx
@@ -1,4 +1,5 @@
 "use client";
+import * as logger from '@/utils/logger';
 
 import React, { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
@@ -33,7 +34,7 @@ const ProjectDetail: React.FC = () => {
       setProject(data);
     } catch (err) {
       setError('Failed to fetch project details');
-      console.error(err);
+      logger.error(err);
     } finally {
       setLoading(false);
     }
@@ -46,7 +47,7 @@ const ProjectDetail: React.FC = () => {
       setTasks(data);
     } catch (err) {
       setTasksError('Failed to fetch tasks');
-      console.error(err);
+      logger.error(err);
     } finally {
       setTasksLoading(false);
     }
@@ -66,7 +67,7 @@ const ProjectDetail: React.FC = () => {
         router.push('/projects');
       } catch (err) {
         alert('Failed to delete project');
-        console.error(err);
+        logger.error(err);
       }
     }
   };
@@ -79,7 +80,7 @@ const ProjectDetail: React.FC = () => {
       fetchProject();
     } catch (err) {
       alert('Failed to archive project');
-      console.error(err);
+      logger.error(err);
     }
   };
 
@@ -91,7 +92,7 @@ const ProjectDetail: React.FC = () => {
       fetchProject();
     } catch (err) {
       alert('Failed to unarchive project');
-      console.error(err);
+      logger.error(err);
     }
   };
 
@@ -105,7 +106,7 @@ const ProjectDetail: React.FC = () => {
       setPlanningPrompt(response.prompt);
     } catch (err) {
       setPlanningError('Failed to generate planning prompt');
-      console.error(err);
+      logger.error(err);
     } finally {
       setPlanningLoading(false);
     }

--- a/frontend/src/components/project/ProjectFiles.tsx
+++ b/frontend/src/components/project/ProjectFiles.tsx
@@ -1,4 +1,5 @@
 'use client';
+import * as logger from '@/utils/logger';
 
 import React, { useEffect, useState } from 'react';
 import { Box, Button, Input, List, ListItem, useToast } from '@chakra-ui/react';
@@ -31,7 +32,7 @@ const ProjectFiles: React.FC<ProjectFilesProps> = ({ projectId }) => {
       setFiles(data);
     } catch (err) {
       setError('Failed to fetch project files');
-      console.error(err);
+      logger.error(err);
     } finally {
       setLoading(false);
     }
@@ -60,7 +61,7 @@ const ProjectFiles: React.FC<ProjectFilesProps> = ({ projectId }) => {
       });
       fetchFiles();
     } catch (err) {
-      console.error(err);
+      logger.error(err);
       toast({
         title: 'Upload failed',
         status: 'error',
@@ -80,7 +81,7 @@ const ProjectFiles: React.FC<ProjectFilesProps> = ({ projectId }) => {
       });
       fetchFiles();
     } catch (err) {
-      console.error(err);
+      logger.error(err);
       toast({
         title: 'Remove failed',
         status: 'error',

--- a/frontend/src/components/project/ProjectMembers.tsx
+++ b/frontend/src/components/project/ProjectMembers.tsx
@@ -1,4 +1,5 @@
 "use client";
+import * as logger from '@/utils/logger';
 
 import React, { useEffect, useState } from 'react';
 import { getProjectMembers } from '@/services/api/projects';
@@ -22,7 +23,7 @@ const ProjectMembers: React.FC<ProjectMembersProps> = ({ projectId }) => {
       setMembers(data);
     } catch (err) {
       setError('Failed to fetch project members');
-      console.error(err);
+      logger.error(err);
     } finally {
       setLoading(false);
     }
@@ -43,7 +44,7 @@ const ProjectMembers: React.FC<ProjectMembersProps> = ({ projectId }) => {
       fetchMembers(); // Refresh the list
     } catch (err) {
       alert('Failed to add member');
-      console.error(err);
+      logger.error(err);
     }
   };
 
@@ -53,7 +54,7 @@ const ProjectMembers: React.FC<ProjectMembersProps> = ({ projectId }) => {
       fetchMembers(); // Refresh the list
     } catch (err) {
       alert('Failed to remove member');
-      console.error(err);
+      logger.error(err);
     }
   };
 

--- a/frontend/src/components/task/TaskItem.tsx
+++ b/frontend/src/components/task/TaskItem.tsx
@@ -1,5 +1,6 @@
 // D:\mcp\task-manager\frontend\src\components\TaskItem.tsx
 "use client";
+import * as logger from '@/utils/logger';
 
 import React, { useCallback, memo } from "react";
 import {
@@ -40,7 +41,7 @@ const iconMap = defaultIconMap;
  * <TaskItem
  *   task={myTaskObject}
  *   compact={false}
- *   onClick={() => console.log('Task clicked')}
+ *   onClick={() => logger.info('Task clicked')}
  * />
  *
  * @param {TaskItemProps} props - The props for the TaskItem component.

--- a/frontend/src/components/task/TaskItemDetailsSection.tsx
+++ b/frontend/src/components/task/TaskItemDetailsSection.tsx
@@ -1,3 +1,4 @@
+import * as logger from '@/utils/logger';
 import React, { useState, useEffect } from "react";
 import {
   Box,
@@ -162,7 +163,7 @@ const TaskItemDetailsSection: React.FC<Omit<TaskItemDetailsSectionProps, 'status
       setComments(taskComments);
 
     } catch (err: any) {
-      console.error("Failed to fetch task details:", err);
+      logger.error("Failed to fetch task details:", err);
       setDetailsError(
         err.message || "An error occurred while fetching task details."
       );
@@ -193,7 +194,7 @@ const TaskItemDetailsSection: React.FC<Omit<TaskItemDetailsSectionProps, 'status
       setFileIdInput("");
       onFileModalClose();
     } catch (err: any) {
-      console.error("Failed to associate file:", err);
+      logger.error("Failed to associate file:", err);
       setAddFileError(err.message || "An error occurred while associating file.");
     } finally {
       setIsAddingFile(false);
@@ -213,7 +214,7 @@ const TaskItemDetailsSection: React.FC<Omit<TaskItemDetailsSectionProps, 'status
       // After disassociating, re-fetch file associations with current pagination/sorting/filtering
       fetchTaskDetails(); // This will refetch all details, including files with current settings
     } catch (err: any) {
-      console.error("Failed to disassociate file:", err);
+      logger.error("Failed to disassociate file:", err);
       setDetailsError(err.message || "An error occurred while disassociating file.");
       setIsLoadingDetails(false);
     }
@@ -249,7 +250,7 @@ const TaskItemDetailsSection: React.FC<Omit<TaskItemDetailsSectionProps, 'status
       setDependencyTypeInput("");
       onDependencyModalClose();
     } catch (err: any) {
-      console.error("Failed to add dependency:", err);
+      logger.error("Failed to add dependency:", err);
       setAddDependencyError(err.message || "An error occurred while adding dependency.");
     } finally {
       setIsAddingDependency(false);
@@ -274,7 +275,7 @@ const TaskItemDetailsSection: React.FC<Omit<TaskItemDetailsSectionProps, 'status
       // After removing, re-fetch task details
       fetchTaskDetails();
     } catch (err: any) {
-      console.error("Failed to remove dependency:", err);
+      logger.error("Failed to remove dependency:", err);
       setDetailsError(err.message || "An error occurred while removing dependency.");
       setIsLoadingDetails(false);
     }
@@ -294,7 +295,7 @@ const TaskItemDetailsSection: React.FC<Omit<TaskItemDetailsSectionProps, 'status
       setNewCommentText("");
       fetchTaskDetails(); // Refetch comments after adding a new one
     } catch (err: any) {
-      console.error("Failed to add comment:", err);
+      logger.error("Failed to add comment:", err);
       setAddCommentError(err.message || "An error occurred while adding the comment.");
     } finally {
       setIsAddingComment(false);

--- a/frontend/src/components/user/LoginForm.tsx
+++ b/frontend/src/components/user/LoginForm.tsx
@@ -1,3 +1,4 @@
+import * as logger from '@/utils/logger';
 import React, { useState } from "react";
 import {
   Box,
@@ -37,7 +38,7 @@ const LoginForm: React.FC = () => {
       localStorage.setItem("token", response.access_token);
       router.push("/");
     } catch (err: any) {
-      console.error("Login failed:", err);
+      logger.error("Login failed:", err);
       const message = err.message || "An error occurred during login.";
       setError(message);
       toast({

--- a/frontend/src/components/user/UserProfile.tsx
+++ b/frontend/src/components/user/UserProfile.tsx
@@ -1,3 +1,4 @@
+import * as logger from '@/utils/logger';
 import React, { useState, useEffect } from "react";
 import {
   Box,
@@ -29,7 +30,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ userId }) => {
         const userData = await getUserById(userId);
         setUser(userData);
       } catch (err: any) {
-        console.error("Failed to fetch user:", err);
+        logger.error("Failed to fetch user:", err);
         setError(err.message || "An error occurred while fetching user data.");
       } finally {
         setIsLoading(false);

--- a/frontend/src/components/views/KanbanView.tsx
+++ b/frontend/src/components/views/KanbanView.tsx
@@ -1,3 +1,4 @@
+import * as logger from '@/utils/logger';
 import React, { useRef, useMemo, useState } from "react";
 import {
   Box,
@@ -120,7 +121,7 @@ const KanbanView: React.FC<KanbanViewProps> = ({
   // Log received filteredTasks
   // useEffect(() => { // REMOVE
   //     if (typeof console !== 'undefined') {
-  //         console.log('[KanbanView.tsx] Received filteredTasks:', filteredTasks.length, filteredTasks);
+  //         logger.info('[KanbanView.tsx] Received filteredTasks:', filteredTasks.length, filteredTasks);
   //     }
   // }, [filteredTasks]);
 
@@ -149,7 +150,7 @@ const KanbanView: React.FC<KanbanViewProps> = ({
         ].tasks.push(task);
       } else {
         // Optional: Log tasks that don't map to a visible column, or handle them differently
-        // console.warn(`Task ${task.id} with status ${statusID} does not map to a visible Kanban column.`);
+        // logger.warn(`Task ${task.id} with status ${statusID} does not map to a visible Kanban column.`);
       }
     });
     return columns;
@@ -171,9 +172,9 @@ const KanbanView: React.FC<KanbanViewProps> = ({
     const { active, over } = event;
     setActiveId(null);
 
-    console.log("[KanbanView.tsx] handleDragEnd event:", event);
-    console.log("[KanbanView.tsx] Active item (composite key):", active.id);
-    console.log("[KanbanView.tsx] Over item/container:", over);
+    logger.info("[KanbanView.tsx] handleDragEnd event:", event);
+    logger.info("[KanbanView.tsx] Active item (composite key):", active.id);
+    logger.info("[KanbanView.tsx] Over item/container:", over);
 
     if (over && active.id !== over.id) {
       // Extract project_id and task_number from the active.id (composite key)
@@ -184,20 +185,20 @@ const KanbanView: React.FC<KanbanViewProps> = ({
         (t) => t.project_id === project_id && t.task_number === task_number,
       );
       if (!sourceTask) {
-        console.error("[KanbanView.tsx] Dragged task not found for ID:", active.id);
+        logger.error("[KanbanView.tsx] Dragged task not found for ID:", active.id);
         return;
       }
 
       const targetColumnId =
         over.data?.current?.sortable?.containerId || over.id;
-      console.log(
+      logger.info(
         `[KanbanView.tsx] Drag End: Task Composite ID: ${active.id}, Original Status: ${sourceTask.status}, Target Column ID Attempt: ${targetColumnId}`,
       );
 
       const isValidStatusId = KANBAN_COLUMN_RENDER_IDS.includes(
         targetColumnId as (typeof KANBAN_COLUMN_RENDER_IDS)[number],
       );
-      console.log(
+      logger.info(
         `[KanbanView.tsx] Is target a valid column (StatusID)? ${isValidStatusId}`,
       );
 
@@ -207,7 +208,7 @@ const KanbanView: React.FC<KanbanViewProps> = ({
       ) {
         const newStatus =
           targetColumnId as (typeof KANBAN_COLUMN_RENDER_IDS)[number];
-        console.log(
+        logger.info(
           `[KanbanView.tsx] Attempting to update task ${active.id} to new status: ${newStatus}`,
         );
         try {
@@ -221,11 +222,11 @@ const KanbanView: React.FC<KanbanViewProps> = ({
             duration: 2000,
             isClosable: true,
           });
-          console.log(
+          logger.info(
             `[KanbanView.tsx] Task ${active.id} status update API call successful.`,
           );
         } catch (error) {
-          console.error(
+          logger.error(
             "[KanbanView.tsx] Failed to update task status after drag:",
             error,
           );
@@ -241,16 +242,16 @@ const KanbanView: React.FC<KanbanViewProps> = ({
         isValidStatusId &&
         mapStatusToStatusID(sourceTask.status) === targetColumnId
       ) {
-        console.log(
+        logger.info(
           `[KanbanView.tsx] Task ${active.id} dropped into the same column. No status change.`,
         );
       } else if (!isValidStatusId) {
-        console.log(
+        logger.info(
           `[KanbanView.tsx] Drag ended over non-column or invalid target. Target ID: ${targetColumnId}`,
         );
       }
     } else {
-      console.log(
+      logger.info(
         "[KanbanView.tsx] Drag ended with no valid 'over' target or active.id === over.id.",
       );
     }

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -1,4 +1,5 @@
 "use client";
+import * as logger from '@/utils/logger';
 
 import React, {
   createContext,
@@ -36,7 +37,7 @@ const getInitialTheme = (): Theme => {
       ? "dark"
       : "light";
   } catch (error) {
-    console.error("Error reading theme preference:", error);
+    logger.error("Error reading theme preference:", error);
     return "light"; // Fallback
   }
 };
@@ -68,7 +69,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
       // Persist theme preference in localStorage
       localStorage.setItem("theme", theme);
     } catch (error) {
-      console.error("Error applying theme:", error);
+      logger.error("Error applying theme:", error);
     }
     // Update localStorage whenever theme changes
   }, [theme]);

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,3 +1,4 @@
+import * as logger from '@/utils/logger';
 // import { Status } from '@/types';
 import {
   getStatusAttributes,
@@ -54,10 +55,10 @@ export const mapStatusToStatusID = (
   const upperStatus = status.toUpperCase().replace(/\s+/g, "_");
   if (getStatusAttributes(upperStatus as CanonicalStatusID)) {
     // It's a known CanonicalStatusID.
-    // Optionally, add a console.warn if 'status' wasn't identical to 'upperStatus'
+    // Optionally, add a logger.warn if 'status' wasn't identical to 'upperStatus'
     // to catch statuses that are almost StatusIDs but have different casing/spacing.
     if (status !== upperStatus && typeof console !== "undefined") {
-      console.warn(
+      logger.warn(
         `[mapStatusToStatusID] Mapped status "${status}" to CanonicalStatusID "${upperStatus}".`,
       );
     }
@@ -66,7 +67,7 @@ export const mapStatusToStatusID = (
 
   // If no match after explicit cases and direct StatusID check, then it's unknown.
   if (typeof console !== "undefined") {
-    console.warn(
+    logger.warn(
       `[mapStatusToStatusID] Unknown status value: "${status}", defaulting to TO_DO.`,
     );
   }

--- a/frontend/src/services/api/request.ts
+++ b/frontend/src/services/api/request.ts
@@ -1,3 +1,4 @@
+import * as logger from '@/utils/logger';
 import { StatusID } from '@/lib/statusUtils';
 
 /** Error type thrown when API requests fail */
@@ -34,7 +35,7 @@ export const normalizeToStatusID = (
       return backendStatus as StatusID;
     }
 
-    console.warn(
+    logger.warn(
       `Unknown backend status string: "${backendStatus}". Defaulting to "To Do".`
     );
     return 'To Do';
@@ -75,7 +76,7 @@ export async function request<T>(
   }
 
   if (!response.ok) {
-    console.error(`API request failed for URL: ${url}`, {
+    logger.error(`API request failed for URL: ${url}`, {
       status: response.status,
       options,
     });
@@ -90,7 +91,7 @@ export async function request<T>(
         errorDetail = response.statusText || errorDetail;
       }
     } catch (e) {
-      console.warn(`Failed to parse error response as JSON for URL: ${url}`, e);
+      logger.warn(`Failed to parse error response as JSON for URL: ${url}`, e);
       errorDetail = response.statusText || errorDetail;
     }
     throw new ApiError(errorDetail, response.status, url);

--- a/frontend/src/store/agentStore.ts
+++ b/frontend/src/store/agentStore.ts
@@ -1,3 +1,4 @@
+import * as logger from '@/utils/logger';
 import { StoreApi } from 'zustand';
 import {
   Agent,
@@ -101,7 +102,7 @@ const agentActionsCreator = (
     set({ loading: true, error: null });
     try {
       const effectiveFilters = filters || get().filters;
-      console.log(
+      logger.info(
         '[AgentStore] Fetching agents with effective filters:',
         effectiveFilters
       );
@@ -127,15 +128,15 @@ const agentActionsCreator = (
         err instanceof Error ? err.message : 'Failed to fetch agents';
       set({ error: errorMessage, loading: false });
       handleApiError(err, 'Failed to fetch agents');
-      console.error('Error fetching agents:', err);
+      logger.error('Error fetching agents:', err);
     }
   },
   addAgent: async (agentData: AgentCreateData) => {
     set({ loading: true, error: null });
     try {
-      console.log(`[Store] Calling API to create agent: ${agentData.name}`);
+      logger.info(`[Store] Calling API to create agent: ${agentData.name}`);
       const newAgent = await api.createAgent(agentData);
-      console.log(`[Store] API returned new agent:`, newAgent);
+      logger.info(`[Store] API returned new agent:`, newAgent);
       set(
         (state) =>
           ({
@@ -143,13 +144,13 @@ const agentActionsCreator = (
             loading: false,
           }) as Partial<AgentState>
       );
-      console.log(`[Store] Agent added to state.`);
+      logger.info(`[Store] Agent added to state.`);
     } catch (err) {
       const errorMessage =
         err instanceof Error ? err.message : 'Failed to add agent';
       set({ error: errorMessage, loading: false });
       handleApiError(err, 'Failed to add agent');
-      console.error('[Store] Error adding agent:', err);
+      logger.error('[Store] Error adding agent:', err);
       throw err;
     }
   },
@@ -161,13 +162,13 @@ const agentActionsCreator = (
         agents: state.agents.filter((agent) => agent.id !== id),
         loading: false,
       }));
-      console.log(`[Store] Agent ${id} removed locally (API call skipped).`);
+      logger.info(`[Store] Agent ${id} removed locally (API call skipped).`);
     } catch (err) {
       const errorMessage =
         err instanceof Error ? err.message : 'Failed to remove agent';
       set({ error: errorMessage });
       handleApiError(err, 'Failed to remove agent');
-      console.error(`[Store] Error removing agent ${id}:`, err);
+      logger.error(`[Store] Error removing agent ${id}:`, err);
       throw err;
     }
   },

--- a/frontend/src/store/baseStore.ts
+++ b/frontend/src/store/baseStore.ts
@@ -1,3 +1,4 @@
+import * as logger from '@/utils/logger';
 import { create, StoreApi } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { handleApiError } from '@/lib/apiErrorHandler';
@@ -80,7 +81,7 @@ export const withLoading = async <T>(
     const errorMessage = extractErrorMessage(err);
     set({ loading: false, error: errorMessage });
     handleApiError(err, errorTitle);
-    // console.error("Operation failed:", errorMessage, err);
+    // logger.error("Operation failed:", errorMessage, err);
     throw err; // Rethrow error so calling action can also catch it if needed
   }
   // finally is not strictly needed if all paths set loading false

--- a/frontend/src/store/projectStore.ts
+++ b/frontend/src/store/projectStore.ts
@@ -1,3 +1,4 @@
+import * as logger from '@/utils/logger';
 import { create } from "zustand";
 import {
   getProjects,
@@ -100,7 +101,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       set({ isPolling: true, pollingError: null });
     }
     const currentActiveFilters = filtersToApply || get().filters;
-    console.log(
+    logger.info(
       "[ProjectStore] Fetching projects with filters:",
       currentActiveFilters,
     );
@@ -131,7 +132,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       } else {
         set({ pollingError: message, isPolling: false });
       }
-      console.error("Fetch Projects Error:", err);
+      logger.error("Fetch Projects Error:", err);
     }
   },
   addProject: async (projectData: ProjectCreateData) => {
@@ -149,7 +150,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       const message =
         err instanceof Error ? err.message : "Failed to add project";
       set({ error: message, loading: false });
-      console.error("Add Project Error:", err);
+      logger.error("Add Project Error:", err);
       throw err;
     }
   },
@@ -178,7 +179,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       const message =
         err instanceof Error ? err.message : "Failed to update project";
       set({ error: message, loading: false });
-      console.error("Edit Project Error:", err);
+      logger.error("Edit Project Error:", err);
       throw err;
     }
   },
@@ -199,7 +200,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       const message =
         err instanceof Error ? err.message : "Failed to delete project";
       set({ error: message, loading: false });
-      console.error("Remove Project Error:", err);
+      logger.error("Remove Project Error:", err);
       throw err;
     }
   },
@@ -222,7 +223,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       const message =
         err instanceof Error ? err.message : "Failed to archive project";
       set({ error: message, loading: false });
-      console.error("Archive Project Error:", err);
+      logger.error("Archive Project Error:", err);
       throw err;
     }
   },
@@ -245,7 +246,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       const message =
         err instanceof Error ? err.message : "Failed to unarchive project";
       set({ error: message, loading: false });
-      console.error("Unarchive Project Error:", err);
+      logger.error("Unarchive Project Error:", err);
       throw err;
     }
   },
@@ -254,7 +255,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
     const mergedFilters = { ...currentFilters, ...newFilters };
     if (!shallowEqual(mergedFilters, currentFilters)) {
       set({ filters: mergedFilters });
-      console.log(
+      logger.info(
         "[ProjectStore] Setting new filters and re-fetching:",
         mergedFilters,
       );

--- a/frontend/src/store/taskStore.ts
+++ b/frontend/src/store/taskStore.ts
@@ -1,3 +1,4 @@
+import * as logger from '@/utils/logger';
 // D:\mcp\task-manager\frontend\src\store\taskStore.ts
 import {
   Task,
@@ -170,7 +171,7 @@ export const useTaskStore = create<TaskState>(
     }
     const currentActiveFilters = filtersToApply || get().filters;
     const currentSortOptions = get().sortOptions;
-    console.log(
+    logger.info(
       "[TaskStore] Fetching tasks with filters:",
       currentActiveFilters,
       "and sort options:",
@@ -211,7 +212,7 @@ export const useTaskStore = create<TaskState>(
       } else {
         set({ pollingError: errorMessage, isPolling: false });
       }
-      console.error("Fetch Tasks Error:", error);
+      logger.error("Fetch Tasks Error:", error);
     }
   },
 
@@ -239,7 +240,7 @@ export const useTaskStore = create<TaskState>(
       let errorMessage = "Failed to fetch projects and agents";
       if (error instanceof Error) errorMessage = error.message;
       else if (typeof error === "string") errorMessage = error;
-      console.error("Error fetching projects and agents:", errorMessage, error);
+      logger.error("Error fetching projects and agents:", errorMessage, error);
     }
   },
 
@@ -300,7 +301,7 @@ export const useTaskStore = create<TaskState>(
         mutationError: { type: "add", message: errorMessage },
         loading: false,
       });
-      console.error("Error adding task:", error);
+      logger.error("Error adding task:", error);
       throw error;
     }
   },
@@ -347,7 +348,7 @@ export const useTaskStore = create<TaskState>(
         },
         loading: false,
       });
-      console.error("Error updating task:", error);
+      logger.error("Error updating task:", error);
       throw error;
     }
   },
@@ -377,7 +378,7 @@ export const useTaskStore = create<TaskState>(
         mutationError: { type: "delete", message: errorMessage },
         loading: false,
       });
-      console.error("Error deleting task:", error);
+      logger.error("Error deleting task:", error);
       throw error;
     }
   },
@@ -400,7 +401,7 @@ export const useTaskStore = create<TaskState>(
     const mergedFilters = { ...currentFilters, ...newFilters };
     if (!shallow(mergedFilters, currentFilters)) {
       set({ filters: mergedFilters });
-      console.log(
+      logger.info(
         "[TaskStore] Setting new task filters and re-fetching:",
         mergedFilters,
       );
@@ -465,7 +466,7 @@ export const useTaskStore = create<TaskState>(
         mutationError: { type: "bulk", message: errorMessage },
         loading: false,
       });
-      console.error("Bulk Delete Error:", error);
+      logger.error("Bulk Delete Error:", error);
     }
   },
   bulkSetStatusTasks: async (status: TaskStatus) => {
@@ -519,7 +520,7 @@ export const useTaskStore = create<TaskState>(
           draft.mutationError = { type: "bulk", message: errorMessage };
         }),
       );
-      console.error("Bulk Set Status Error:", error);
+      logger.error("Bulk Set Status Error:", error);
     }
   },
   removeTasksByProjectId: (projectId: string) => {
@@ -576,7 +577,7 @@ export const useTaskStore = create<TaskState>(
         },
         loading: false,
       });
-      console.error("Archive Task Error:", error);
+      logger.error("Archive Task Error:", error);
       throw error;
     }
   },
@@ -618,7 +619,7 @@ export const useTaskStore = create<TaskState>(
         },
         loading: false,
       });
-      console.error("Unarchive Task Error:", error);
+      logger.error("Unarchive Task Error:", error);
       throw error;
     }
   },

--- a/frontend/src/utils/logger.ts
+++ b/frontend/src/utils/logger.ts
@@ -1,0 +1,20 @@
+const LEVELS = { info: 0, warn: 1, error: 2 } as const;
+export type LogLevel = keyof typeof LEVELS;
+const envLevel = process.env.NEXT_PUBLIC_LOG_LEVEL as LogLevel | undefined;
+const currentLevel: LogLevel = envLevel && envLevel in LEVELS ? envLevel : 'info';
+export function info(...args: unknown[]) {
+  if (LEVELS[currentLevel] <= LEVELS.info) {
+    console.info(...args);
+  }
+}
+export function warn(...args: unknown[]) {
+  if (LEVELS[currentLevel] <= LEVELS.warn) {
+    console.warn(...args);
+  }
+}
+export function error(...args: unknown[]) {
+  if (LEVELS[currentLevel] <= LEVELS.error) {
+    console.error(...args);
+  }
+}
+export default { info, warn, error };


### PR DESCRIPTION
## Summary
- add `logger.ts` with simple log level support
- replace `console` usage with new logger
- document `NEXT_PUBLIC_LOG_LEVEL` and logging utility
- update environment example with log level

## Testing
- `npm run lint`
- `npm run test:run` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6841c0f4e1c8832c9d1a40301448433b