### PR TITLE
Add ProjectMenu component and tests

### DIFF
--- a/frontend/src/components/project/ProjectCard.tsx
+++ b/frontend/src/components/project/ProjectCard.tsx
@@ -13,7 +13,7 @@ import { format, formatRelative } from 'date-fns';
 import { ProjectWithMeta, Project } from '@/types';
 import { colorPrimitives } from '@/tokens/colors';
 import AppIcon from '../common/AppIcon';
-import ProjectCardMenu from './ProjectCardMenu';
+import ProjectMenu from './ProjectMenu';
 
 interface ProjectCardProps {
   project: ProjectWithMeta;
@@ -62,10 +62,17 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
   onCopyGet,
   onOpenCliPrompt,
 }) => {
-  const { colorScheme, icon: StatusIcon, fullText } = getProjectStatusInfo(project);
+  const {
+    colorScheme,
+    icon: StatusIcon,
+    fullText,
+  } = getProjectStatusInfo(project);
   const displayTotalTasks = project.task_count ?? 0;
   const displayCompletedTasks = project.completed_task_count ?? 0;
-  const displayProgress = displayTotalTasks > 0 ? (displayCompletedTasks / displayTotalTasks) * 100 : 0;
+  const displayProgress =
+    displayTotalTasks > 0
+      ? (displayCompletedTasks / displayTotalTasks) * 100
+      : 0;
   const displayDescription = project.description || 'No description provided.';
 
   const cardBaseStyles: BoxProps = {
@@ -105,10 +112,16 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
     },
   };
 
