### PR TITLE
Standardize delete responses

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -62,7 +62,7 @@ async def update_user(
         )
 
 
-@router.delete("/users/{user_id}")
+@router.delete("/users/{user_id}", response_model=DataResponse[bool])
 async def delete_user(
     user_id: str,
     user_service: UserService = Depends(get_user_service),
@@ -77,7 +77,7 @@ async def delete_user(
 
     try:
         await user_service.delete_user(user_id)
-        return {"message": "User deleted successfully"}
+        return DataResponse[bool](data=True, message="User deleted successfully")
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/routers/comments/comments.py
+++ b/backend/routers/comments/comments.py
@@ -99,7 +99,7 @@ async def update_comment_endpoint(
         message="Comment updated successfully"
     )
 
-@router.delete("/{comment_id}", response_model=DataResponse[dict], summary="Delete Comment", operation_id="delete_comment")
+@router.delete("/{comment_id}", response_model=DataResponse[bool], summary="Delete Comment", operation_id="delete_comment")
 
 
 async def delete_comment_endpoint(
@@ -110,7 +110,7 @@ async def delete_comment_endpoint(
     success = await delete_comment(db, comment_id=comment_id)
     if not success:
         raise HTTPException(status_code=404, detail="Comment not found")
-    return DataResponse[dict](
-        data={"message": "Comment deleted successfully"},
-        message="Comment deleted successfully"
-    )
+    return DataResponse[bool](
+            data=True,
+            message="Comment deleted successfully"
+        )

--- a/backend/routers/mcp/core.py
+++ b/backend/routers/mcp/core.py
@@ -320,10 +320,11 @@ async def mcp_update_task(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.post(
+@router.delete(
     "/mcp-tools/task/delete",
     tags=["mcp-tools"],
     operation_id="delete_task_tool",
+    response_model=DataResponse[bool],
 )
 @track_tool_usage("delete_task_tool")
 async def mcp_delete_task(
@@ -345,7 +346,7 @@ async def mcp_delete_task(
             entity_id=f"{project_id}-{task_number}"
         )
 
-        return {"success": True, "message": "Task deleted successfully"}
+        return DataResponse[bool](data=True, message="Task deleted successfully")
     except HTTPException:
         raise
     except Exception as e:
@@ -413,10 +414,11 @@ async def mcp_list_project_files(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.post(
+@router.delete(
     "/mcp-tools/project/remove-file",
     tags=["mcp-tools"],
     operation_id="remove_project_file_tool",
+    response_model=DataResponse[bool],
 )
 @track_tool_usage("remove_project_file_tool")
 async def mcp_remove_project_file(
@@ -431,7 +433,7 @@ async def mcp_remove_project_file(
             raise HTTPException(
                 status_code=404, detail="File association not found"
             )
-        return {"success": True, "message": "File removed from project successfully"}
+        return DataResponse[bool](data=True, message="File removed from project successfully")
     except ValueError as ve:
         raise HTTPException(status_code=400, detail=str(ve))
     except Exception as e:
@@ -916,6 +918,7 @@ async def mcp_list_handoff_criteria(
     "/mcp-tools/handoff/delete",
     tags=["mcp-tools"],
     operation_id="delete_handoff_criteria_tool",
+    response_model=DataResponse[bool],
 )
 @track_tool_usage("delete_handoff_criteria_tool")
 async def mcp_delete_handoff_criteria(
@@ -927,7 +930,7 @@ async def mcp_delete_handoff_criteria(
         success = service.delete_criteria(criteria_id)
         if not success:
             raise HTTPException(status_code=404, detail="Handoff criteria not found")
-        return {"success": True, "message": "Handoff criteria deleted successfully"}
+        return DataResponse[bool](data=True, message="Handoff criteria deleted successfully")
     except Exception as e:
         logger.error(f"MCP delete handoff criteria tool failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -1001,6 +1004,7 @@ async def mcp_list_error_protocols(
     "/mcp-tools/error-protocol/remove",
     tags=["mcp-tools"],
     operation_id="remove_error_protocol_tool",
+    response_model=DataResponse[bool],
 )
 @track_tool_usage("remove_error_protocol_tool")
 async def mcp_remove_error_protocol(
@@ -1012,7 +1016,7 @@ async def mcp_remove_error_protocol(
         success = service.remove_protocol(protocol_id)
         if not success:
             raise HTTPException(status_code=404, detail="Error protocol not found")
-        return {"success": True}
+        return DataResponse[bool](data=True, message="Error protocol removed")
     except HTTPException:
         raise
     except Exception as e:
@@ -1110,6 +1114,7 @@ async def mcp_list_capabilities(
     "/mcp-tools/capability/delete",
     tags=["mcp-tools"],
     operation_id="delete_capability_tool",
+    response_model=DataResponse[bool],
 )
 async def mcp_delete_capability(
     capability_id: str,
@@ -1117,7 +1122,8 @@ async def mcp_delete_capability(
 ):
     """MCP Tool: Delete a capability."""
     try:
-        return await delete_capability_tool(capability_id, db)
+        await delete_capability_tool(capability_id, db)
+        return DataResponse[bool](data=True, message="Capability deleted")
     except HTTPException:
         raise
     except Exception as e:
@@ -1170,6 +1176,7 @@ async def mcp_list_roles(
     "/mcp-tools/user-role/remove",
     tags=["mcp-tools"],
     operation_id="remove_role_tool",
+    response_model=DataResponse[bool],
 )
 @track_tool_usage("remove_role_tool")
 async def mcp_remove_role(
@@ -1181,7 +1188,8 @@ async def mcp_remove_role(
     try:
         from ...mcp_tools.user_role_tools import remove_role_tool
 
-        return await remove_role_tool(user_id, role_name, db)
+        await remove_role_tool(user_id, role_name, db)
+        return DataResponse[bool](data=True, message="Role removed")
     except HTTPException:
         raise
     except Exception as e:

--- a/backend/routers/memory/core/core.py
+++ b/backend/routers/memory/core/core.py
@@ -119,7 +119,7 @@ def update_memory_entity_endpoint(
         raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
 
 
-@router.delete("/{entity_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/{entity_id}", response_model=DataResponse[bool])
 def delete_memory_entity_endpoint(
     entity_id: int = Path(...),
     memory_service: MemoryService = Depends(get_memory_service),
@@ -128,7 +128,7 @@ def delete_memory_entity_endpoint(
         success = memory_service.delete_entity(entity_id)
         if not success:
             raise EntityNotFoundError("MemoryEntity", entity_id)
-        return {"message": "Memory entity deleted successfully"}
+        return DataResponse[bool](data=True, message="Memory entity deleted successfully")
     except EntityNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:

--- a/backend/routers/memory/observations/observations.py
+++ b/backend/routers/memory/observations/observations.py
@@ -72,7 +72,7 @@ def update_observation(
         raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
 
 
-@router.delete("/observations/{observation_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/observations/{observation_id}", response_model=DataResponse[bool])
 
 
 def delete_observation(
@@ -84,7 +84,7 @@ def delete_observation(
         success = memory_service.delete_observation(observation_id)
         if not success:
             raise EntityNotFoundError("MemoryObservation", observation_id)
-        return {"message": "Memory observation deleted successfully"}
+        return DataResponse[bool](data=True, message="Memory observation deleted successfully")
     except EntityNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:

--- a/backend/routers/memory/relations/relations.py
+++ b/backend/routers/memory/relations/relations.py
@@ -119,7 +119,7 @@ def update_relation(
             detail=f"Internal server error: {e}",
         )
 
-@router.delete("/relations/{relation_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/relations/{relation_id}", response_model=DataResponse[bool])
 
 
 def delete_relation(
@@ -131,7 +131,7 @@ def delete_relation(
         success = memory_service.delete_memory_relation(relation_id)
         if not success:
             raise EntityNotFoundError("MemoryRelation", relation_id)
-        return {"message": "Memory relation deleted successfully"}
+        return DataResponse[bool](data=True, message="Memory relation deleted successfully")
     except EntityNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:

--- a/backend/routers/projects/core.py
+++ b/backend/routers/projects/core.py
@@ -252,9 +252,9 @@ async def update_project(
         )
 
 
-@router.delete(
+@router
     "/{project_id}",
-    response_model=DataResponse[Project],
+    response_model=DataResponse[bool],
     summary="Delete Project",
     operation_id="delete_project_by_id",
 )
@@ -268,8 +268,8 @@ async def delete_project(
         if db_project is None:
             # Use EntityNotFoundError from services
             raise EntityNotFoundError("Project", project_id)
-        return DataResponse[Project](
-            data=Project.model_validate(db_project),  # Return the deleted project data
+        return DataResponse[bool](
+            data=True,
             message="Project deleted successfully"
         )
     except EntityNotFoundError as e:

--- a/backend/routers/rules/roles/capabilities.py
+++ b/backend/routers/rules/roles/capabilities.py
@@ -47,7 +47,7 @@ async def update_capability(
     return updated
 
 
-@router.delete("/capabilities/{capability_id}")
+@router.delete("/capabilities/{capability_id}", response_model=DataResponse[bool])
 async def delete_capability(
     capability_id: str,
     service: AgentCapabilityService = Depends(get_service),
@@ -55,4 +55,4 @@ async def delete_capability(
     success = await service.delete_capability(capability_id)
     if not success:
         raise HTTPException(status_code=404, detail="Capability not found")
-    return {"message": "Capability deleted successfully"}
+    return DataResponse[bool](data=True, message="Capability deleted successfully")

--- a/backend/routers/rules/roles/forbidden_actions.py
+++ b/backend/routers/rules/roles/forbidden_actions.py
@@ -63,7 +63,7 @@ async def create_forbidden_action_endpoint(
 
 @router.delete(
     "/forbidden-actions/{action_id}",
-    response_model=DataResponse[dict],
+    response_model=DataResponse[bool],
     summary="Delete Forbidden Action",
     operation_id="delete_forbidden_action",
 )
@@ -74,7 +74,7 @@ async def delete_forbidden_action_endpoint(
     success = await service.delete_forbidden_action(action_id)
     if not success:
         raise HTTPException(status_code=404, detail="Forbidden action not found")
-    return DataResponse[dict](
-        data={"message": "Forbidden action removed"},
+    return DataResponse[bool](
+        data=True,
         message="Forbidden action removed",
     )

--- a/backend/routers/rules/roles/handoff_criteria.py
+++ b/backend/routers/rules/roles/handoff_criteria.py
@@ -60,7 +60,7 @@ def update_handoff_criteria(
     return db_obj
 
 
-@router.delete("/{criteria_id}")
+@router.delete("/{criteria_id}", response_model=DataResponse[bool])
 def delete_handoff_criteria(
     criteria_id: str,
     db: Session = Depends(get_db),
@@ -70,4 +70,4 @@ def delete_handoff_criteria(
     success = service.delete_criteria(criteria_id)
     if not success:
         raise HTTPException(status_code=404, detail="Criteria not found")
-    return {"message": "Criteria deleted successfully"}
+    return DataResponse[bool](data=True, message="Criteria deleted successfully")

--- a/backend/routers/rules/templates/templates.py
+++ b/backend/routers/rules/templates/templates.py
@@ -50,7 +50,7 @@ def update_prompt_template(
     return result
 
 
-@router.delete("/{template_id}")
+@router.delete("/{template_id}", response_model=DataResponse[bool])
 
 
 def delete_prompt_template(
@@ -61,4 +61,4 @@ def delete_prompt_template(
     success = crud_rules.delete_agent_prompt_template(db, template_id)
     if not success:
         raise HTTPException(status_code=404, detail="Prompt template not found")
-    return {"message": "Prompt template deleted successfully"}
+    return DataResponse[bool](data=True, message="Prompt template deleted successfully")

--- a/backend/routers/rules/violations/error_protocols.py
+++ b/backend/routers/rules/violations/error_protocols.py
@@ -52,9 +52,9 @@ async def update_error_protocol(
     return updated
 
 
-@router.delete("/error-protocols/{protocol_id}")
+@router.delete("/error-protocols/{protocol_id}", response_model=DataResponse[bool])
 async def delete_error_protocol(protocol_id: str, service: AgentErrorProtocolService = Depends(get_service)):
     success = await service.delete_protocol(protocol_id)
     if not success:
         raise HTTPException(status_code=404, detail="Error protocol not found")
-    return {"message": "Error protocol deleted successfully"}
+    return DataResponse[bool](data=True, message="Error protocol deleted successfully")

--- a/backend/routers/tasks/core/core.py
+++ b/backend/routers/tasks/core/core.py
@@ -38,7 +38,7 @@ def get_audit_log_service(db: Session = Depends(get_db)) -> AuditLogService:
 
 @router.post(
     "/{project_id}/tasks/",
-    response_model=DataResponse[Task],
+    response_model=DataResponse[bool],
     summary="Create Task in Project",
     tags=["Tasks"],
     operation_id="projects_tasks_create_task"
@@ -199,9 +199,9 @@ async def read_task(
             task_number=task_number
         )
 
-        return DataResponse[Task](
-            data=Task.model_validate(db_task),
-            message=f"Task  #{task_number} retrieved successfully"
+        return DataResponse[bool](
+            data=True,
+            message=f"Task  #{task_number} deleted successfully"
         )
     except EntityNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
@@ -382,8 +382,8 @@ async def delete_task(
             }
         )
 
-        return DataResponse[Task](
-            data=Task.model_validate(db_task),
+        return DataResponse[bool](
+            data=True,
             message=f"Task  #{task_number} deleted successfully"
         )
     except EntityNotFoundError as e:

--- a/backend/routers/tasks/dependencies/dependencies.py
+++ b/backend/routers/tasks/dependencies/dependencies.py
@@ -195,7 +195,7 @@ async def get_task_successors_endpoint(
 
 @router.delete(
     "/{project_id}/tasks/{task_number}/dependencies/{predecessor_project_id}/{predecessor_task_number}",
-    response_model=DataResponse[dict],
+    response_model=DataResponse[bool],
     summary="Remove Task Dependency",
     tags=["Task Dependencies"],
     operation_id="projects_tasks_remove_task_dependency"
@@ -221,8 +221,8 @@ async def remove_task_dependency_endpoint(
         )
         if not success:
             raise HTTPException(status_code=404, detail="Task dependency not found")
-        return DataResponse[dict](
-            data={"success": success},
+        return DataResponse[bool](
+            data=True,
             message="Task dependency removed successfully"
         )
     except EntityNotFoundError as e:

--- a/backend/routers/tasks/files/files.py
+++ b/backend/routers/tasks/files/files.py
@@ -129,7 +129,7 @@ async def get_task_file_association_by_file_memory_entity_id_endpoint(
 
 @router.delete(
     "/{project_id}/tasks/{task_number}/files/{file_memory_entity_id}",
-    response_model=DataResponse[dict],
+    response_model=DataResponse[bool],
     summary="Disassociate File from Task by File Memory Entity ID",
     tags=["Task Files"],
     operation_id="projects_tasks_disassociate_file_from_task_by_file_memory_entity_id"
@@ -152,10 +152,10 @@ async def disassociate_file_from_task_by_file_memory_entity_id_endpoint(
     )
     if not success:
     raise HTTPException(status_code=404, detail="Task file association not found")
-    return DataResponse[dict](
-    data={"success": success},
-    message="File disassociated from task successfully"
-    )
+    return DataResponse[bool](
+            data=True,
+            message="File disassociated from task successfully"
+        )
     except EntityNotFoundError as e:
     raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:

--- a/backend/routers/tasks/minimal.py
+++ b/backend/routers/tasks/minimal.py
@@ -56,7 +56,7 @@ async def update_task(
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Server error: {str(e)}")
 
-@router.delete("/{task_id}", response_model=DataResponse[Task])
+@router.delete("/{task_id}", response_model=DataResponse[bool])
 async def delete_task(
     task_id: str,
     db: AsyncSession = Depends(get_db)
@@ -77,7 +77,7 @@ async def delete_task(
         # Delete the task 
         await task_service.delete_task(project_id=project_id, task_number=task_number)
         
-        return DataResponse[Task](data=task_to_delete, message="Task deleted successfully")
+        return DataResponse[bool](data=True, message="Task deleted successfully")
     except HTTPException:
         raise
     except Exception as e:

--- a/backend/routers/users/core/core.py
+++ b/backend/routers/users/core/core.py
@@ -130,7 +130,7 @@ async def update_user(
         raise HTTPException(status_code=500, detail="User update failed")
     return updated_user
 
-@router.delete("/{user_id}", response_model=DataResponse[User],
+@router.delete("/{user_id}", response_model=DataResponse[bool],
     dependencies=[Depends(RoleChecker([UserRoleEnum.ADMIN]))])  # Protect endpoint
 async def delete_user(
     user_id: str,
@@ -145,8 +145,8 @@ async def delete_user(
         deleted_user = user_service.delete_user(user_id=user_id)
         if deleted_user is None:
             raise HTTPException(status_code=500, detail="User deletion failed")  # Return standardized response
-        return DataResponse[User](
-            data=User.model_validate(deleted_user),
+        return DataResponse[bool](
+            data=True,
             message=f"User '{deleted_user.username}' deleted successfully"
         )
     except EntityNotFoundError as e:

--- a/backend/routers/workflows/core.py
+++ b/backend/routers/workflows/core.py
@@ -82,7 +82,7 @@ def update_workflow(
     )
 
 
-@router.delete("/{workflow_id}", response_model=DataResponse[dict])
+@router.delete("/{workflow_id}", response_model=DataResponse[bool])
 def delete_workflow(
     workflow_id: str,
     workflow_service: WorkflowService = Depends(get_workflow_service),
@@ -90,7 +90,7 @@ def delete_workflow(
     success = workflow_service.delete_workflow(workflow_id)
     if not success:
         raise HTTPException(status_code=404, detail="Workflow not found")
-    return DataResponse[dict](
-        data={"message": "Workflow deleted"},
+    return DataResponse[bool](
+        data=True,
         message="Workflow deleted",
     )

--- a/backend/tests/test_memory_observations.py
+++ b/backend/tests/test_memory_observations.py
@@ -78,7 +78,8 @@ async def test_update_and_delete_observation():
         assert resp.json()["content"] == "updated"
 
         resp = await client.delete(f"/observations/{obs_id}")
-        assert resp.status_code == 204
+        assert resp.status_code == 200
+        assert resp.json()["data"] is True
 
         resp = await client.delete(f"/observations/{obs_id}")
         assert resp.status_code == 404

--- a/backend/tests/test_project_task_endpoints.py
+++ b/backend/tests/test_project_task_endpoints.py
@@ -59,6 +59,7 @@ async def test_task_crud_flow(authenticated_client, test_project):
 
     delete_resp = await authenticated_client.delete(f"/api/v1/tasks/{task_id}")
     assert delete_resp.status_code == 200
+    assert delete_resp.json()["data"] is True
 
     final_list = await authenticated_client.get(
         f"/api/v1/tasks/?project_id={test_project.id}"

--- a/backend/tests/test_user_roles.py
+++ b/backend/tests/test_user_roles.py
@@ -55,6 +55,7 @@ async def test_role_lifecycle():
 
         resp = await client.delete("/123/roles/admin")
         assert resp.status_code == 200
+        assert resp.json()["data"] is True
 
         resp = await client.get("/123/roles/")
         assert resp.json()["data"] == []

--- a/backend/tests/test_workflow_endpoints.py
+++ b/backend/tests/test_workflow_endpoints.py
@@ -100,4 +100,4 @@ async def test_update_and_delete_workflow():
 
         resp = await client.delete(f"/workflows/{wf.id}")
         assert resp.status_code == 200
-        assert resp.json()["data"]["message"] == "Workflow deleted"
+        assert resp.json()["data"] is True

--- a/frontend/src/services/api/agents.ts
+++ b/frontend/src/services/api/agents.ts
@@ -105,12 +105,11 @@ export const updateAgentById = async (
   };
 };
 
-export const deleteAgentById = async (agent_id: string): Promise<null> => {
-  await request<null>(
+export const deleteAgentById = async (agent_id: string): Promise<boolean> => {
+  return request<boolean>(
     buildApiUrl(API_CONFIG.ENDPOINTS.AGENTS, `/${agent_id}`),
     { method: "DELETE" },
   );
-  return null;
 };
 
 export const archiveAgent = async (agentId: string): Promise<AgentArchiveResponse> => {

--- a/frontend/src/services/api/comments.ts
+++ b/frontend/src/services/api/comments.ts
@@ -63,8 +63,8 @@ export const commentsApi = {
   },
 
   // Delete a comment
-  delete: async (commentId: string): Promise<void> => {
-    await request(
+  delete: async (commentId: string): Promise<boolean> => {
+    return request<boolean>(
       buildApiUrl(API_CONFIG.ENDPOINTS.COMMENTS, `/${commentId}`),
       {
         method: "DELETE",

--- a/frontend/src/services/api/forbidden_actions.ts
+++ b/frontend/src/services/api/forbidden_actions.ts
@@ -62,8 +62,8 @@ export const forbiddenActionsApi = {
   },
 
   /** Delete a forbidden action */
-  async delete(actionId: string): Promise<{ message: string }> {
-    return request<{ message: string }>(
+  async delete(actionId: string): Promise<boolean> {
+    return request<boolean>(
       buildApiUrl(
         API_CONFIG.ENDPOINTS.RULES,
         `/roles/forbidden-actions/${actionId}`

--- a/frontend/src/services/api/memory.ts
+++ b/frontend/src/services/api/memory.ts
@@ -85,8 +85,8 @@ export const memoryApi = {
   },
 
   // Delete a memory entity
-  deleteEntity: async (entityId: number): Promise<void> => {
-    await request(buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/${entityId}`), {
+  deleteEntity: async (entityId: number): Promise<boolean> => {
+    return request<boolean>(buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/${entityId}`), {
       method: 'DELETE',
     });
   },
@@ -172,8 +172,8 @@ export const memoryApi = {
   },
 
   // Delete an observation
-  deleteObservation: async (observationId: number): Promise<void> => {
-    await request(
+  deleteObservation: async (observationId: number): Promise<boolean> => {
+    return request<boolean>(
       buildApiUrl(
         API_CONFIG.ENDPOINTS.MEMORY,
         `/observations/${observationId}`
@@ -237,8 +237,8 @@ export const memoryApi = {
   updateRelation,
 
   // Delete a relation
-  deleteRelation: async (relationId: number): Promise<void> => {
-    await request(
+  deleteRelation: async (relationId: number): Promise<boolean> => {
+    return request<boolean>(
       buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, `/relations/${relationId}`),
       {
         method: 'DELETE',

--- a/frontend/src/services/api/project_templates.ts
+++ b/frontend/src/services/api/project_templates.ts
@@ -12,8 +12,8 @@ import {
  */
 export async function deleteTemplate(
   templateId: string,
-): Promise<{ message: string }> {
-  return request<{ message: string }>(
+): Promise<boolean> {
+  return request<boolean>(
     buildApiUrl("/project-templates/", `/${templateId}`),
     { method: "DELETE" },
   );

--- a/frontend/src/services/api/projects.ts
+++ b/frontend/src/services/api/projects.ts
@@ -120,21 +120,11 @@ export const updateProject = async (
 };
 
 // Delete a project
-export const deleteProject = async (project_id: string): Promise<Project> => {
-  const rawProject = await request<RawProject>(
+export const deleteProject = async (project_id: string): Promise<boolean> => {
+  return request<boolean>(
     buildApiUrl(API_CONFIG.ENDPOINTS.PROJECTS, `/${project_id}`),
     { method: 'DELETE' }
   );
-  return {
-    ...rawProject,
-    id: String(rawProject.id),
-    name: String(rawProject.name || ''),
-    description: rawProject.description ? String(rawProject.description) : null,
-    is_archived: !!rawProject.is_archived,
-    created_at: String(rawProject.created_at || new Date().toISOString()),
-    task_count:
-      typeof rawProject.task_count === 'number' ? rawProject.task_count : 0,
-  };
 };
 
 // --- Project Archive/Unarchive ---

--- a/frontend/src/services/api/tasks.ts
+++ b/frontend/src/services/api/tasks.ts
@@ -365,34 +365,11 @@ export const getAllTasksForProject = async (projectId: string, filters?: TaskFil
 export const deleteTask = async (
   project_id: string,
   task_number: number,
-): Promise<Task> => {
-  const rawTask = await request<RawTask>(
+): Promise<boolean> => {
+  return request<boolean>(
     buildApiUrl(API_CONFIG.ENDPOINTS.PROJECTS, `/${project_id}/tasks/${task_number}`),
     { method: "DELETE" },
   );
-  if (!rawTask) {
-    throw new Error(
-      `Task ${project_id}/${task_number} deleted, but backend did not return the task object.`,
-    );
-  }
-  const statusId = normalizeToStatusID(rawTask.status, !!rawTask.completed);
-  return {
-    ...rawTask,
-    id: `${rawTask.project_id}-${rawTask.task_number}`, // Computed ID for frontend compatibility
-    project_id: String(rawTask.project_id),
-    task_number: Number(rawTask.task_number),
-    title: String(rawTask.title || ""),
-    description: rawTask.description ? String(rawTask.description) : null,
-    status: statusId,
-    agent_id: rawTask.agent_id ? String(rawTask.agent_id) : null,
-    agent_name: rawTask.agent_name ? String(rawTask.agent_name) : null,
-    agent_status: rawTask.agent_status ? String(rawTask.agent_status) : undefined,
-    created_at: String(rawTask.created_at || new Date().toISOString()),
-    updated_at: String(rawTask.updated_at || new Date().toISOString()),
-    is_archived: !!rawTask.is_archived,
-    subtasks: rawTask.subtasks || [],
-    dependencies: rawTask.dependencies || [],
-  } as Task;
 };
 
 // --- Task Comments API ---

--- a/frontend/src/services/api/user_roles.ts
+++ b/frontend/src/services/api/user_roles.ts
@@ -16,8 +16,8 @@ export const userRolesApi = {
   async remove(
     userId: string,
     roleName: UserRole
-  ): Promise<{ message: string }> {
-    return request<{ message: string }>(
+  ): Promise<boolean> {
+    return request<boolean>(
       buildApiUrl(API_CONFIG.ENDPOINTS.USERS, `/${userId}/roles/${roleName}`),
       { method: 'DELETE' }
     );


### PR DESCRIPTION
## Summary
- return `DataResponse[bool]` from DELETE handlers
- adjust frontend services to expect boolean data
- update tests for new standardized responses

## Testing
- `flake8 backend` *(fails: command not found)*
- `npm run fix` *(fails: cannot find ESLint config)*
- `npm run format`
- `pytest backend/tests/test_workflow_endpoints.py::test_update_and_delete_workflow -q` *(fails: ModuleNotFoundError for sqlalchemy)*
- `npm --prefix frontend run test:coverage` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c9850564832ca9b9d0e67825cf26