### PR TITLE
Add pagination parameters for task queries

### DIFF
--- a/frontend/src/components/dashboard/useDashboardData.ts
+++ b/frontend/src/components/dashboard/useDashboardData.ts
@@ -16,7 +16,7 @@ export function useDashboardData() {
     try {
       const [projectsFromApi, tasksFromApi] = await Promise.all([
         api.getProjects({ is_archived: null }),
-        api.getAllTasks({ is_archived: null }),
+        api.getAllTasks({ is_archived: null }, undefined, 0, 100),
       ]);
       setAllProjects(projectsFromApi || []);
       setAllTasks(tasksFromApi || []);

--- a/frontend/src/components/project/ProjectDetail.tsx
+++ b/frontend/src/components/project/ProjectDetail.tsx
@@ -42,7 +42,7 @@ const ProjectDetail: React.FC = () => {
   const fetchTasks = async () => {
     if (!projectId) return;
     try {
-      const data = await getAllTasksForProject(projectId);
+      const data = await getAllTasksForProject(projectId, undefined, undefined, 0, 100);
       setTasks(data);
     } catch (err) {
       setTasksError('Failed to fetch tasks');

--- a/frontend/src/hooks/__tests__/useProjectData.test.tsx
+++ b/frontend/src/hooks/__tests__/useProjectData.test.tsx
@@ -34,6 +34,13 @@ describe('useProjectData', () => {
 
     await waitFor(() => expect(result.current.project).toEqual(project));
     expect(result.current.tasks).toEqual(tasks);
+    expect(mockedApi.getAllTasksForProject).toHaveBeenCalledWith(
+      'p1',
+      undefined,
+      undefined,
+      0,
+      100,
+    );
     expect(result.current.error).toBeNull();
   });
 

--- a/frontend/src/hooks/useProjectData.ts
+++ b/frontend/src/hooks/useProjectData.ts
@@ -28,7 +28,7 @@ export const useProjectData = (projectId: string): UseProjectDataResult => {
     try {
       const [proj, projTasks] = await Promise.all([
         getProjectById(projectId),
-        getAllTasksForProject(projectId),
+        getAllTasksForProject(projectId, undefined, undefined, 0, 100),
       ]);
       setProject(proj);
       setTasks(projTasks);

--- a/frontend/src/services/__tests__/tasks.test.ts
+++ b/frontend/src/services/__tests__/tasks.test.ts
@@ -43,6 +43,10 @@ describe('Tasks API', () => {
 
       const result = await tasksApi.getTasks('project-1');
 
+      expect(mockBuildApiUrl).toHaveBeenCalledWith(
+        expect.any(String),
+        '/project-1/tasks?skip=0&limit=100'
+      );
       expect(mockRequest).toHaveBeenCalledWith('http://localhost:8000/api/test');
       expect(result).toHaveLength(1);
       expect(result[0]).toMatchObject({
@@ -66,11 +70,32 @@ describe('Tasks API', () => {
         is_archived: false,
       };
 
-      await tasksApi.getTasks('project-1', filters);
+      await tasksApi.getTasks('project-1', filters, undefined, 1, 10);
 
       expect(mockBuildApiUrl).toHaveBeenCalledWith(
-        expect.any(String), 
+        expect.any(String),
         expect.stringContaining('agent_id=agent-1')
+      );
+      expect(mockBuildApiUrl).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('skip=10')
+      );
+    });
+  });
+
+  describe('getAllTasks', () => {
+    it('builds pagination query params', async () => {
+      mockRequest.mockResolvedValue([]);
+
+      await tasksApi.getAllTasks(undefined, undefined, 2, 5);
+
+      expect(mockBuildApiUrl).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('skip=10'),
+      );
+      expect(mockBuildApiUrl).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('limit=5'),
       );
     });
   });

--- a/frontend/src/services/api/tasks.ts
+++ b/frontend/src/services/api/tasks.ts
@@ -175,9 +175,11 @@ export const getTasks = async (
   projectId: string,
   filters?: TaskFilters,
   sortOptions?: TaskSortOptions,
-  skip = 0,
-  limit = 100,
+  page = 0,
+  pageSize = 100,
 ): Promise<Task[]> => {
+  const skip = page * pageSize;
+  const limit = pageSize;
   const queryParams = new URLSearchParams();
   if (filters?.agentId) queryParams.append("agent_id", filters.agentId);
   if (filters?.status && filters.status !== "all")
@@ -223,9 +225,11 @@ export const getTasks = async (
 export const getAllTasks = async (
   filters?: TaskFilters,
   sortOptions?: TaskSortOptions,
-  skip = 0,
-  limit = 100,
+  page = 0,
+  pageSize = 100,
 ): Promise<Task[]> => {
+  const skip = page * pageSize;
+  const limit = pageSize;
   const queryParams = new URLSearchParams();
   if (filters?.agentId) queryParams.append("agent_id", filters.agentId);
   if (filters?.status && filters.status !== "all")
@@ -359,8 +363,14 @@ export const updateTask = async (
 };
 
 // Fetch all tasks for a specific project (alias for getTasks for backward compatibility)
-export const getAllTasksForProject = async (projectId: string, filters?: TaskFilters, sortOptions?: TaskSortOptions): Promise<Task[]> => {
-  return getTasks(projectId, filters, sortOptions);
+export const getAllTasksForProject = async (
+  projectId: string,
+  filters?: TaskFilters,
+  sortOptions?: TaskSortOptions,
+  page = 0,
+  pageSize = 100,
+): Promise<Task[]> => {
+  return getTasks(projectId, filters, sortOptions, page, pageSize);
 };
 export const deleteTask = async (
   project_id: string,

--- a/frontend/src/store/__tests__/apiError.test.ts
+++ b/frontend/src/store/__tests__/apiError.test.ts
@@ -4,7 +4,8 @@ import { getTasks } from "@/services/api/tasks";
 import { server } from "@/__tests__/mocks/server";
 import { http, HttpResponse } from "msw";
 
-const API_URL = "http://localhost:8000/api/projects/project-1/tasks";
+const API_URL =
+  "http://localhost:8000/api/projects/project-1/tasks?skip=0&limit=100";
 
 describe("ApiError handling", () => {
   it("request throws ApiError for non-ok response", async () => {
@@ -38,6 +39,6 @@ describe("ApiError handling", () => {
       ),
     );
 
-    await expect(getTasks("project-1")).rejects.toBeInstanceOf(ApiError);
+    await expect(getTasks("project-1", undefined, undefined, 0, 100)).rejects.toBeInstanceOf(ApiError);
   });
 });

--- a/frontend/src/store/__tests__/taskStore.test.ts
+++ b/frontend/src/store/__tests__/taskStore.test.ts
@@ -53,7 +53,12 @@ describe('taskStore', () => {
       await useTaskStore.getState().fetchTasks()
     })
 
-    expect(mockedApi.getAllTasks).toHaveBeenCalled()
+    expect(mockedApi.getAllTasks).toHaveBeenCalledWith(
+      initialState.filters,
+      initialState.sortOptions,
+      0,
+      100,
+    )
     expect(useTaskStore.getState().tasks).toEqual(tasks)
   })
 

--- a/frontend/src/store/taskStore.ts
+++ b/frontend/src/store/taskStore.ts
@@ -178,7 +178,12 @@ export const useTaskStore = create<TaskState>(
     );
     try {
       // Pass sortOptions to API so backend handles sorting
-      const fetchedTasks = await api.getAllTasks(currentActiveFilters, currentSortOptions);
+      const fetchedTasks = await api.getAllTasks(
+        currentActiveFilters,
+        currentSortOptions,
+        0,
+        100,
+      );
       set((state: TaskState) => {
         let updatedTasks = upsertTasks(fetchedTasks, state.tasks);
         const fetchedIds = new Set(


### PR DESCRIPTION
## Summary
- support `page` and `pageSize` in task API requests
- update store and hooks to send pagination
- adjust components for new API signatures
- test query string generation for pagination

## Testing
- `npm --prefix frontend run test:coverage` *(fails: vitest not found)*
- `npm --prefix frontend run lint` *(fails: next not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6841c1073224832ca898c79e37310217