### PR TITLE
Implement custom service exceptions

### DIFF
--- a/backend/routers/memory/core/core.py
+++ b/backend/routers/memory/core/core.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, status, Query, Path
+from fastapi import APIRouter, Depends, status, Query, Path
 from sqlalchemy.orm import Session
 from typing import List, Optional, Dict, Any
 from pydantic import BaseModel, Field
@@ -30,10 +30,7 @@ def get_memory_graph(
     memory_service: MemoryService = Depends(get_memory_service),
 ):
     """Retrieve the entire knowledge graph."""
-    try:
-        return memory_service.get_knowledge_graph()
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+    return memory_service.get_knowledge_graph()
 
 # =============================
 # CRUD Endpoints
@@ -45,14 +42,7 @@ def create_memory_entity_endpoint(
     entity_data: MemoryEntityCreate,
     memory_service: MemoryService = Depends(get_memory_service),
 ):
-    try:
-        return memory_service.create_entity(entity_data)
-    except DuplicateEntityError as e:
-        raise HTTPException(status_code=409, detail=str(e))
-    except ValidationError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+    return memory_service.create_entity(entity_data)
 
 
 @router.get("/{entity_id}", response_model=MemoryEntity)
@@ -60,15 +50,10 @@ def read_memory_entity_endpoint(
     entity_id: int = Path(...),
     memory_service: MemoryService = Depends(get_memory_service),
 ):
-    try:
-        db_entity = memory_service.get_entity(entity_id)
-        if db_entity is None:
-            raise EntityNotFoundError("MemoryEntity", entity_id)
-        return db_entity
-    except EntityNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+    db_entity = memory_service.get_entity(entity_id)
+    if db_entity is None:
+        raise EntityNotFoundError("MemoryEntity", entity_id)
+    return db_entity
 
 
 @router.get("/", response_model=List[MemoryEntity])
@@ -79,10 +64,7 @@ def list_memory_entities_endpoint(
     limit: int = Query(100),
     memory_service: MemoryService = Depends(get_memory_service),
 ):
-    try:
-        return memory_service.get_entities(type=type, name=name, skip=skip, limit=limit)
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+    return memory_service.get_entities(type=type, name=name, skip=skip, limit=limit)
 
 
 @router.get("/by-type/{entity_type}", response_model=List[MemoryEntity])
@@ -92,14 +74,11 @@ def read_entities_by_type(
     skip: int = Query(0),
     limit: int = Query(100),
 ):
-    try:
-        return memory_service.get_entities_by_type(
-            entity_type=entity_type,
-            skip=skip,
-            limit=limit,
-        )
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+    return memory_service.get_entities_by_type(
+        entity_type=entity_type,
+        skip=skip,
+        limit=limit,
+    )
 
 
 @router.put("/{entity_id}", response_model=MemoryEntity)
@@ -108,15 +87,10 @@ def update_memory_entity_endpoint(
     entity_id: int = Path(...),
     memory_service: MemoryService = Depends(get_memory_service),
 ):
-    try:
-        db_entity = memory_service.update_entity(entity_id, entity_update)
-        if db_entity is None:
-            raise EntityNotFoundError("MemoryEntity", entity_id)
-        return db_entity
-    except EntityNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+    db_entity = memory_service.update_entity(entity_id, entity_update)
+    if db_entity is None:
+        raise EntityNotFoundError("MemoryEntity", entity_id)
+    return db_entity
 
 
 @router.delete("/{entity_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -124,15 +98,10 @@ def delete_memory_entity_endpoint(
     entity_id: int = Path(...),
     memory_service: MemoryService = Depends(get_memory_service),
 ):
-    try:
-        success = memory_service.delete_entity(entity_id)
-        if not success:
-            raise EntityNotFoundError("MemoryEntity", entity_id)
-        return {"message": "Memory entity deleted successfully"}
-    except EntityNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+    success = memory_service.delete_entity(entity_id)
+    if not success:
+        raise EntityNotFoundError("MemoryEntity", entity_id)
+    return {"message": "Memory entity deleted successfully"}
 
 # =============================
 # Ingestion Inputs
