### PR TITLE
Make file ingestion async

### DIFF
--- a/backend/routers/memory/__init__.py
+++ b/backend/routers/memory/__init__.py
@@ -20,28 +20,39 @@ def get_memory_service(db: Session = Depends(get_db)) -> MemoryService:
     return MemoryService(db)
 
 
-@router.post("/ingest-url", response_model=MemoryEntity, status_code=status.HTTP_201_CREATED)
-def ingest_url_root(
+@router.post(
+    "/ingest-url",
+    response_model=MemoryEntity,
+    status_code=status.HTTP_201_CREATED,
+)
+async def ingest_url_root(
     ingest_input: UrlIngestInput,
     memory_service: MemoryService = Depends(get_memory_service),
     current_user: UserModel = Depends(get_current_active_user),
 ):
     """Ingest content directly from a URL."""
     try:
-        return memory_service.ingest_url(url=ingest_input.url, user_id=current_user.id)
+        return await memory_service.ingest_url(
+            url=ingest_input.url,
+            user_id=current_user.id,
+        )
     except Exception as e:  # pragma: no cover - pass through any service errors
         raise HTTPException(status_code=500, detail=f"Failed to ingest url: {e}")
 
 
-@router.post("/ingest-text", response_model=MemoryEntity, status_code=status.HTTP_201_CREATED)
-def ingest_text_root(
+@router.post(
+    "/ingest-text",
+    response_model=MemoryEntity,
+    status_code=status.HTTP_201_CREATED,
+)
+async def ingest_text_root(
     ingest_input: TextIngestInput,
     memory_service: MemoryService = Depends(get_memory_service),
     current_user: UserModel = Depends(get_current_active_user),
 ):
     """Store a raw text snippet as a MemoryEntity."""
     try:
-        return memory_service.ingest_text(
+        return await memory_service.ingest_text(
             text=ingest_input.text,
             user_id=current_user.id,
             metadata=ingest_input.metadata,

--- a/backend/routers/memory/core/core.py
+++ b/backend/routers/memory/core/core.py
@@ -157,13 +157,13 @@ class TextIngestInput(BaseModel):
     response_model=MemoryEntity,
     status_code=status.HTTP_201_CREATED,
 )
-def ingest_file_endpoint(
+async def ingest_file_endpoint(
     ingest_input: FileIngestInput,
     memory_service: MemoryService = Depends(get_memory_service),
     current_user: UserModel = Depends(get_current_active_user),
 ):
     try:
-        return memory_service.ingest_file(
+        return await memory_service.ingest_file(
             ingest_input=ingest_input,
             user_id=current_user.id,
         )
@@ -180,13 +180,13 @@ def ingest_file_endpoint(
     response_model=MemoryEntity,
     status_code=status.HTTP_201_CREATED,
 )
-def ingest_url_endpoint(
+async def ingest_url_endpoint(
     ingest_input: UrlIngestInput,
     memory_service: MemoryService = Depends(get_memory_service),
     current_user: UserModel = Depends(get_current_active_user),
 ):
     try:
-        return memory_service.ingest_url(
+        return await memory_service.ingest_url(
             url=ingest_input.url,
             user_id=current_user.id,
         )
@@ -199,13 +199,13 @@ def ingest_url_endpoint(
     response_model=MemoryEntity,
     status_code=status.HTTP_201_CREATED,
 )
-def ingest_text_endpoint(
+async def ingest_text_endpoint(
     ingest_input: TextIngestInput,
     memory_service: MemoryService = Depends(get_memory_service),
     current_user: UserModel = Depends(get_current_active_user),
 ):
     try:
-        return memory_service.ingest_text(
+        return await memory_service.ingest_text(
             text=ingest_input.text,
             user_id=current_user.id,
             metadata=ingest_input.metadata,

--- a/backend/tests/test_memory_endpoints.py
+++ b/backend/tests/test_memory_endpoints.py
@@ -20,7 +20,7 @@ class DummyService:
         self.entities = {}
         self.next_id = 1
 
-    def ingest_text(self, text: str, user_id=None, metadata=None):
+    async def ingest_text(self, text: str, user_id=None, metadata=None):
         entity = MemoryEntity(
             id=self.next_id,
             entity_type="text",
@@ -36,8 +36,8 @@ class DummyService:
         self.next_id += 1
         return entity
 
-    def ingest_url(self, url: str, user_id=None):
-        return self.ingest_text(f"content from {url}", user_id)
+    async def ingest_url(self, url: str, user_id=None):
+        return await self.ingest_text(f"content from {url}", user_id)
 
     def get_file_content(self, entity_id: int):
         return self.entities[entity_id].content

--- a/backend/tests/test_memory_service.py
+++ b/backend/tests/test_memory_service.py
@@ -20,7 +20,8 @@ def test_delete_memory_entity_no_error():
     assert result == dummy_entity
 
 
-def test_ingest_file_reads_text(tmp_path):
+@pytest.mark.asyncio
+async def test_ingest_file_reads_text(tmp_path):
     """File ingestion should read text content and pass it to create_entity."""
     tmp_file = tmp_path / "sample.txt"
     content = "Hello world"
@@ -32,7 +33,7 @@ def test_ingest_file_reads_text(tmp_path):
     service.create_entity = MagicMock(return_value=created)
 
     ingest_input = FileIngestInput(file_path=str(tmp_file))
-    result = service.ingest_file(ingest_input, user_id="u1")
+    result = await service.ingest_file(ingest_input, user_id="u1")
 
     service.create_entity.assert_called_once()
     entity = service.create_entity.call_args.args[0]
@@ -44,16 +45,18 @@ def test_ingest_file_reads_text(tmp_path):
     assert result == created
 
 
-def test_ingest_file_missing_file_raises():
+@pytest.mark.asyncio
+async def test_ingest_file_missing_file_raises():
     """ingest_file should raise HTTPException when the file is missing."""
     session = MagicMock()
     service = MemoryService(session)
 
     with pytest.raises(HTTPException):
-        service.ingest_file(FileIngestInput(file_path="/nonexistent/file.txt"))
+        await service.ingest_file(FileIngestInput(file_path="/nonexistent/file.txt"))
 
 
-def test_ingest_file_unsupported_encoding(tmp_path):
+@pytest.mark.asyncio
+async def test_ingest_file_unsupported_encoding(tmp_path):
     """If decoding fails for all attempts, HTTPException should be raised."""
     tmp_file = tmp_path / "bad.txt"
     tmp_file.write_bytes(b"\xff\xfe")
@@ -62,6 +65,26 @@ def test_ingest_file_unsupported_encoding(tmp_path):
     service = MemoryService(session)
 
     decode_error = UnicodeDecodeError("utf-8", b"", 0, 1, "bad")
-    with patch("builtins.open", side_effect=[decode_error, decode_error]):
+
+    with patch("aiofiles.open", side_effect=decode_error):
         with pytest.raises(HTTPException):
-            service.ingest_file(FileIngestInput(file_path=str(tmp_file)))
+            await service.ingest_file(FileIngestInput(file_path=str(tmp_file)))
+
+
+@pytest.mark.asyncio
+async def test_ingest_large_file(tmp_path):
+    """Ingesting large files should succeed."""
+    tmp_file = tmp_path / "large.txt"
+    content = "x" * (1024 * 1024 * 5)
+    tmp_file.write_text(content, encoding="utf-8")
+
+    session = MagicMock()
+    service = MemoryService(session)
+    created = MagicMock()
+    service.create_entity = MagicMock(return_value=created)
+
+    ingest_input = FileIngestInput(file_path=str(tmp_file))
+    await service.ingest_file(ingest_input)
+
+    entity = service.create_entity.call_args.args[0]
+    assert entity.content == content


### PR DESCRIPTION
## Summary
- switch ingestion service methods to async/await
- use `aiofiles` for reading files
- update ingestion endpoints for async service calls
- adjust tests for async API and cover large files

## Testing
- `pytest backend/tests/test_memory_service.py backend/tests/test_memory_ingestion.py backend/tests/test_memory_endpoints.py -q`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6841c10d7604832ca562f199f3142e9d