### PR TITLE
Add accessibility gating to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   # pull_request:
   #   branches: [ main ]
 
@@ -83,3 +83,8 @@ jobs:
         run: |
           cd frontend
           npm audit --audit-level=high
+
+      - name: Accessibility tests
+        run: |
+          cd frontend
+          npm run test:e2e --project="Accessibility Tests"

--- a/frontend/TESTING_FRAMEWORK.md
+++ b/frontend/TESTING_FRAMEWORK.md
@@ -85,6 +85,7 @@ describe('TaskStatusTag', () => {
 ```
 
 **Coverage Requirements:**
+
 - Minimum 80% line coverage
 - All critical paths tested
 - Edge cases and error states covered
@@ -98,8 +99,8 @@ Tests component interactions and API integration:
 describe('Task Management Integration', () => {
   it('should create task and update project count', async () => {
     // Test full task creation flow with mocked API
-  })
-})
+  });
+});
 ```
 
 ### End-to-End Tests (`tests-e2e/`)
@@ -110,7 +111,7 @@ Tests complete user workflows:
 // Example: comprehensive.e2e.spec.ts
 test('should complete full task management workflow', async ({ page }) => {
   // Test real user interactions across the entire application
-})
+});
 ```
 
 ### API Tests (`tests-e2e/api.e2e.spec.ts`)
@@ -120,7 +121,7 @@ Direct backend API validation:
 ```typescript
 test('should handle task CRUD operations', async ({ request }) => {
   // Test API endpoints directly without UI
-})
+});
 ```
 
 ## Test Data Management
@@ -133,8 +134,8 @@ Realistic test data generation aligned with backend models:
 // createRealisticTask - generates tasks matching backend Task model
 const task = createRealisticTask({
   project_id: 'proj123',
-  status: TaskStatus.IN_PROGRESS
-})
+  status: TaskStatus.IN_PROGRESS,
+});
 ```
 
 ### Mock Service Worker (MSW)
@@ -144,8 +145,8 @@ API mocking for consistent testing:
 ```typescript
 // handlers.ts - Mock API responses
 http.get('/api/v1/tasks', () => {
-  return HttpResponse.json(createMockTasks(10))
-})
+  return HttpResponse.json(createMockTasks(10));
+});
 ```
 
 ## Data Model Alignment
@@ -155,8 +156,9 @@ http.get('/api/v1/tasks', () => {
 ### Backend Model Compliance
 
 Our tests verify that frontend components correctly handle data structures defined in:
+
 - `backend/models/task.py` - Task entity structure
-- `backend/models/project.py` - Project entity structure  
+- `backend/models/project.py` - Project entity structure
 - `backend/models/user.py` - User entity structure
 
 ### Type Safety Validation
@@ -164,10 +166,10 @@ Our tests verify that frontend components correctly handle data structures defin
 ```typescript
 // Tests validate TypeScript types match backend models
 const task: Task = createMockTask({
-  project_id: string,    // Must match backend string format
-  task_number: number,   // Must match backend integer
-  status: TaskStatus,    // Must match backend enum values
-})
+  project_id: string, // Must match backend string format
+  task_number: number, // Must match backend integer
+  status: TaskStatus, // Must match backend enum values
+});
 ```
 
 ## Test Configuration
@@ -181,14 +183,14 @@ export default defineConfig({
       threshold: {
         global: {
           branches: 80,
-          functions: 80, 
+          functions: 80,
           lines: 80,
-          statements: 80
-        }
-      }
-    }
-  }
-})
+          statements: 80,
+        },
+      },
+    },
+  },
+});
 ```
 
 ### Playwright Configuration (`playwright.config.ts`)
@@ -200,9 +202,9 @@ export default defineConfig({
     { name: 'firefox', use: devices['Desktop Firefox'] },
     { name: 'webkit', use: devices['Desktop Safari'] },
     { name: 'Mobile Chrome', use: devices['Pixel 5'] },
-    { name: 'API Tests', testMatch: /.*\.api\.spec\.ts/ }
-  ]
-})
+    { name: 'API Tests', testMatch: /.*\.api\.spec\.ts/ },
+  ],
+});
 ```
 
 ## Best Practices
