### PR TITLE
Use TaskStatus constants

### DIFF
--- a/frontend/src/components/TaskList.utils.ts
+++ b/frontend/src/components/TaskList.utils.ts
@@ -3,6 +3,7 @@
 
 import { Task, TaskFilters, GroupByType, Project, Agent, TaskSortOptions } from "@/types";
 import { mapStatusToStatusID, formatDisplayName } from "@/lib/utils";
+import { TaskStatus } from "@/types/task";
 import * as statusUtils from "@/lib/statusUtils";
 import { sortTasks } from "@/store/taskStore";
 import type { TaskGroup, TaskSubgroup, GroupedTasks } from "./views/ListView.types";
@@ -89,7 +90,7 @@ function getStatusSubgroupsForProjectOrAgent(currentTasks: Task[], sortOptions: 
 export function groupTasksByStatus(topLevelTasks: Task[], sortOptions: TaskSortOptions): { type: GroupByType, groups: TaskGroup[] } {
   const tasksByStatusId: { [key: string]: Task[] } = {};
   topLevelTasks.forEach((task) => {
-    const currentTaskStatusId = (task.status || "TO_DO");
+    const currentTaskStatusId = task.status || TaskStatus.TO_DO;
     if (!tasksByStatusId[currentTaskStatusId]) {
       tasksByStatusId[currentTaskStatusId] = [];
     }
@@ -98,7 +99,7 @@ export function groupTasksByStatus(topLevelTasks: Task[], sortOptions: TaskSortO
 
   const allStatusIdsInTasks = Object.keys(tasksByStatusId);
   const preferredStatusOrder = [
-    "TO_DO",
+    TaskStatus.TO_DO,
     "IN_PROGRESS",
     "BLOCKED",
     "PENDING_VERIFICATION",

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -3,6 +3,7 @@ import {
   getStatusAttributes,
   StatusID as CanonicalStatusID,
 } from "@/lib/statusUtils";
+import { TaskStatus } from "@/types/task";
 
 export const formatDisplayName = (name?: string | null): string => {
   if (!name || name.trim() === "") {
@@ -23,7 +24,7 @@ export const mapStatusToStatusID = (
   status: string | null | undefined,
 ): CanonicalStatusID => {
   if (!status || typeof status !== "string" || status.trim() === "") {
-    return "TO_DO"; // Default for null, undefined, or empty/non-string
+    return TaskStatus.TO_DO; // Default for null, undefined, or empty/non-string
   }
 
   // Handle common display names case-insensitively
@@ -31,7 +32,7 @@ export const mapStatusToStatusID = (
   switch (lowerStatus) {
     case "to do":
     case "todo":
-      return "TO_DO";
+      return TaskStatus.TO_DO;
     case "in progress":
       return "IN_PROGRESS";
     case "blocked":
@@ -70,5 +71,5 @@ export const mapStatusToStatusID = (
       `[mapStatusToStatusID] Unknown status value: "${status}", defaulting to TO_DO.`,
     );
   }
-  return "TO_DO";
+  return TaskStatus.TO_DO;
 };

--- a/frontend/tests-e2e/api.e2e.spec.ts
+++ b/frontend/tests-e2e/api.e2e.spec.ts
@@ -9,6 +9,7 @@
  */
 
 import { test, expect } from '@playwright/test'
+import { TaskStatus } from '../src/types/task'
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000'
 
@@ -101,7 +102,7 @@ test.describe('Task Manager API E2E Tests', () => {
         data: {
           title: 'API Test Task',
           description: 'Task created via API test',
-          status: 'TO_DO',
+          status: TaskStatus.TO_DO,
         }
       })
       
@@ -143,7 +144,7 @@ test.describe('Task Manager API E2E Tests', () => {
         data: {
           title: 'Status Transition Test',
           description: 'Testing status transitions',
-          status: 'TO_DO',
+          status: TaskStatus.TO_DO,
         }
       })
       
@@ -152,7 +153,7 @@ test.describe('Task Manager API E2E Tests', () => {
 
       // Valid transitions: TO_DO -> IN_PROGRESS -> COMPLETED
       const transitions = [
-        { from: 'TO_DO', to: 'IN_PROGRESS' },
+        { from: TaskStatus.TO_DO, to: 'IN_PROGRESS' },
         { from: 'IN_PROGRESS', to: 'COMPLETED' }
       ]
 
@@ -175,7 +176,7 @@ test.describe('Task Manager API E2E Tests', () => {
       const missingTitleResponse = await request.post(`${API_BASE_URL}/api/v1/projects/${testProjectId}/tasks`, {
         data: {
           description: 'Task without title',
-          status: 'TO_DO',
+          status: TaskStatus.TO_DO,
         }
       })
       expect(missingTitleResponse.status()).toBe(422) // Validation error
@@ -194,7 +195,7 @@ test.describe('Task Manager API E2E Tests', () => {
         data: {
           title: 'Valid Task',
           description: 'This is a valid task',
-          status: 'TO_DO',
+          status: TaskStatus.TO_DO,
         }
       })
       expect(validResponse.status()).toBe(201)
@@ -210,7 +211,7 @@ test.describe('Task Manager API E2E Tests', () => {
     test.beforeEach(async ({ request }) => {
       // Create test tasks with different statuses
       const testTasks = [
-        { title: 'Frontend Task', status: 'TO_DO', description: 'Frontend development' },
+        { title: 'Frontend Task', status: TaskStatus.TO_DO, description: 'Frontend development' },
         { title: 'Backend Task', status: 'IN_PROGRESS', description: 'Backend development' },
         { title: 'Testing Task', status: 'COMPLETED', description: 'Testing phase' },
       ]
@@ -228,7 +229,7 @@ test.describe('Task Manager API E2E Tests', () => {
       
       expect(todoData.data).toHaveLength(1)
       expect(todoData.data[0].title).toBe('Frontend Task')
-      expect(todoData.data[0].status).toBe('TO_DO')
+      expect(todoData.data[0].status).toBe(TaskStatus.TO_DO)
     })
 
     test('should search tasks by title', async ({ request }) => {
@@ -314,7 +315,7 @@ test.describe('Task Manager API E2E Tests', () => {
         data: {
           title: 'Model Compliance Test',
           description: 'Testing data model compliance',
-          status: 'TO_DO',
+          status: TaskStatus.TO_DO,
         }
       })
       

--- a/frontend/tests-e2e/comprehensive.e2e.spec.ts
+++ b/frontend/tests-e2e/comprehensive.e2e.spec.ts
@@ -1,3 +1,5 @@
+import { TaskStatus } from '../src/types/task'
+
 Page.route('**/api/v1/projects/*/tasks/*', (route) => {
         if (route.request().method() === 'PATCH') {
           route.fulfill({
@@ -71,7 +73,7 @@ Page.route('**/api/v1/projects/*/tasks/*', (route) => {
             task_number: 1,
             title: 'Frontend Development',
             description: 'Build the frontend',
-            status: 'TO_DO',
+            status: TaskStatus.TO_DO,
             created_at: new Date().toISOString(),
             updated_at: new Date().toISOString(),
             is_archived: false,
@@ -126,7 +128,7 @@ Page.route('**/api/v1/projects/*/tasks/*', (route) => {
             project_id: 'proj1',
             task_number: 1,
             title: 'Todo Task',
-            status: 'TO_DO',
+            status: TaskStatus.TO_DO,
             created_at: new Date().toISOString(),
             updated_at: new Date().toISOString(),
             is_archived: false,
@@ -161,7 +163,7 @@ Page.route('**/api/v1/projects/*/tasks/*', (route) => {
       await taskPage.gotoTasks()
       await taskPage.expectTaskCount(2)
       
-      await taskPage.filterByStatus('TO_DO')
+      await taskPage.filterByStatus(TaskStatus.TO_DO)
       await taskPage.expectTaskCount(1)
       await taskPage.expectTaskVisible('Todo Task')
     })
@@ -235,7 +237,7 @@ Page.route('**/api/v1/projects/*/tasks/*', (route) => {
                 project_id: 'proj1',
                 task_number: 1,
                 title: 'Recovered Task',
-                status: 'TO_DO',
+                status: TaskStatus.TO_DO,
                 created_at: new Date().toISOString(),
                 updated_at: new Date().toISOString(),
                 is_archived: false,
@@ -288,7 +290,7 @@ Page.route('**/api/v1/projects/*/tasks/*', (route) => {
         task_number: i + 1,
         title: `Task ${i + 1}`,
         description: `Description for task ${i + 1}`,
-        status: 'TO_DO',
+        status: TaskStatus.TO_DO,
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
         is_archived: false,

--- a/frontend/tests-e2e/integration-flow.e2e.spec.ts
+++ b/frontend/tests-e2e/integration-flow.e2e.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 import { spawn } from "child_process";
 import path from "path";
+import { TaskStatus } from "../src/types/task";
 
 async function waitFor(url: string, timeout = 120000) {
   const start = Date.now();
@@ -63,7 +64,7 @@ test.describe("Integration Flow via start_system.py", () => {
         data: {
           title: "Integration Task",
           description: "e2e",
-          status: "TO_DO",
+          status: TaskStatus.TO_DO,
         },
       },
     );

--- a/frontend/tests-e2e/user-flows.e2e.spec.ts
+++ b/frontend/tests-e2e/user-flows.e2e.spec.ts
@@ -6,6 +6,7 @@
  */
 
 import { test, expect } from '@playwright/test';
+import { TaskStatus } from '../src/types/task';
 
 // Helper class for common user flow operations
 class UserFlowPage {
@@ -43,7 +44,7 @@ class UserFlowPage {
     await this.page.waitForSelector(`[data-testid="project-item"]:has-text("${name}")`);
   }
 
-  async createTask(projectId, title, description, status = 'TO_DO') {
+  async createTask(projectId, title, description, status = TaskStatus.TO_DO) {
     await this.page.goto(`/projects/${projectId}/tasks`);
     await this.page.click('[data-testid="create-task-button"]');
     
@@ -159,7 +160,7 @@ test.describe('User Flows', () => {
             task_number: 1,
             title: requestBody.title,
             description: requestBody.description,
-            status: requestBody.status || 'TO_DO',
+            status: requestBody.status || TaskStatus.TO_DO,
             created_at: new Date().toISOString(),
             is_archived: false
           })


### PR DESCRIPTION
## Summary
- import TaskStatus where missing
- replace 'TO_DO' literals with TaskStatus.TO_DO

## Testing
- `npm run test:e2e` *(fails: require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6841c103920c832c87144509b78a4f6b