### PR TITLE
Fix type exports

### DIFF
--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,6 +1,5 @@
 export * from './project';
 export * from './agent';
-export * from './agents';
 export * from './task';
 export * from './user';
 export * from './audit_log';
@@ -12,7 +11,6 @@ export * from './project_template';
 export * from './agent_prompt_template';
 export * from './handoff';
 export * from './verification_requirement';
-export * from './error_protocol';
 
 // Common types used across the application
 // Canonical shared sort direction type for all entities


### PR DESCRIPTION
## Summary
- remove incorrect error_protocol export
- remove agents barrel export to avoid type conflicts

## Testing
- `npm run lint`
- `npm run type-check` *(fails: error TS2345, TS2353, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6841ca8875cc832c8e95dbbf74755fe6