### PR TITLE
Update README update script

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -38,6 +38,10 @@ Run `npm run type-check` to ensure the TypeScript codebase compiles without erro
 
 At the repository root there is a matching `type-check` script that simply invokes the frontend command, allowing you to execute the check from either location.
 
+### Updating README File Lists
+
+Run `npm run update-readmes` from the project root to refresh the `File List` sections across all README files. The script overwrites files in place, so review the diff and commit the changes. It automatically skips directories named `__tests__`.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/scripts/update_readmes.py
+++ b/scripts/update_readmes.py
@@ -1,3 +1,11 @@
+"""Update README files with directory contents.
+
+This script walks the repository and injects a "File List" section into every
+`README.md` it finds. The operation overwrites README files in place, so run it
+only when you intend to commit the resulting changes. Directories named
+`__tests__` are skipped to avoid polluting docs with test fixtures.
+"""
+
 import os
 from pathlib import Path
 
@@ -7,6 +15,9 @@ START_MARK = "<!-- File List Start -->"
 END_MARK = "<!-- File List End -->"
 
 for dirpath, dirnames, filenames in os.walk(REPO_ROOT):
+    # Skip test directories entirely
+    dirnames[:] = [d for d in dirnames if d != "__tests__"]
+
     if "README.md" in filenames:
         readme_path = Path(dirpath) / "README.md"
         file_list = sorted(


### PR DESCRIPTION
## Summary
- skip `__tests__` directories when generating README file lists
- mention the `update-readmes` script and usage precautions in the frontend docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c1028d08832c8c608602fb9e6d4a