### PR TITLE
Apply Alembic migrations in dev workflow

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -45,14 +45,14 @@ To set up a fresh dev environment, follow these steps (examples use Unix-style s
    (This installs Next.js, React, Chakra UI, Zustand, and all frontend packages.)
 
 3. **Database setup:**
-   By default, the system uses SQLite (`backend/sql_app.db`).  If the DB file does not exist, run:
+   Apply migrations with Alembic (this will create the SQLite `sql_app.db` if needed):
 
    ```bash
    cd backend
-   python init_db.py
+   python -m alembic upgrade head
    ```
 
-   to create tables (or use Alembic: `alembic upgrade head`).  If switching to PostgreSQL, define a `.env` and rerun migrations via Alembic as shown in the project docs.
+   If switching to PostgreSQL, define a `.env` and rerun `alembic upgrade head` to initialize the new database.
 
 4. **Starting servers:**  You can launch both servers with one command:
 

--- a/SYSTEM_GUIDE.md
+++ b/SYSTEM_GUIDE.md
@@ -67,14 +67,14 @@ cd backend
 
 ### 🗄️ Database Management
 ```bash
-# Initialize database (uses `DATABASE_URL` from backend/.env)
+# Apply migrations (uses `DATABASE_URL` from backend/.env)
 cd backend
-python init_db.py
+python -m alembic upgrade head
 
-# Generate migration
+# Generate new migration
 alembic revision --autogenerate -m "description"
 
-# Run migrations
+# Upgrade to latest
 alembic upgrade head
 ```
 
@@ -156,7 +156,7 @@ python -m venv .venv
 .venv\Scripts\pip install -r requirements.txt
 
 # If database issues:
-python init_db.py  # reads DATABASE_URL from backend/.env
+python -m alembic upgrade head  # reads DATABASE_URL from backend/.env
 ```
 
 ### Frontend Issues

--- a/backend/README.md
+++ b/backend/README.md
@@ -12,7 +12,7 @@ backend\.venv\Scripts\python.exe -m uvicorn backend.main:app --host 0.0.0.0 --po
 ```
 
 The server will start and you should see:
-- ✅ Database tables being checked/initialized
+- ✅ Database migrations applied
 - ✅ "Application startup complete."
 - ✅ Server running on `http://0.0.0.0:8000`
 
@@ -105,7 +105,7 @@ ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 DEBUG=True
 ```
-`DATABASE_URL` is read by `database.py` and `init_db.py`. Set it to a
+`DATABASE_URL` is read by `database.py`. Set it to a
 SQLAlchemy-compatible URL (e.g., a custom SQLite file path or PostgreSQL URI)
 to override the default `sql_app.db`.
 

--- a/backend/app_factory.py
+++ b/backend/app_factory.py
@@ -201,11 +201,9 @@ async def lifespan(app: FastAPI):
     """Application lifespan manager."""
     logger.info("Starting Task Manager Backend...")
     try:
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
-        logger.info("Database tables initialized")
+        logger.info("Task Manager Backend initialization complete")
     except Exception as e:  # pragma: no cover - unexpected DB failure
-        logger.error(f"Failed to initialize database: {e}")
+        logger.error(f"Initialization failed: {e}")
         raise
 
     server_addr = os.getenv("MCP_SERVER_ADDRESS", "http://localhost:8000")

--- a/backend/main.py
+++ b/backend/main.py
@@ -83,11 +83,9 @@ async def lifespan(app: FastAPI):
     logger.info("Starting backend initialization...")
 
     try:
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
-        logger.info("Database initialized.")
+        logger.info("Backend initialization complete.")
     except Exception as e:
-        logger.error(f"Database initialization failed: {e}")
+        logger.error(f"Initialization failed: {e}")
         raise
 
     yield

--- a/dev_launcher.bat
+++ b/dev_launcher.bat
@@ -14,6 +14,11 @@ echo Checking and clearing ports...
 powershell -NoProfile -Command "$ports = @(8000, 3000); foreach ($port in $ports) { try { $process = Get-NetTCPConnection -LocalPort $port -ErrorAction SilentlyContinue; if ($process) { Stop-Process -Id $process.OwningProcess -Force -ErrorAction SilentlyContinue; Write-Host ('✓ Killed process on port ' + $port) } else { Write-Host ('✓ Port ' + $port + ' is free') } } catch { Write-Host ('⚠ Error checking port ' + $port + ': ' + $_.Exception.Message) } }; exit 0"
 echo.
 
+REM --- Apply database migrations ---
+echo Applying database migrations...
+cd /d D:\mcp\task-manager && backend\.venv\Scripts\python.exe -m alembic upgrade head
+cd /d D:\mcp\task-manager
+
 REM --- Start Backend Server ---
 echo Starting Backend Server (Python/FastAPI)...
 echo Backend will be available at: http://localhost:8000

--- a/dev_launcher.js
+++ b/dev_launcher.js
@@ -61,7 +61,21 @@ async function main() {
     
     const projectRoot = path.resolve(__dirname);
     const isWindows = os.platform() === 'win32';
-    
+
+    // Apply database migrations
+    console.log('Applying database migrations...');
+    const migratePath = isWindows
+        ? path.join(projectRoot, 'backend', '.venv', 'Scripts', 'python.exe')
+        : path.join(projectRoot, 'backend', '.venv', 'bin', 'python');
+    await new Promise(resolve => {
+        const migrate = spawn(migratePath, ['-m', 'alembic', 'upgrade', 'head'], {
+            cwd: path.join(projectRoot, 'backend'),
+            stdio: 'inherit',
+            shell: false
+        });
+        migrate.on('close', resolve);
+    });
+
     // Start Backend
     console.log('Starting Backend Server (Python/FastAPI)...');
     console.log('Backend will be available at: http://localhost:8000');

--- a/dev_launcher.ps1
+++ b/dev_launcher.ps1
@@ -33,6 +33,10 @@ Write-Host ""
 $projectRoot = "D:\mcp\task-manager"
 Set-Location $projectRoot
 
+# Apply database migrations
+Write-Host "Applying database migrations..." -ForegroundColor Yellow
+& backend\.venv\Scripts\python.exe -m alembic upgrade head
+
 # Start Backend Server
 Write-Host "Starting Backend Server (Python/FastAPI)..." -ForegroundColor Yellow
 Write-Host "Backend will be available at: http://localhost:8000" -ForegroundColor Cyan

--- a/final_integration.py
+++ b/final_integration.py
@@ -168,9 +168,10 @@ class TheBuilderSystemIntegrator:
         return all(dep in content.lower() for dep in required_deps)
     
     def _check_database(self):
-        """Check database files."""
-        init_script = self.backend_dir / "init_db.py"
-        return init_script.exists()
+        """Check Alembic migration configuration."""
+        alembic_ini = self.backend_dir / "alembic.ini"
+        versions_dir = self.backend_dir / "alembic" / "versions"
+        return alembic_ini.exists() and versions_dir.exists()
     
     def _check_models(self):
         """Check backend models."""

--- a/start_system.py
+++ b/start_system.py
@@ -129,27 +129,14 @@ class SystemIntegrator:
         """Initialize the database."""
         print("\n[Database] Initializing Database")
         print("-" * 40)
-        
         python_cmd = ".venv\\Scripts\\python.exe" if os.name == 'nt' else ".venv/bin/python"
-        
-        # Check if database exists
-        db_path = self.backend_dir / "sql_app.db"
-        if db_path.exists():
-            print("[Success] Database already exists")
-            return True
-        
-        # Run database initialization
-        init_script = self.backend_dir / "init_db.py"
-        if init_script.exists():
-            return self.run_command(
-                f"{python_cmd} init_db.py",
-                "Initializing database",
-                cwd=self.backend_dir,
-                timeout=60
-            )
-        else:
-            print("[Warning] Database initialization script not found")
-            return True
+
+        return self.run_command(
+            f"{python_cmd} -m alembic upgrade head",
+            "Applying database migrations",
+            cwd=self.backend_dir,
+            timeout=60
+        )
     
     def start_backend_server(self):
         """Start the backend server in a separate process."""


### PR DESCRIPTION
## Summary
- remove `Base.metadata.create_all()` calls from app lifespan
- apply migrations from `alembic upgrade head` in dev scripts and setup
- update docs to use Alembic for DB initialization

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c9773c28832cbb96b6d1904ab792