### PR TITLE
Add settings validation

### DIFF
--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -2,7 +2,7 @@
 Configuration package initialization.
 """
 
-from .app_config import Settings
+from .app_config import Settings, validate_settings
 
 settings = Settings()
 
@@ -17,6 +17,7 @@ OAUTH_SCOPE = settings.OAUTH_SCOPE
 
 __all__ = [
     'configure_logging',
+    'validate_settings',
     'SECRET_KEY',
     'ALGORITHM',
     'ACCESS_TOKEN_EXPIRE_MINUTES',

--- a/backend/config/app_config.py
+++ b/backend/config/app_config.py
@@ -60,6 +60,19 @@ def __init__(self, **kwargs):
 
 settings = Settings()
 
+
+def validate_settings(cfg: Settings = settings) -> None:
+    """Ensure required settings values are present."""
+    missing = []
+    if not getattr(cfg, "SECRET_KEY", ""):  # pragma: no cover - simple check
+        missing.append("SECRET_KEY")
+    if not getattr(cfg, "ALGORITHM", ""):
+        missing.append("ALGORITHM")
+    if missing:
+        raise ValueError(
+            "Missing required configuration values: " + ", ".join(missing)
+        )
+
 def configure_logging():
     """
     Configure application logging.

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,6 +10,7 @@ from typing import Dict, Any
 from .database import get_db, Base, engine
 from .middleware import init_middleware
 from .app_factory import create_app as factory_create_app
+from .config import validate_settings
 
 # Optional MCP integration
 try:
@@ -234,4 +235,5 @@ def _define_custom_routes(app: FastAPI):
         }
 
 
+validate_settings()
 app = factory_create_app()

--- a/backend/tests/test_app_config_validation.py
+++ b/backend/tests/test_app_config_validation.py
@@ -1,0 +1,17 @@
+import pytest
+
+from backend.config.app_config import Settings, validate_settings
+
+
+def test_validate_settings_missing_secret_key():
+    cfg = Settings(SECRET_KEY="", ALGORITHM="HS256", ACCESS_TOKEN_EXPIRE_MINUTES=30)
+    with pytest.raises(ValueError) as exc:
+        validate_settings(cfg)
+    assert "SECRET_KEY" in str(exc.value)
+
+
+def test_validate_settings_missing_algorithm():
+    cfg = Settings(SECRET_KEY="key", ALGORITHM="", ACCESS_TOKEN_EXPIRE_MINUTES=30)
+    with pytest.raises(ValueError) as exc:
+        validate_settings(cfg)
+    assert "ALGORITHM" in str(exc.value)


### PR DESCRIPTION
## Summary
- validate required config values
- call validation when building FastAPI app
- test config validation errors

## Testing
- `flake8 config/app_config.py __init__.py main.py tests/test_app_config_validation.py | head`
- `pytest backend/tests/test_app_config_validation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6841c97b29d0832c8de435460a03ecd1