### PR TITLE
Add token refresh endpoint

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -14,6 +14,7 @@ from backend.config import (
     SECRET_KEY,
     ALGORITHM,
     ACCESS_TOKEN_EXPIRE_MINUTES,
+    REFRESH_TOKEN_EXPIRE_MINUTES,
 )
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/login")
@@ -89,3 +90,28 @@ def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
     to_encode.update({"exp": expire})
     encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt
+
+
+def create_refresh_token(data: dict, expires_delta: Optional[timedelta] = None):
+    """Create a JWT refresh token."""
+    to_encode = data.copy()
+    if expires_delta:
+        expire = datetime.now(timezone.utc) + expires_delta
+    else:
+        expire = (
+            datetime.now(timezone.utc)
+            + timedelta(minutes=REFRESH_TOKEN_EXPIRE_MINUTES)
+        )
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+
+def verify_refresh_token(token: str) -> str:
+    """Verify a refresh token and return the username."""
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Invalid refresh token",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    return verify_token(token, credentials_exception)

--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -2,12 +2,19 @@
 Configuration package initialization.
 """
 
-from .app_config import Settings
+from .app_config import Settings, configure_logging
 
 settings = Settings()
 
 SECRET_KEY = settings.SECRET_KEY
 ALGORITHM = settings.ALGORITHM
 ACCESS_TOKEN_EXPIRE_MINUTES = settings.ACCESS_TOKEN_EXPIRE_MINUTES
+REFRESH_TOKEN_EXPIRE_MINUTES = settings.REFRESH_TOKEN_EXPIRE_MINUTES
 
-__all__ = ['configure_logging', 'SECRET_KEY', 'ALGORITHM', 'ACCESS_TOKEN_EXPIRE_MINUTES']
+__all__ = [
+    'configure_logging',
+    'SECRET_KEY',
+    'ALGORITHM',
+    'ACCESS_TOKEN_EXPIRE_MINUTES',
+    'REFRESH_TOKEN_EXPIRE_MINUTES',
+]

--- a/backend/config/app_config.py
+++ b/backend/config/app_config.py
@@ -26,6 +26,7 @@ class Settings(BaseSettings):
     SECRET_KEY: str
     ALGORITHM: str
     ACCESS_TOKEN_EXPIRE_MINUTES: int
+    REFRESH_TOKEN_EXPIRE_MINUTES: int = 60 * 24 * 7
     DEBUG: bool = False  # Add debug setting
     
     # Rate limiting settings

--- a/backend/routers/users/auth/auth.py
+++ b/backend/routers/users/auth/auth.py
@@ -1,6 +1,6 @@
 # Task ID: <taskId>  # Agent Role: ImplementationSpecialist  # Request ID: <requestId>  # Project: task-manager  # Timestamp: <timestamp>
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status, Response, Request
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.ext.asyncio import AsyncSession
 from datetime import timedelta
@@ -10,7 +10,11 @@ from backend.services.user_service import UserService
 from backend.services.audit_log_service import AuditLogService
 from backend.services.exceptions import AuthorizationError
 from backend.config import ACCESS_TOKEN_EXPIRE_MINUTES
-from backend.auth import create_access_token
+from backend.auth import (
+    create_access_token,
+    create_refresh_token,
+    verify_refresh_token,
+)
 from backend.security import login_tracker  # Import specific schema classes from their files
 from pydantic import BaseModel  # Placeholder for token related logic (e.g., SECRET_KEY, ALGORITHM, Token schemas)  # Should be moved to a separate auth module later  # SECRET_KEY = "your-secret-key"  # ALGORITHM = "HS256"  # ACCESS_TOKEN_EXPIRE_MINUTES = 30
 
@@ -37,23 +41,68 @@ class LoginRequest(BaseModel):
 
 @router.post("/token", response_model=Token)
 async def login_for_access_token_form(
+    response: Response,
     form_data: OAuth2PasswordRequestForm = Depends(),
     user_service: UserService = Depends(get_user_service),
     audit_log_service: AuditLogService = Depends(get_audit_log_service)
 ):
     """Authenticate user and return access token using form data."""
-    return await _authenticate_user(form_data.username, form_data.password, user_service, audit_log_service)
+    return await _authenticate_user(
+        form_data.username,
+        form_data.password,
+        user_service,
+        audit_log_service,
+        response,
+    )
 
 @router.post("/login", response_model=Token)
 async def login_for_access_token_json(
+    response: Response,
     login_data: LoginRequest,
     user_service: UserService = Depends(get_user_service),
     audit_log_service: AuditLogService = Depends(get_audit_log_service)
 ):
     """Authenticate user and return access token using JSON data."""
-    return await _authenticate_user(login_data.username, login_data.password, user_service, audit_log_service)
+    return await _authenticate_user(
+        login_data.username,
+        login_data.password,
+        user_service,
+        audit_log_service,
+        response,
+    )
 
-async def _authenticate_user(username: str, password: str, user_service: UserService, audit_log_service: AuditLogService):
+
+@router.post("/refresh", response_model=Token)
+async def refresh_access_token(request: Request, response: Response):
+    """Refresh access token using refresh token cookie."""
+    refresh_token = request.cookies.get("refresh_token")
+    if not refresh_token:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Refresh token missing")
+    username = verify_refresh_token(refresh_token)
+    access_token = create_access_token(data={"sub": username})
+    new_refresh_token = create_refresh_token(data={"sub": username})
+    response.set_cookie(
+        key="refresh_token",
+        value=new_refresh_token,
+        httponly=True,
+        samesite="lax",
+    )
+    return {"access_token": access_token, "token_type": "bearer"}
+
+
+@router.post("/logout")
+async def logout(response: Response):
+    """Clear refresh token cookie."""
+    response.delete_cookie("refresh_token")
+    return {"success": True}
+
+async def _authenticate_user(
+    username: str,
+    password: str,
+    user_service: UserService,
+    audit_log_service: AuditLogService,
+    response: Response,
+):
     """Common authentication logic with brute force protection."""
     try:
         user = await user_service.authenticate_user(username=username, password=password)
@@ -65,6 +114,13 @@ async def _authenticate_user(username: str, password: str, user_service: UserSer
             access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
             access_token = create_access_token(
                 data={"sub": user.username}, expires_delta=access_token_expires
+            )
+            refresh_token = create_refresh_token(data={"sub": user.username})
+            response.set_cookie(
+                key="refresh_token",
+                value=refresh_token,
+                httponly=True,
+                samesite="lax",
             )
             
             await audit_log_service.create_log(

--- a/frontend/src/components/user/LoginForm.tsx
+++ b/frontend/src/components/user/LoginForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState } from 'react';
 import {
   Box,
   VStack,
@@ -9,15 +9,15 @@ import {
   Heading,
   Text,
   useToast,
-} from "@chakra-ui/react";
-import { useRouter } from "next/navigation";
-import { login } from "@/services/api/users";
-import { LoginRequest, TokenResponse } from "@/types/user";
-import { useAuthStore } from "@/store/authStore";
+} from '@chakra-ui/react';
+import { useRouter } from 'next/navigation';
+import { login } from '@/services/api/users';
+import { LoginRequest, TokenResponse } from '@/types/user';
+import { useAuthStore } from '@/store/authStore';
 
 const LoginForm: React.FC = () => {
-  const [username, setUsername] = useState("");
-  const [password, setPassword] = useState("");
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const setToken = useAuthStore((state) => state.setToken);
@@ -34,16 +34,15 @@ const LoginForm: React.FC = () => {
     try {
       const response: TokenResponse = await login(loginData);
       setToken(response.access_token);
-      localStorage.setItem("token", response.access_token);
-      router.push("/");
+      router.push('/');
     } catch (err: any) {
-      console.error("Login failed:", err);
-      const message = err.message || "An error occurred during login.";
+      console.error('Login failed:', err);
+      const message = err.message || 'An error occurred during login.';
       setError(message);
       toast({
-        title: "Login failed",
+        title: 'Login failed',
         description: message,
-        status: "error",
+        status: 'error',
         duration: 5000,
         isClosable: true,
       });

--- a/frontend/src/services/api/request.ts
+++ b/frontend/src/services/api/request.ts
@@ -1,4 +1,5 @@
 import { StatusID } from '@/lib/statusUtils';
+import { buildApiUrl, API_CONFIG } from './config';
 
 /** Error type thrown when API requests fail */
 export class ApiError extends Error {
@@ -42,6 +43,27 @@ export const normalizeToStatusID = (
   return 'To Do';
 };
 
+// Request a new access token using the refresh token cookie
+async function refreshAccessToken(): Promise<string | null> {
+  try {
+    const res = await fetch(
+      buildApiUrl(API_CONFIG.ENDPOINTS.AUTH, '/refresh'),
+      { method: 'POST', credentials: 'include' }
+    );
+    if (!res.ok) {
+      return null;
+    }
+    const data = await res.json();
+    if (data && data.access_token) {
+      localStorage.setItem('token', data.access_token);
+      return data.access_token as string;
+    }
+  } catch (err) {
+    console.error('Token refresh failed', err);
+  }
+  return null;
+}
+
 // Helper function to handle API requests
 export async function request<T>(
   url: string,
@@ -69,12 +91,25 @@ export async function request<T>(
     response = await fetch(url, {
       ...options,
       headers,
+      credentials: 'include',
     });
   } catch (err) {
     throw new ApiError((err as Error).message || 'Network Error', 0, url);
   }
 
   if (!response.ok) {
+    if (response.status === 401) {
+      const newToken = await refreshAccessToken();
+      if (newToken) {
+        (headers as Record<string, string>).Authorization =
+          `Bearer ${newToken}`;
+        response = await fetch(url, {
+          ...options,
+          headers,
+          credentials: 'include',
+        });
+      }
+    }
     console.error(`API request failed for URL: ${url}`, {
       status: response.status,
       options,

--- a/frontend/src/services/api/users.ts
+++ b/frontend/src/services/api/users.ts
@@ -71,11 +71,20 @@ export const login = async (formData: LoginRequest): Promise<TokenResponse> => {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: new URLSearchParams(formData as Record<string, string>).toString(),
+      credentials: 'include',
     }
   );
 };
 
-export const logout = (): void => {
+export const logout = async (): Promise<void> => {
+  try {
+    await request(buildApiUrl(API_CONFIG.ENDPOINTS.AUTH, '/logout'), {
+      method: 'POST',
+      credentials: 'include',
+    });
+  } catch {
+    // Ignore errors during logout
+  }
   if (typeof window !== 'undefined') {
     localStorage.removeItem('token');
   }


### PR DESCRIPTION
## Summary
- implement refresh token creation and verification in auth module
- set/clear refresh token cookie in auth router with `/refresh` and `/logout`
- support refresh token expiry config
- handle token refresh on the frontend API client
- update login form and logout API to work with refresh token

## Testing
- `flake8 auth.py routers/users/auth/auth.py config/__init__.py config/app_config.py`
- `npm run fix` *(fails: @typescript-eslint/no-unused-vars)*
- `npm run format`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test` *(fails: various frontend tests)*

------
https://chatgpt.com/codex/tasks/task_e_6841bde6cf8c832ca5ca6d0d643ddf41