### PR TITLE
Fix file metadata path handling

### DIFF
--- a/backend/schemas/file_ingest.py
+++ b/backend/schemas/file_ingest.py
@@ -3,5 +3,7 @@ from pydantic import BaseModel, Field
 
 class FileIngestInput(BaseModel):
     """Input schema for file ingestion."""
-    file_path: str = Field(..., description="Absolute path to the file to ingest.")
+    file_path: str = Field(
+        ..., description="Path to the file to ingest." 
+    )
 

--- a/backend/tests/test_memory_ingestion.py
+++ b/backend/tests/test_memory_ingestion.py
@@ -62,4 +62,5 @@ def test_ingest_file_and_retrieve(tmp_path, memory_service):
     entity = memory_service.ingest_file(str(f), user_id="u3")
 
     assert entity.content == "file content"
+    assert entity.entity_metadata["path"] == f.name
     assert memory_service.get_entity(entity.id) == entity

--- a/backend/tests/test_memory_service.py
+++ b/backend/tests/test_memory_service.py
@@ -39,7 +39,8 @@ def test_ingest_file_reads_text(tmp_path):
     assert entity.entity_type == "file"
     assert entity.content == content
     assert entity.source == "file_ingestion"
-    assert entity.source_metadata == {"path": str(tmp_file)}
+    assert entity.source_metadata == {"path": tmp_file.name}
+    assert entity.entity_metadata["path"] == tmp_file.name
     assert entity.created_by_user_id == "u1"
     assert result == created
 


### PR DESCRIPTION
## Summary
- keep only the filename when ingesting files
- update FileIngestInput description
- adjust tests for new metadata

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_memory_ingestion.py::test_ingest_file_and_retrieve -q`
- `pytest tests/test_memory_service.py tests/test_memory_ingestion.py -q`
- `pytest -q` *(fails: test_project_task_endpoints, test_rules_service, test_user_roles)*

------
https://chatgpt.com/codex/tasks/task_e_6841c1007a6c832cb87f7989e2359e4b