### PR TITLE
Add MetricsResponse model

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -158,6 +158,19 @@ cd backend
 - ✅ **Forbidden Action MCP Tools**: MCP endpoints `/mcp-tools/forbidden-action/create` and `/mcp-tools/forbidden-action/list` enable managing forbidden actions.
 - ✅ **Capability MCP Tools**: MCP endpoints `/mcp-tools/capability/create`, `/mcp-tools/capability/list`, and `/mcp-tools/capability/delete` manage agent capabilities.
 - ✅ **Error Protocol MCP Tools**: `/mcp-tools/error-protocol/add`, `/mcp-tools/error-protocol/list`, and `/mcp-tools/error-protocol/remove` handle agent error protocols.
+- ✅ **Metrics Endpoint**: `/mcp-tools/metrics` returns a `MetricsResponse` with a `metrics` object mapping tool names to usage counts.
+
+```json
+{
+  "success": true,
+  "message": "Operation successful",
+  "timestamp": "2024-05-06T12:00:00Z",
+  "metrics": {
+    "create_project": 5,
+    "list_tasks": 12
+  }
+}
+```
 - ✅ **Project Template API**: CRUD operations available at `/api/v1/project-templates`.
 - ✅ **User Roles API**: Assign, list, and remove roles via `/api/v1/users/{user_id}/roles`.
 - ✅ **Agent Capability API**: Manage capabilities through `/api/v1/rules/roles/capabilities`.

--- a/backend/routers/mcp/core.py
+++ b/backend/routers/mcp/core.py
@@ -30,6 +30,7 @@ from ....schemas.memory import (
     MemoryObservationCreate,
     MemoryRelationCreate
 )
+from ....schemas.api_responses import MetricsResponse
 from ....schemas.agent_handoff_criteria import AgentHandoffCriteriaCreate
 from ....schemas.error_protocol import ErrorProtocolCreate
 from ....mcp_tools.forbidden_action_tools import (
@@ -1190,6 +1191,6 @@ async def mcp_remove_role(
 
 
 @router.get("/mcp-tools/metrics", tags=["mcp-tools"], operation_id="mcp_tools_metrics")
-async def mcp_tools_metrics():
+async def mcp_tools_metrics() -> MetricsResponse:
     """Return usage metrics for MCP tools."""
-    return {"metrics": dict(tool_counters)}
+    return MetricsResponse(metrics=dict(tool_counters))

--- a/backend/schemas/_schema_init.py
+++ b/backend/schemas/_schema_init.py
@@ -43,7 +43,8 @@ from .api_responses import (  # noqa: F401
     DataResponse,
     ListResponse,
     ErrorResponse,
-    PaginationParams
+    PaginationParams,
+    MetricsResponse,
 )
 
 # Rebuild models to resolve forward references

--- a/backend/schemas/api_responses.py
+++ b/backend/schemas/api_responses.py
@@ -52,3 +52,9 @@ class PaginationParams(BaseModel):
     @property
     def limit(self) -> int:
         return self.page_size
+
+
+class MetricsResponse(BaseResponse):
+    """Response model for tool usage metrics."""
+
+    metrics: Dict[str, int] = Field(default_factory=dict)

--- a/frontend/src/services/api/mcp.ts
+++ b/frontend/src/services/api/mcp.ts
@@ -20,6 +20,7 @@ import type {
   MCPProjectTemplateCreateRequest,
   MCPProjectTemplateDeleteRequest,
   MCPToolInfo,
+  MetricsResponse,
 } from '@/types/mcp';
 import type { ProjectFileAssociation } from './projects';
 
@@ -372,7 +373,7 @@ export const mcpApi = {
 
   // --- Metrics ---
   metrics: async (): Promise<Record<string, number>> => {
-    const response = await request<{ metrics: Record<string, number> }>(
+    const response = await request<MetricsResponse>(
       buildApiUrl(API_CONFIG.ENDPOINTS.MCP_TOOLS, '/metrics')
     );
     return response.metrics;

--- a/frontend/src/types/mcp.ts
+++ b/frontend/src/types/mcp.ts
@@ -185,3 +185,11 @@ export interface MCPToolInfo {
   parameters: Record<string, any>;
   example?: Record<string, any>;
 }
+
+// --- Metrics Response ---
+export interface MetricsResponse {
+  success: boolean;
+  message: string;
+  timestamp: string;
+  metrics: Record<string, number>;
+}


### PR DESCRIPTION
## Summary
- add `MetricsResponse` schema
- use it in `/mcp-tools/metrics`
- expose new metrics response on the frontend
- document metrics format in backend README

## Testing
- `python3 -m flake8 routers/mcp/core.py schemas/api_responses.py schemas/_schema_init.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c1016128832ca19458c640694c75