### PR TITLE
Fix schema rebuild initialization

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -10,6 +10,7 @@ from typing import Dict, Any
 from .database import get_db, Base, engine
 from .middleware import init_middleware
 from .app_factory import create_app as factory_create_app
+from .schemas import _schema_init  # noqa: F401
 
 # Optional MCP integration
 try:

--- a/backend/schemas/_schema_init.py
+++ b/backend/schemas/_schema_init.py
@@ -43,19 +43,42 @@ from .api_responses import (  # noqa: F401
     DataResponse,
     ListResponse,
     ErrorResponse,
-    PaginationParams
+    PaginationParams,
 )
 
 # Rebuild models to resolve forward references
-# This is typically handled by Pydantic v2 automatically if type hints are used correctly,
-# but this explicit rebuild can be kept if necessary for compatibility or specific patterns.
-# This part seems incomplete in the original code, so I'm commenting it out.
-# You might need to add the actual model_rebuild() calls here if required.
+_SCHEMAS = [
+    Agent,
+    AgentCreate,
+    AgentUpdate,
+    AgentRule,
+    AgentRuleCreate,
+    AgentRuleUpdate,
+    MemoryEntity,
+    MemoryEntityCreate,
+    MemoryEntityUpdate,
+    MemoryObservation,
+    MemoryObservationCreate,
+    MemoryRelationCreate,
+    Project,
+    ProjectCreate,
+    ProjectUpdate,
+    ProjectMember,
+    ProjectMemberCreate,
+    ProjectMemberUpdate,
+    ProjectFileAssociation,
+    ProjectFileAssociationCreate,
+    AgentHandoffCriteria,
+    AgentHandoffCriteriaCreate,
+    AgentHandoffCriteriaUpdate,
+    ProjectTemplate,
+    ProjectTemplateCreate,
+    ProjectTemplateUpdate,
+    DataResponse,
+    ListResponse,
+    ErrorResponse,
+    PaginationParams,
+]
 
-# Agent.model_rebuild()
-# AgentCreate.model_rebuild()
-# AgentUpdate.model_rebuild()
-# AgentRule.model_rebuild()
-# AgentRuleCreate.model_rebuild()
-# AgentRuleUpdate.model_rebuild()
-# ... and so on for all models
+for schema in _SCHEMAS:
+    schema.model_rebuild()

--- a/backend/tests/test_openapi_validators.py
+++ b/backend/tests/test_openapi_validators.py
@@ -1,0 +1,10 @@
+import pytest
+from backend.main import app
+
+def test_openapi_no_validator_error():
+    """OpenAPI generation should not raise validator errors."""
+    try:
+        schema = app.openapi()
+    except RuntimeError as exc:
+        pytest.fail(f"OpenAPI generation failed: {exc}")
+    assert "paths" in schema


### PR DESCRIPTION
## Summary
- rebuild all Pydantic schemas in `_schema_init`
- load `_schema_init` during app startup so schemas are rebuilt
- test that OpenAPI generation succeeds without validator errors

## Testing
- `flake8 backend/main.py backend/schemas/_schema_init.py backend/tests/test_openapi_validators.py`
- `pytest backend/tests/test_openapi_validators.py::test_openapi_no_validator_error -q`
- `pytest -q` *(fails: ModuleNotFoundError / other failures)*

------
https://chatgpt.com/codex/tasks/task_e_6841c0fbfff4832cb78d3843b49f3b06