### PR TITLE
Handle graph errors

### DIFF
--- a/frontend/src/__tests__/integration/memory-graph.test.tsx
+++ b/frontend/src/__tests__/integration/memory-graph.test.tsx
@@ -1,9 +1,13 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, waitFor } from '@/__tests__/utils/test-utils';
-import MemoryGraphPage from '@/app/memory/graph/page';
 
 vi.mock('react-force-graph', () => ({
   ForceGraph2D: (props: any) => <div data-testid="graph" {...props} />,
+}));
+
+vi.mock('next/dynamic', () => ({
+  __esModule: true,
+  default: () => (props: any) => <div data-testid="graph" {...props} />,
 }));
 
 vi.mock('@/services/api', () => ({
@@ -26,6 +30,8 @@ vi.mock('@/services/api', () => ({
     }),
   },
 }));
+
+import MemoryGraphPage from '@/app/memory/graph/page';
 
 describe('MemoryGraph page', () => {
   it('renders graph with data', async () => {

--- a/frontend/src/components/memory/MemoryGraph.tsx
+++ b/frontend/src/components/memory/MemoryGraph.tsx
@@ -18,7 +18,7 @@ const MemoryGraph: React.FC = () => {
     memoryApi
       .getKnowledgeGraph()
       .then((g) => setGraph(g))
-      .catch((e) => setError(e instanceof Error ? e.message : 'Error'));
+      .catch(() => setError('Failed to load memory graph'));
   }, []);
 
   if (error) {


### PR DESCRIPTION
## Summary
- mock `memoryApi.getKnowledgeGraph` in memory graph test
- show an error message when the graph fetch fails

## Testing
- `npm test src/__tests__/integration/memory-graph.test.tsx` *(fails: Failed to resolve entry for package "react-force-graph")*

------
https://chatgpt.com/codex/tasks/task_e_6841be1605a8832c8e089be3226447a9