### PR TITLE
Add slowapi rate limiting

### DIFF
--- a/backend/middleware/__init__.py
+++ b/backend/middleware/__init__.py
@@ -5,74 +5,48 @@ Middleware initialization module.
 from .error_handlers import register_exception_handlers
 from .request_middleware import register_middleware
 
-# Import middleware classes from standalone file
-try:
-    from ..security import rate_limiter
-    from fastapi import Request, HTTPException, status
-    from fastapi.responses import JSONResponse
-    from starlette.middleware.base import BaseHTTPMiddleware
-    import time
+try:  # pragma: no cover - optional dependency
+    from slowapi import Limiter, _rate_limit_exceeded_handler
+    from slowapi.util import get_remote_address
+    from slowapi.errors import RateLimitExceeded
+    from slowapi.middleware import SlowAPIMiddleware
+    SLOWAPI_AVAILABLE = True
+except Exception:  # pragma: no cover - slowapi missing
+    SLOWAPI_AVAILABLE = False
 
-    class RateLimitMiddleware(BaseHTTPMiddleware):
-        """Rate limiting middleware."""
-        
-        def __init__(self, app, calls: int = 60, period: int = 60):
-            super().__init__(app)
-            self.calls = calls
-            self.period = period
-        
-        async def dispatch(self, request: Request, call_next):
-            # Get client IP
-            client_ip = request.client.host
-            
-            # Check rate limit for API endpoints only
-            if request.url.path.startswith("/api/"):
-                allowed = await rate_limiter.check_rate_limit(
-                    key=client_ip,
-                    max_requests=self.calls,
-                    window_seconds=self.period
-                )
-                
-                if not allowed:
-                    return JSONResponse(
-                        status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-                        content={"detail": "Rate limit exceeded. Please try again later."}
-                    )
-            
-            # Process request
-            start_time = time.time()
-            response = await call_next(request)
-            process_time = time.time() - start_time
-            response.headers["X-Process-Time"] = str(process_time)
-            
-            return response
+from starlette.middleware.base import BaseHTTPMiddleware
+from backend.config.app_config import settings
 
-    class SecurityHeadersMiddleware(BaseHTTPMiddleware):
-        """Add security headers to responses."""
-        
-        async def dispatch(self, request: Request, call_next):
-            response = await call_next(request)
-            
-            # Add security headers
-            response.headers["X-Content-Type-Options"] = "nosniff"
-            response.headers["X-Frame-Options"] = "DENY"
-            response.headers["X-XSS-Protection"] = "1; mode=block"
-            response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
-            
-            return response
 
-except ImportError:
-    # Fallback if dependencies are not available
-    RateLimitMiddleware = None
-    SecurityHeadersMiddleware = None
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Add security headers to responses."""
+
+    async def dispatch(self, request, call_next):
+        response = await call_next(request)
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-XSS-Protection"] = "1; mode=block"
+        response.headers["Strict-Transport-Security"] = (
+            "max-age=31536000; includeSubDomains"
+        )
+        return response
+
 
 def init_middleware(app):
     """Initialize all middleware."""
     register_exception_handlers(app)
     register_middleware(app)
-    
-    # Add custom middleware if available
-    if RateLimitMiddleware:
-        app.add_middleware(RateLimitMiddleware, calls=60, period=60)
+
+    if SLOWAPI_AVAILABLE:
+        limiter = Limiter(
+            key_func=get_remote_address,
+            default_limits=[f"{settings.RATE_LIMIT_PER_MINUTE}/minute"],
+        )
+        app.state.limiter = limiter
+        app.add_exception_handler(
+            RateLimitExceeded, _rate_limit_exceeded_handler
+        )
+        app.add_middleware(SlowAPIMiddleware)
+
     if SecurityHeadersMiddleware:
         app.add_middleware(SecurityHeadersMiddleware)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -22,6 +22,7 @@ aiosqlite = "*"
 aiohttp = "*"
 httpx = "*"
 authlib = "*"
+slowapi = "*"
 
 [tool.poetry.group.dev.dependencies]
 flake8 = "*"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,6 +12,7 @@ aiosqlite
 aiohttp
 httpx
 authlib
+slowapi
 
 # For CI/Dev
 flake8

--- a/backend/tests/test_rate_limiting.py
+++ b/backend/tests/test_rate_limiting.py
@@ -1,0 +1,30 @@
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient, ASGITransport
+
+from backend.middleware import init_middleware
+from backend.config.app_config import settings
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_exceeded():
+    original = settings.RATE_LIMIT_PER_MINUTE
+    settings.RATE_LIMIT_PER_MINUTE = 1
+    try:
+        app = FastAPI()
+        init_middleware(app)
+
+        @app.get("/limited")
+        async def limited():
+            return {"message": "ok"}
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            first = await client.get("/limited")
+            assert first.status_code == 200
+            second = await client.get("/limited")
+            assert second.status_code == 429
+    finally:
+        settings.RATE_LIMIT_PER_MINUTE = original


### PR DESCRIPTION
## Summary
- use slowapi middleware for request limiting
- expose limit configuration in settings
- test hitting rate limit

## Testing
- `flake8 backend/middleware/__init__.py backend/tests/test_rate_limiting.py`
- `pytest backend/tests/test_rate_limiting.py -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6841c979410c832caf4fe8fb86cdf51e