### PR TITLE
Add memory upload endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,20 @@ project-manager/
 * Human-agent task collaboration
 * Full task/project lifecycle management
 * Task dependencies, filtering, archiving
-* Memory service with `/api/memory/ingest-url` and `/api/memory/ingest-text`
+* Memory service with `/api/memory/ingest-url`, `/api/memory/ingest-text` and `/api/memory/ingest/upload`
 * Integrated MCP agentic automation
 * CLI-first UX with automatic backend/frontend orchestration
 * Auto-restoring services and port management
+
+### Uploading Files to Memory
+
+```bash
+curl -X POST -H "Authorization: Bearer <TOKEN>" \
+  -F "file=@path/to/file.txt" \
+  http://localhost:8000/api/v1/memory/ingest/upload
+```
+
+In the frontend, call `memoryApi.uploadFile(file)` after selecting a file in the UI.
 
 ---
 

--- a/backend/routers/memory/__init__.py
+++ b/backend/routers/memory/__init__.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status, UploadFile, File
 from sqlalchemy.orm import Session
 
 from ...database import get_sync_db as get_db
@@ -48,6 +48,19 @@ def ingest_text_root(
         )
     except Exception as e:  # pragma: no cover - pass through any service errors
         raise HTTPException(status_code=500, detail=f"Failed to ingest text: {e}")
+
+
+@router.post("/ingest/upload", response_model=MemoryEntity, status_code=status.HTTP_201_CREATED)
+def ingest_upload_root(
+    file: UploadFile = File(...),
+    memory_service: MemoryService = Depends(get_memory_service),
+    current_user: UserModel = Depends(get_current_active_user),
+):
+    """Upload a file and ingest it into the knowledge graph."""
+    try:
+        return memory_service.ingest_file(file, user_id=current_user.id)
+    except Exception as e:  # pragma: no cover - pass through any service errors
+        raise HTTPException(status_code=500, detail=f"Failed to ingest file: {e}")
 
 
 @router.get("/graph", response_model=KnowledgeGraph)

--- a/frontend/src/services/api/memory.ts
+++ b/frontend/src/services/api/memory.ts
@@ -103,6 +103,20 @@ export const memoryApi = {
     return response.data;
   },
 
+  // Upload and ingest a file
+  uploadFile: async (file: File): Promise<MemoryEntity> => {
+    const formData = new FormData();
+    formData.append('file', file);
+    const response = await request<MemoryEntityResponse>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/ingest/upload'),
+      {
+        method: 'POST',
+        body: formData,
+      }
+    );
+    return response.data;
+  },
+
   // Ingest content directly from a URL
   ingestUrl: async (url: string): Promise<MemoryEntity> => {
     const response = await request<MemoryEntityResponse>(

--- a/frontend/src/services/api/request.ts
+++ b/frontend/src/services/api/request.ts
@@ -60,7 +60,10 @@ export async function request<T>(
   }
 
   const method = options.method?.toUpperCase();
-  if (method === 'POST' || method === 'PUT' || method === 'PATCH') {
+  if (
+    (method === 'POST' || method === 'PUT' || method === 'PATCH') &&
+    !(options.body instanceof FormData)
+  ) {
     (headers as Record<string, string>)['Content-Type'] = 'application/json';
   }
 


### PR DESCRIPTION
## Summary
- enable uploading files to MemoryService
- expose `/ingest/upload` endpoint on the backend
- support file uploads in the frontend API
- document curl usage and UI code
- adjust request helper for `FormData`

## Testing
- `flake8 services/memory_service.py tests/test_memory_service.py tests/test_memory_endpoints.py`
- `npm run lint`
- `pytest tests/test_memory_service.py tests/test_memory_endpoints.py -q`
- `npm test` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6841c0f65b54832c96d752ec9de96d5f