@@ -211,7 +213,7 @@ export default defineConfig({
 
 ```
 ComponentName.test.tsx         - Unit tests
-feature-name.test.tsx          - Integration tests  
+feature-name.test.tsx          - Integration tests
 feature-name.e2e.spec.ts       - End-to-end tests
 feature-name.api.spec.ts       - API tests
 ```
@@ -233,23 +235,25 @@ src/
 ### Writing Effective Tests
 
 1. **Follow AAA Pattern**
+
    - Arrange: Set up test data and conditions
    - Act: Execute the functionality being tested
    - Assert: Verify the expected outcome
 
 2. **Test Behavior, Not Implementation**
+
    ```typescript
    // Good - tests behavior
-   expect(screen.getByText('Task created successfully')).toBeInTheDocument()
-   
+   expect(screen.getByText('Task created successfully')).toBeInTheDocument();
+
    // Avoid - tests implementation
-   expect(component.state.tasks).toHaveLength(1)
+   expect(component.state.tasks).toHaveLength(1);
    ```
 
 3. **Use Realistic Test Data**
    ```typescript
    // Use factories for consistent, realistic data
-   const task = createRealisticTask({ status: TaskStatus.COMPLETED })
+   const task = createRealisticTask({ status: TaskStatus.COMPLETED });
    ```
 
 ## Continuous Integration
@@ -298,7 +302,7 @@ test('should render large task list efficiently', async () => {
   const startTime = performance.now()
   render(<TaskList tasks={createMockTasks(1000)} />)
   const renderTime = performance.now() - startTime
-  
+
   expect(renderTime).toBeLessThan(2000)
 })
 ```
@@ -313,7 +317,7 @@ import { axe } from 'axe-core'
 test('should meet accessibility standards', async () => {
   const { container } = render(<TaskList />)
   const results = await axe.run(container)
-  
+
   expect(results.violations).toHaveLength(0)
 })
 ```
@@ -323,14 +327,24 @@ test('should meet accessibility standards', async () => {
 ```typescript
 test('should support keyboard navigation', () => {
   render(<TaskList />)
-  
+
   const searchInput = screen.getByRole('searchbox')
   searchInput.focus()
-  
+
   fireEvent.keyDown(searchInput, { key: 'Tab' })
   // Verify focus moves to next interactive element
 })
 ```
+
+### CI Accessibility Gating
+
+Accessibility tests run automatically in continuous integration:
+
+```bash
+npm run test:e2e --project="Accessibility Tests"
+```
+
+Any violations cause the build to fail.
 
 ## Debugging Tests
 
@@ -340,7 +354,7 @@ test('should support keyboard navigation', () => {
 # Open Vitest UI for interactive debugging
 npm run test:ui
 
-# Open Playwright UI for E2E debugging  
+# Open Playwright UI for E2E debugging
 npm run test:e2e:ui
 
 # Generate and view test reports
@@ -350,27 +364,33 @@ npm run test:e2e:report
 ### Common Issues and Solutions
 
 1. **Test Timeouts**
+
    ```typescript
    // Increase timeout for slow operations
-   test('slow operation', async () => {
-     // test code
-   }, { timeout: 10000 })
+   test(
+     'slow operation',
+     async () => {
+       // test code
+     },
+     { timeout: 10000 }
+   );
    ```
 
 2. **Flaky Tests**
+
    ```typescript
    // Use proper waits instead of timeouts
    await waitFor(() => {
-     expect(screen.getByText('Loading complete')).toBeInTheDocument()
-   })
+     expect(screen.getByText('Loading complete')).toBeInTheDocument();
+   });
    ```
 
 3. **Mock Issues**
    ```typescript
    // Clear mocks between tests
    beforeEach(() => {
-     vi.clearAllMocks()
-   })
+     vi.clearAllMocks();
+   });
    ```
 
 ## Coverage Reports
@@ -398,12 +418,12 @@ open coverage/index.html
 ```typescript
 test('should sanitize user input', () => {
   const maliciousInput = '<script>alert("xss")</script>'
-  
+
   render(<TaskForm />)
   fireEvent.change(screen.getByLabelText('Task Title'), {
     target: { value: maliciousInput }
   })
-  
+
   // Verify input is sanitized
   expect(screen.queryByText('alert')).not.toBeInTheDocument()
 })
@@ -417,7 +437,7 @@ test('should sanitize user input', () => {
 # Before starting development
 npm run test:watch
 
-# Before committing changes  
+# Before committing changes
 npm run test:all
 
 # Before creating pull request
@@ -436,12 +456,14 @@ npm run test:ci
 ### Common Setup Issues
 
 1. **Backend Not Running**
+
    ```bash
    # Start backend first
    python ../run_backend.py
    ```
 
 2. **Port Conflicts**
+
    ```bash
    # Check ports 3000 and 8000 are available
    lsof -i :3000
@@ -458,6 +480,7 @@ npm run test:ci
 ## Support
 
 For testing framework support:
+
 - Check test documentation in `/docs/testing/`
 - Review example tests in each category
 - Consult with the development team for complex scenarios


### PR DESCRIPTION
## Summary
- run Playwright accessibility tests in CI
- document accessibility gating in the testing framework

## Testing
- `npx prettier -w .github/workflows/ci.yml frontend/TESTING_FRAMEWORK.md`
- `npm test` *(fails: Tests failed)*
- `flake8 backend` *(fails: various lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841c10bf080832ca67c62d698ae97c4