### PR TITLE
Handle network errors in fetch

### DIFF
--- a/frontend/src/lib/__tests__/apiErrorHandler.test.ts
+++ b/frontend/src/lib/__tests__/apiErrorHandler.test.ts
@@ -13,7 +13,7 @@ vi.mock('@chakra-ui/react', async () => {
 });
 
 import { handleApiError } from '../apiErrorHandler';
-import { ApiError } from '@/services/api/request';
+import { ApiError, NetworkError } from '@/services/api/request';
 
 describe('handleApiError', () => {
   beforeEach(() => {
@@ -27,6 +27,16 @@ describe('handleApiError', () => {
         title: 'Oops',
         description: 'Boom',
         status: 'error',
+      })
+    );
+  });
+
+  it('handles NetworkError instances with network title', () => {
+    handleApiError(new NetworkError('Offline', 'http://foo'));
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Network Error',
+        description: 'Offline',
       })
     );
   });

--- a/frontend/src/lib/apiErrorHandler.ts
+++ b/frontend/src/lib/apiErrorHandler.ts
@@ -1,5 +1,5 @@
 import { createStandaloneToast, UseToastOptions } from '@chakra-ui/react';
-import { ApiError } from '@/services/api/request';
+import { ApiError, NetworkError } from '@/services/api/request';
 
 const { toast } = createStandaloneToast();
 
@@ -9,7 +9,10 @@ export function handleApiError(
   options?: Partial<UseToastOptions>
 ): void {
   let description = 'An unexpected error occurred.';
-  if (error instanceof ApiError) {
+  if (error instanceof NetworkError) {
+    description = error.message;
+    title = 'Network Error';
+  } else if (error instanceof ApiError) {
     description = error.message;
   } else if (error instanceof Error) {
     description = error.message;

--- a/frontend/src/services/api/request.ts
+++ b/frontend/src/services/api/request.ts
@@ -13,6 +13,14 @@ export class ApiError extends Error {
   }
 }
 
+/** Error type for network failures */
+export class NetworkError extends ApiError {
+  constructor(message: string, url: string) {
+    super(message, 0, url);
+    this.name = 'NetworkError';
+  }
+}
+
 // Helper to normalize status string to a known StatusID
 export const normalizeToStatusID = (
   backendStatus: string | null | undefined,
@@ -71,7 +79,7 @@ export async function request<T>(
       headers,
     });
   } catch (err) {
-    throw new ApiError((err as Error).message || 'Network Error', 0, url);
+    throw new NetworkError((err as Error).message || 'Network Error', url);
   }
 
   if (!response.ok) {

--- a/frontend/src/store/__tests__/apiError.test.ts
+++ b/frontend/src/store/__tests__/apiError.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { request, ApiError } from "@/services/api/request";
+import { request, ApiError, NetworkError } from "@/services/api/request";
 import { getTasks } from "@/services/api/tasks";
 import { server } from "@/__tests__/mocks/server";
 import { http, HttpResponse } from "msw";
@@ -21,14 +21,14 @@ describe("ApiError handling", () => {
     });
   });
 
-  it("request wraps network errors in ApiError", async () => {
+  it("request wraps network errors in NetworkError", async () => {
     server.use(
       http.get(API_URL, () => {
         throw new Error("Network fail");
       }),
     );
 
-    await expect(request(API_URL)).rejects.toBeInstanceOf(ApiError);
+    await expect(request(API_URL)).rejects.toBeInstanceOf(NetworkError);
   });
 
   it("service functions propagate ApiError", async () => {


### PR DESCRIPTION
## Summary
- introduce `NetworkError` and throw it when fetch fails
- show a toast for network failures via `handleApiError`
- adjust tests for new error type

## Testing
- `npx vitest run -t "ApiError handling" src/store/__tests__/apiError.test.ts` *(fails: Failed to resolve import "./error_protocol" from "src/types/index.ts")*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6841c1087d44832caf597c7fba5b67b7