### PR TITLE
Fix forbidden actions router

### DIFF
--- a/backend/routers/rules/roles/forbidden_actions.py
+++ b/backend/routers/rules/roles/forbidden_actions.py
@@ -1,9 +1,9 @@
-from typing import List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy.orm import Session
 
-from ....database import get_sync_db as get_db
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ....database import get_db
 from ....schemas.agent_forbidden_action import (
     AgentForbiddenAction,
     AgentForbiddenActionCreate,
@@ -14,7 +14,7 @@ from ....services.agent_forbidden_action_service import AgentForbiddenActionServ
 router = APIRouter()
 
 
-def get_service(db: Session = Depends(get_db)) -> AgentForbiddenActionService:
+def get_service(db: AsyncSession = Depends(get_db)) -> AgentForbiddenActionService:
     return AgentForbiddenActionService(db)
 
 

--- a/backend/services/agent_forbidden_action_service.py
+++ b/backend/services/agent_forbidden_action_service.py
@@ -1,5 +1,5 @@
 from typing import List, Optional
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import models
 from ..crud import rules as crud_rules
@@ -8,7 +8,7 @@ from ..crud import rules as crud_rules
 class AgentForbiddenActionService:
     """Service layer for agent forbidden actions."""
 
-    def __init__(self, db: Session) -> None:
+    def __init__(self, db: AsyncSession) -> None:
         self.db = db
 
     async def create_forbidden_action(


### PR DESCRIPTION
## Summary
- align forbidden actions router with service helper
- use async session in the service

## Testing
- `flake8 backend/routers/rules/roles/forbidden_actions.py`
- `flake8 backend/services/agent_forbidden_action_service.py`
- `pytest backend/tests/test_rules_service.py -q` *(fails: ImportError: cannot import name 'field_validator' from 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6841ca879088832c960c1a1545f37127