-  const currentCardStyles = project.is_archived ? cardArchivedStyles : cardActiveStyles;
+  const currentCardStyles = project.is_archived
+    ? cardArchivedStyles
+    : cardActiveStyles;
 
   return (
-    <Box {...currentCardStyles} role="group" data-testid={`project-card-${project.id}`}>
+    <Box
+      {...currentCardStyles}
+      role="group"
+      data-testid={`project-card-${project.id}`}
+    >
       {project.is_archived && (
         <Flex
           position="absolute"
@@ -130,12 +143,26 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
           <Text isTruncated>Archived</Text>
         </Flex>
       )}
-      <VStack spacing="3" align="stretch" flexGrow={1} opacity={project.is_archived ? 0.6 : 1}>
+      <VStack
+        spacing="3"
+        align="stretch"
+        flexGrow={1}
+        opacity={project.is_archived ? 0.6 : 1}
+      >
         <Flex justifyContent="space-between" alignItems="flex-start" mb={2}>
-          <Heading as="h3" size="md" color={project.is_archived ? 'textDisabled' : 'textStrong'} fontWeight="semibold" noOfLines={2} title={project.name} flexGrow={1} mr={2}>
+          <Heading
+            as="h3"
+            size="md"
+            color={project.is_archived ? 'textDisabled' : 'textStrong'}
+            fontWeight="semibold"
+            noOfLines={2}
+            title={project.name}
+            flexGrow={1}
+            mr={2}
+          >
             {project.name}
           </Heading>
-          <ProjectCardMenu
+          <ProjectMenu
             project={project}
             onEdit={onEdit}
             onArchive={onArchive}
@@ -143,14 +170,34 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
             onDelete={onDelete}
             onCopyGet={onCopyGet}
             onOpenCliPrompt={onOpenCliPrompt}
-            disableActions={!!(project.is_archived && projectToDeleteId === project.id)}
+            disableActions={
+              !!(project.is_archived && projectToDeleteId === project.id)
+            }
           />
         </Flex>
-        <Text fontSize="sm" color={project.description ? 'textSecondary' : 'textPlaceholder'} fontWeight="normal" lineHeight="condensed" noOfLines={2} title={displayDescription} fontStyle={project.description ? undefined : 'italic'}>
+        <Text
+          fontSize="sm"
+          color={project.description ? 'textSecondary' : 'textPlaceholder'}
+          fontWeight="normal"
+          lineHeight="condensed"
+          noOfLines={2}
+          title={displayDescription}
+          fontStyle={project.description ? undefined : 'italic'}
+        >
           {displayDescription}
         </Text>
         <Flex justifyContent="space-between" alignItems="center" mt="1" mb="1">
-          <Badge px="2.5" py="0.5" borderRadius="full" fontSize="xs" textTransform="capitalize" display="inline-flex" alignItems="center" variant="subtle" colorScheme={colorScheme}>
+          <Badge
+            px="2.5"
+            py="0.5"
+            borderRadius="full"
+            fontSize="xs"
+            textTransform="capitalize"
+            display="inline-flex"
+            alignItems="center"
+            variant="subtle"
+            colorScheme={colorScheme}
+          >
             <AppIcon component={StatusIcon} mr="1.5" boxSize={3} />
             {fullText}
           </Badge>
@@ -159,14 +206,21 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
           </Text>
         </Flex>
         {(displayTotalTasks > 0 || project.is_archived) && (
-          <Box w="full" bg={project.is_archived ? 'transparent' : 'borderDecorative'} borderRadius="full" h="1.5" overflow="hidden" mt={1}>
+          <Box
+            w="full"
+            bg={project.is_archived ? 'transparent' : 'borderDecorative'}
+            borderRadius="full"
+            h="1.5"
+            overflow="hidden"
+            mt={1}
+          >
             <Box
               bg={
                 project.is_archived
                   ? 'transparent'
                   : displayProgress === 100
-                  ? colorPrimitives.green[500]
-                  : 'primary'
+                    ? colorPrimitives.green[500]
+                    : 'primary'
               }
               h="full"
               w={`${displayProgress}%`}
@@ -175,12 +229,23 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
             />
           </Box>
         )}
-        <Flex justifyContent="space-between" alignItems="center" mt="auto" pt="3">
+        <Flex
+          justifyContent="space-between"
+          alignItems="center"
+          mt="auto"
+          pt="3"
+        >
           <Text fontSize="xs" color="textSecondary">
-            Created: {project.created_at ? format(new Date(project.created_at), 'MMM d, yy') : 'N/A'}
+            Created:{' '}
+            {project.created_at
+              ? format(new Date(project.created_at), 'MMM d, yy')
+              : 'N/A'}
           </Text>
           <Text fontSize="xs" color="textSecondary">
-            Updated: {project.updated_at ? formatRelative(new Date(project.updated_at), new Date()) : 'Never'}
+            Updated:{' '}
+            {project.updated_at
+              ? formatRelative(new Date(project.updated_at), new Date())
+              : 'Never'}
           </Text>
         </Flex>
       </VStack>

--- a/frontend/src/components/project/ProjectMenu.tsx
+++ b/frontend/src/components/project/ProjectMenu.tsx
@@ -1,0 +1,3 @@
+import ProjectCardMenu from './ProjectCardMenu';
+
+export default ProjectCardMenu;

--- a/frontend/src/components/project/README.md
+++ b/frontend/src/components/project/README.md
@@ -4,12 +4,13 @@ This directory contains React components for displaying and managing project-rel
 
 Key files:
 
-*   `ProjectList.tsx`: Component for displaying a list of projects.
-*   `ProjectDetail.tsx`: Component for displaying the detailed information of a single project.
-*   `ProjectFiles.tsx`: Component for displaying and managing files associated with a project.
-*   `ProjectMembers.tsx`: Component for displaying and managing members associated with a project.
+- `ProjectList.tsx`: Component for displaying a list of projects.
+- `ProjectDetail.tsx`: Component for displaying the detailed information of a single project.
+- `ProjectFiles.tsx`: Component for displaying and managing files associated with a project.
+- `ProjectMembers.tsx`: Component for displaying and managing members associated with a project.
 
 ## Architecture Diagram
+
 ```mermaid
 graph TD
     user((User)) -->|interacts with| frontend(Frontend)
@@ -19,18 +20,17 @@ graph TD
 ```
 
 <!-- File List Start -->
+
 ## File List
 
 - `CliPromptModal.tsx`
 - `DeleteProjectDialog.tsx`
 - `ProjectCard.tsx`
 - `ProjectCardMenu.tsx`
+- `ProjectMenu.tsx`
 - `ProjectDetail.tsx`
 - `ProjectFiles.tsx`
 - `ProjectList.tsx`
 - `ProjectMembers.tsx`
 
 <!-- File List End -->
-
-
-

--- a/frontend/src/components/project/__tests__/ProjectCard.test.tsx
+++ b/frontend/src/components/project/__tests__/ProjectCard.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TestWrapper } from '@/__tests__/utils/test-utils';
+import ProjectCard from '../ProjectCard';
+import { ProjectWithMeta } from '@/types';
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual('@chakra-ui/react');
+  return {
+    ...actual,
+    useToast: () => vi.fn(),
+    useColorModeValue: (light: any, dark: any) => light,
+  };
+});
+
+const mockProject: ProjectWithMeta = {
+  id: '1',
+  name: 'Test Project',
+  description: 'desc',
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  is_archived: false,
+  status: 'not_started',
+  task_count: 0,
+  completed_task_count: 0,
+};
+
+describe('ProjectCard', () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render without crashing', () => {
+    render(
+      <TestWrapper>
+        <ProjectCard
+          project={mockProject}
+          onEdit={vi.fn()}
+          onArchive={vi.fn()}
+          onUnarchive={vi.fn()}
+          onDelete={vi.fn()}
+          onCopyGet={vi.fn()}
+          onOpenCliPrompt={vi.fn()}
+        />
+      </TestWrapper>
+    );
+    expect(
+      screen.getByTestId(`project-card-${mockProject.id}`)
+    ).toBeInTheDocument();
+  });
+
+  it('should handle user interactions', async () => {
+    render(
+      <TestWrapper>
+        <ProjectCard
+          project={mockProject}
+          onEdit={vi.fn()}
+          onArchive={vi.fn()}
+          onUnarchive={vi.fn()}
+          onDelete={vi.fn()}
+          onCopyGet={vi.fn()}
+          onOpenCliPrompt={vi.fn()}
+        />
+      </TestWrapper>
+    );
+
+    const buttons = screen.getAllByRole('button');
+    if (buttons.length > 0) {
+      await user.click(buttons[0]);
+    }
+
+    expect(
+      screen.getByTestId(`project-card-${mockProject.id}`)
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/project/__tests__/ProjectMenu.test.tsx
+++ b/frontend/src/components/project/__tests__/ProjectMenu.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TestWrapper } from '@/__tests__/utils/test-utils';
+import ProjectMenu from '../ProjectMenu';
+import { ProjectWithMeta } from '@/types';
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual('@chakra-ui/react');
+  return {
+    ...actual,
+    useToast: () => vi.fn(),
+    useColorModeValue: (light: any, dark: any) => light,
+  };
+});
+
+const mockProject: ProjectWithMeta = {
+  id: '1',
+  name: 'Test',
+  description: 'desc',
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  is_archived: false,
+  status: 'not_started',
+  task_count: 0,
+  completed_task_count: 0,
+};
+
+describe('ProjectMenu', () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render without crashing', () => {
+    render(
+      <TestWrapper>
+        <ProjectMenu
+          project={mockProject}
+          onEdit={vi.fn()}
+          onArchive={vi.fn()}
+          onUnarchive={vi.fn()}
+          onDelete={vi.fn()}
+          onCopyGet={vi.fn()}
+          onOpenCliPrompt={vi.fn()}
+          disableActions={false}
+        />
+      </TestWrapper>
+    );
+    const buttons = screen.getAllByRole('button');
+    expect(buttons.length).toBeGreaterThan(0);
+  });
+
+  it('should handle user interactions', async () => {
+    render(
+      <TestWrapper>
+        <ProjectMenu
+          project={mockProject}
+          onEdit={vi.fn()}
+          onArchive={vi.fn()}
+          onUnarchive={vi.fn()}
+          onDelete={vi.fn()}
+          onCopyGet={vi.fn()}
+          onOpenCliPrompt={vi.fn()}
+          disableActions={false}
+        />
+      </TestWrapper>
+    );
+
+    const button = screen.getByRole('button');
+    await user.click(button);
+    expect(button).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add `ProjectMenu` component that re-exports `ProjectCardMenu`
- update `ProjectCard` to use `ProjectMenu`
- document new file in project README
- add unit tests for `ProjectCard` and `ProjectMenu`

## Testing
- `npm run lint`
- `npm run test:run` *(fails: cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6841c1096068832cab4b3a039d7b3d01