### PR TITLE
Add migrate command to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ npm run dev                   # NPM script
 powershell dev_launcher.ps1   # PowerShell (Windows)
 ```
 
+### Database Migrations
+
+Apply pending migrations using the CLI:
+
+```bash
+node cli.js migrate
+```
+
 See [`DEV_LAUNCHER_GUIDE.md`](./DEV_LAUNCHER_GUIDE.md) for complete setup instructions.
 For an overview of all dev scripts, see [`DEV_SCRIPTS.md`](./DEV_SCRIPTS.md).
 If you're contributing, read the [CONTRIBUTING.md](./CONTRIBUTING.md) guide.

--- a/cli.js
+++ b/cli.js
@@ -6,5 +6,40 @@ if (major < 18) {
   process.exit(1);
 }
 
-require('./dev_launcher.js');
+const { Command } = require('commander');
+const { spawn } = require('child_process');
+const path = require('path');
+const pkg = require('./package.json');
+
+const program = new Command();
+program
+  .name('mcp-project-manager')
+  .description('CLI for MCP Project Manager')
+  .version(pkg.version);
+
+program
+  .command('dev')
+  .description('Launch backend and frontend in development mode')
+  .action(() => {
+    require('./dev_launcher.js');
+  });
+
+program
+  .command('migrate')
+  .description('Run database migrations using Alembic')
+  .action(() => {
+    const proc = spawn('alembic', ['upgrade', 'head'], {
+      cwd: path.join(__dirname, 'backend'),
+      stdio: 'inherit',
+      shell: true,
+    });
+    proc.on('exit', code => process.exit(code));
+  });
+
+const args = process.argv.slice(2);
+if (args.length === 0) {
+  require('./dev_launcher.js');
+} else {
+  program.parse(process.argv);
+}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.1.3",
       "license": "ISC",
       "dependencies": {
-        "@wonderwhy-er/desktop-commander": "^0.1.39"
+        "@wonderwhy-er/desktop-commander": "^0.1.39",
+        "commander": "^11.0.0"
       },
       "bin": {
         "mcp-project-manager": "cli.js"
@@ -262,6 +263,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/content-disposition": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@wonderwhy-er/desktop-commander": "^0.1.39"
+    "@wonderwhy-er/desktop-commander": "^0.1.39",
+    "commander": "^11.0.0"
   },
   "devDependencies": {
     "typescript": "^5.8.3"

--- a/tests/cli/help.test.js
+++ b/tests/cli/help.test.js
@@ -9,4 +9,5 @@ test('cli.js --help displays help information', () => {
   const result = spawnSync('node', [cliPath, '--help'], { encoding: 'utf8' });
   assert.strictEqual(result.status, 0, 'expected exit code 0');
   assert.ok(result.stdout.length > 0, 'stdout should not be empty');
+  assert.ok(result.stdout.includes('migrate'), 'help should mention migrate command');
 });


### PR DESCRIPTION
## Summary
- extend `cli.js` with Commander and add `migrate` command
- document migration command in README
- update package.json dependencies
- test that `--help` shows the new command

## Testing
- `node --test tests/cli/*.js`


------
https://chatgpt.com/codex/tasks/task_e_6841c0faea24832c8f6298930d680a2b