### PR TITLE
Add event streaming via SSE

### DIFF
--- a/backend/services/event_bus.py
+++ b/backend/services/event_bus.py
@@ -1,0 +1,18 @@
+import asyncio
+from typing import Any, Dict, List
+
+# Simple in-memory pub/sub for server events
+_subscribers: List[asyncio.Queue] = []
+
+async def subscribe() -> asyncio.Queue:
+    queue: asyncio.Queue = asyncio.Queue()
+    _subscribers.append(queue)
+    return queue
+
+def unsubscribe(queue: asyncio.Queue) -> None:
+    if queue in _subscribers:
+        _subscribers.remove(queue)
+
+def publish(event: Dict[str, Any]) -> None:
+    for queue in list(_subscribers):
+        queue.put_nowait(event)

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -38,6 +38,18 @@ Run `npm run type-check` to ensure the TypeScript codebase compiles without erro
 
 At the repository root there is a matching `type-check` script that simply invokes the frontend command, allowing you to execute the check from either location.
 
+### Server Events
+
+The frontend can subscribe to real-time updates from the backend using Server-Sent Events. The stream is exposed at `${NEXT_PUBLIC_API_BASE_URL}/api/mcp/events`.
+
+Use the `useServerEvents` hook to handle events:
+
+```tsx
+useServerEvents((event) => {
+  console.log('server event', event);
+});
+```
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/frontend/src/hooks/__tests__/useServerEvents.test.tsx
+++ b/frontend/src/hooks/__tests__/useServerEvents.test.tsx
@@ -1,0 +1,36 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useServerEvents } from '../useServerEvents';
+import { buildApiUrl, API_CONFIG } from '@/services/api/config';
+
+describe('useServerEvents', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('opens an EventSource and handles messages', () => {
+    const close = vi.fn();
+    const eventSourceMock: any = { close };
+    const constructor = vi.fn(() => eventSourceMock);
+    (global as any).EventSource = constructor;
+
+    const handler = vi.fn();
+    const { unmount } = renderHook(() => useServerEvents(handler));
+
+    expect(constructor).toHaveBeenCalledWith(
+      buildApiUrl(API_CONFIG.ENDPOINTS.MCP_EVENTS)
+    );
+
+    const message = {
+      data: JSON.stringify({ hello: 'world' }),
+    } as MessageEvent;
+    if (typeof eventSourceMock.onmessage === 'function') {
+      eventSourceMock.onmessage(message);
+    }
+
+    expect(handler).toHaveBeenCalledWith({ hello: 'world' });
+
+    unmount();
+    expect(close).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useServerEvents.ts
+++ b/frontend/src/hooks/useServerEvents.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from 'react';
+import { buildApiUrl, API_CONFIG } from '@/services/api/config';
+
+export type ServerEventHandler = (data: any) => void;
+
+/**
+ * Subscribe to backend Server-Sent Events.
+ * The provided handler is called for each parsed JSON event.
+ */
+export const useServerEvents = (handler: ServerEventHandler) => {
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
+
+  useEffect(() => {
+    const url = buildApiUrl(API_CONFIG.ENDPOINTS.MCP_EVENTS);
+    const source = new EventSource(url);
+
+    source.onmessage = (evt) => {
+      try {
+        const data = JSON.parse(evt.data);
+        handlerRef.current(data);
+      } catch (err) {
+        console.error('Failed to parse server event', err);
+      }
+    };
+
+    return () => {
+      source.close();
+    };
+  }, []);
+};
+
+export default useServerEvents;

--- a/frontend/src/services/api/config.ts
+++ b/frontend/src/services/api/config.ts
@@ -18,6 +18,7 @@ export const API_CONFIG = {
     MEMORY: "/memory",
     RULES: "/rules",
     MCP_TOOLS: "/mcp-tools",
+    MCP_EVENTS: "/mcp/events",
     VERIFICATION_REQUIREMENTS: "/verification-requirements",
   },
 } as const;


### PR DESCRIPTION
## Summary
- implement event bus for in-memory pub/sub
- stream events from `/api/mcp/events`
- publish audit log events
- provide `useServerEvents` React hook
- expose event endpoint in API config
- document SSE connection in frontend README

## Testing
- `flake8 backend/services/event_bus.py backend/services/audit_log_service.py`
- `npm --prefix frontend run lint`
- `npx prettier -w frontend/src/hooks/useServerEvents.ts frontend/src/hooks/__tests__/useServerEvents.test.tsx`
- `npx vitest run frontend/src/hooks/__tests__/useServerEvents.test.tsx` *(fails: need to install vitest)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6841c0fef600832c9b68cf722d53de5f