@@ -162,17 +131,10 @@ def ingest_file_endpoint(
     memory_service: MemoryService = Depends(get_memory_service),
     current_user: UserModel = Depends(get_current_active_user),
 ):
-    try:
-        return memory_service.ingest_file(
-            ingest_input=ingest_input,
-            user_id=current_user.id,
-        )
-    except FileNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to ingest file: {e}")
+    return memory_service.ingest_file(
+        ingest_input=ingest_input,
+        user_id=current_user.id,
+    )
 
 
 @router.post(
@@ -185,13 +147,10 @@ def ingest_url_endpoint(
     memory_service: MemoryService = Depends(get_memory_service),
     current_user: UserModel = Depends(get_current_active_user),
 ):
-    try:
-        return memory_service.ingest_url(
-            url=ingest_input.url,
-            user_id=current_user.id,
-        )
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to ingest url: {e}")
+    return memory_service.ingest_url(
+        url=ingest_input.url,
+        user_id=current_user.id,
+    )
 
 
 @router.post(
@@ -204,14 +163,11 @@ def ingest_text_endpoint(
     memory_service: MemoryService = Depends(get_memory_service),
     current_user: UserModel = Depends(get_current_active_user),
 ):
-    try:
-        return memory_service.ingest_text(
-            text=ingest_input.text,
-            user_id=current_user.id,
-            metadata=ingest_input.metadata,
-        )
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to ingest text: {e}")
+    return memory_service.ingest_text(
+        text=ingest_input.text,
+        user_id=current_user.id,
+        metadata=ingest_input.metadata,
+    )
 
 # =============================
 # File Content & Metadata
@@ -223,13 +179,8 @@ def get_file_content_endpoint(
     entity_id: int = Path(...),
     memory_service: MemoryService = Depends(get_memory_service),
 ):
-    try:
-        content = memory_service.get_file_content(entity_id)
-        return {"content": content}
-    except EntityNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+    content = memory_service.get_file_content(entity_id)
+    return {"content": content}
 
 
 @router.get("/{entity_id}/metadata")
@@ -237,10 +188,5 @@ def get_file_metadata_endpoint(
     entity_id: int = Path(...),
     memory_service: MemoryService = Depends(get_memory_service),
 ):
-    try:
-        metadata = memory_service.get_file_metadata(entity_id)
-        return {"metadata": metadata}
-    except EntityNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+    metadata = memory_service.get_file_metadata(entity_id)
+    return {"metadata": metadata}

--- a/backend/routers/memory/observations/observations.py
+++ b/backend/routers/memory/observations/observations.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, Query, Path, status
+from fastapi import APIRouter, Depends, Query, Path, status
 from sqlalchemy.orm import Session
 from typing import List, Optional
 
@@ -19,15 +19,10 @@ def add_observation(
     memory_service: MemoryService = Depends(get_memory_service),
 ):
     """Add an observation to a memory entity."""
-    try:
-        db_observation = memory_service.add_observation_to_entity(
-            entity_id=entity_id, observation=observation
-        )
-        return db_observation
-    except EntityNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+    db_observation = memory_service.add_observation_to_entity(
+        entity_id=entity_id, observation=observation
+    )
+    return db_observation
 
 @router.get("/observations/", response_model=List[MemoryObservation])
 
@@ -44,15 +39,12 @@ def read_observations(
     memory_service: MemoryService = Depends(get_memory_service),
 ):
     """Get observations, optionally filtered by entity or content search."""
-    try:
-        return memory_service.get_observations(
-            entity_id=entity_id,
-            search_query=search_query,
-            skip=skip,
-            limit=limit,
-        )
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+    return memory_service.get_observations(
+        entity_id=entity_id,
+        search_query=search_query,
+        skip=skip,
+        limit=limit,
+    )
 
 @router.put("/observations/{observation_id}", response_model=MemoryObservation)
 def update_observation(
@@ -61,15 +53,10 @@ def update_observation(
     memory_service: MemoryService = Depends(get_memory_service),
 ):
     """Update an existing memory observation."""
-    try:
-        db_obs = memory_service.update_observation(observation_id, observation)
-        if db_obs is None:
-            raise EntityNotFoundError("MemoryObservation", observation_id)
-        return db_obs
-    except EntityNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+    db_obs = memory_service.update_observation(observation_id, observation)
+    if db_obs is None:
+        raise EntityNotFoundError("MemoryObservation", observation_id)
+    return db_obs
 
 
 @router.delete("/observations/{observation_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -80,12 +67,7 @@ def delete_observation(
     memory_service: MemoryService = Depends(get_memory_service),
 ):
     """Delete a memory observation."""
-    try:
-        success = memory_service.delete_observation(observation_id)
-        if not success:
-            raise EntityNotFoundError("MemoryObservation", observation_id)
-        return {"message": "Memory observation deleted successfully"}
-    except EntityNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+    success = memory_service.delete_observation(observation_id)
+    if not success:
+        raise EntityNotFoundError("MemoryObservation", observation_id)
+    return {"message": "Memory observation deleted successfully"}

--- a/backend/routers/memory/relations/relations.py
+++ b/backend/routers/memory/relations/relations.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, status, Query, Path
+from fastapi import APIRouter, Depends, status, Query, Path
 from sqlalchemy.orm import Session
 from typing import List, Optional
 
@@ -20,15 +20,7 @@ def create_relation(
     memory_service: MemoryService = Depends(get_memory_service)
 ):
     """Create a relationship between two memory entities."""
-    try:
-        return memory_service.create_memory_relation(relation)
-    except (EntityNotFoundError, DuplicateEntityError) as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        raise HTTPException(
-            status_code=500,
-            detail=f"Internal server error: {e}",
-        )
+    return memory_service.create_memory_relation(relation)
 
 @router.get("/relations/by-type/{relation_type}", response_model=List[MemoryRelation])
 
@@ -41,15 +33,9 @@ def read_relations_by_type(
     memory_service: MemoryService = Depends(get_memory_service)
 ):
     """Retrieve a list of memory relations filtered by type."""
-    try:
-        return memory_service.get_memory_relations_by_type(
-            relation_type=relation_type, skip=skip, limit=limit
-        )
-    except Exception as e:
-        raise HTTPException(
-            status_code=500,
-            detail=f"Internal server error: {e}",
-        )
+    return memory_service.get_memory_relations_by_type(
+        relation_type=relation_type, skip=skip, limit=limit
+    )
 @router.get("/entities/{from_entity_id}/relations/{to_entity_id}", response_model=List[MemoryRelation])
 
 
@@ -63,19 +49,13 @@ def read_relations_between_entities(
     memory_service: MemoryService = Depends(get_memory_service)
 ):
     """Retrieve relations between two specific memory entities."""
-    try:
-        return memory_service.get_memory_relations_between_entities(
-            from_entity_id=from_entity_id,
-            to_entity_id=to_entity_id,
-            relation_type=relation_type,
-            skip=skip,
-            limit=limit,
-        )
-    except Exception as e:
-        raise HTTPException(
-            status_code=500,
-            detail=f"Internal server error: {e}",
-        )
+    return memory_service.get_memory_relations_between_entities(
+        from_entity_id=from_entity_id,
+        to_entity_id=to_entity_id,
+        relation_type=relation_type,
+        skip=skip,
+        limit=limit,
+    )
 
 @router.get("/entities/{entity_id}/relations/", response_model=List[MemoryRelation])
 
@@ -86,17 +66,9 @@ def get_entity_relations(
     memory_service: MemoryService = Depends(get_memory_service)
 ):
     """Get all relations for a specific entity (where it is either the source or target)."""
-    try:
-        return memory_service.get_relations_for_entity(
-            entity_id=entity_id, relation_type=relation_type
-        )
-    except EntityNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except Exception as e:
-        raise HTTPException(
-            status_code=500,
-            detail=f"Internal server error: {e}",
-        )
+    return memory_service.get_relations_for_entity(
+        entity_id=entity_id, relation_type=relation_type
+    )
 
 @router.put("/relations/{relation_id}", response_model=MemoryRelation)
 
@@ -107,17 +79,7 @@ def update_relation(
     memory_service: MemoryService = Depends(get_memory_service),
 ):
     """Update an existing memory relation."""
-    try:
-        return memory_service.update_memory_relation(relation_id, relation)
-    except EntityNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except DuplicateEntityError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        raise HTTPException(
-            status_code=500,
-            detail=f"Internal server error: {e}",
-        )
+    return memory_service.update_memory_relation(relation_id, relation)
 
 @router.delete("/relations/{relation_id}", status_code=status.HTTP_204_NO_CONTENT)
 
@@ -127,15 +89,7 @@ def delete_relation(
     memory_service: MemoryService = Depends(get_memory_service)
 ):
     """Delete a memory relation."""
-    try:
-        success = memory_service.delete_memory_relation(relation_id)
-        if not success:
-            raise EntityNotFoundError("MemoryRelation", relation_id)
-        return {"message": "Memory relation deleted successfully"}
-    except EntityNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except Exception as e:
-        raise HTTPException(
-            status_code=500,
-            detail=f"Internal server error: {e}",
-        )
+    success = memory_service.delete_memory_relation(relation_id)
+    if not success:
+        raise EntityNotFoundError("MemoryRelation", relation_id)
+    return {"message": "Memory relation deleted successfully"}

--- a/backend/services/task_dependency_service.py
+++ b/backend/services/task_dependency_service.py
@@ -8,7 +8,7 @@ from backend.crud.task_dependencies import create_task_dependency
 from ..schemas.task_dependency import TaskDependencyCreate
 import logging
 from sqlalchemy.ext.asyncio import AsyncSession
-from fastapi import HTTPException
+from ..services.exceptions import ValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -74,12 +74,12 @@ class TaskDependencyService:
         # Check for self-dependency
         if self._is_self_dependency(task_dependency):
             logger.error("Self-dependency detected: Service Layer Check.")
-            raise HTTPException(status_code=400, detail="A task cannot be dependent on itself")
+            raise ValidationError("A task cannot be dependent on itself")
         
         # Check for circular dependency
         if await self._is_circular_dependency(task_dependency):
             logger.error("Circular dependency detected: Service Layer Check.")
-            raise HTTPException(status_code=400, detail="Circular dependency detected")
+            raise ValidationError("Circular dependency detected")
         
         # Create the dependency in the database
         db_task_dependency = await create_task_dependency(self.db, task_dependency)

--- a/backend/tests/test_memory_service.py
+++ b/backend/tests/test_memory_service.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from fastapi import HTTPException
+from backend.services.exceptions import EntityNotFoundError, ServiceError
 
 from backend.services.memory_service import MemoryService
 from backend.schemas.file_ingest import FileIngestInput
@@ -45,16 +45,16 @@ def test_ingest_file_reads_text(tmp_path):
 
 
 def test_ingest_file_missing_file_raises():
-    """ingest_file should raise HTTPException when the file is missing."""
+    """ingest_file should raise EntityNotFoundError when the file is missing."""
     session = MagicMock()
     service = MemoryService(session)
 
-    with pytest.raises(HTTPException):
+    with pytest.raises(EntityNotFoundError):
         service.ingest_file(FileIngestInput(file_path="/nonexistent/file.txt"))
 
 
 def test_ingest_file_unsupported_encoding(tmp_path):
-    """If decoding fails for all attempts, HTTPException should be raised."""
+    """If decoding fails for all attempts, ServiceError should be raised."""
     tmp_file = tmp_path / "bad.txt"
     tmp_file.write_bytes(b"\xff\xfe")
 
@@ -63,5 +63,5 @@ def test_ingest_file_unsupported_encoding(tmp_path):
 
     decode_error = UnicodeDecodeError("utf-8", b"", 0, 1, "bad")
     with patch("builtins.open", side_effect=[decode_error, decode_error]):
-        with pytest.raises(HTTPException):
+        with pytest.raises(ServiceError):
             service.ingest_file(FileIngestInput(file_path=str(tmp_file)))


### PR DESCRIPTION
## Summary
- replace HTTPExceptions in memory service with service errors
- rework task dependency service validation errors
- map exceptions to standardized ErrorResponse
- update memory routes to rely on global handlers
- adjust tests for new exceptions

## Testing
- `pytest tests/test_memory_service.py -q`
- `pytest -q` *(fails: 13 failed, 43 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6841c98119e4832c8846d43f17bb512a