### PR TITLE
Add persist middleware to task store

### DIFF
--- a/frontend/src/store/__tests__/taskStore.test.ts
+++ b/frontend/src/store/__tests__/taskStore.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { act } from 'react-dom/test-utils'
-import { useTaskStore } from '../taskStore'
-import * as api from '@/services/api'
-import { TaskStatus } from '@/types/task'
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { act } from 'react-dom/test-utils';
+import { useTaskStore } from '../taskStore';
+import * as api from '@/services/api';
+import { TaskStatus } from '@/types/task';
 
 vi.mock('@/services/api', () => ({
   getAllTasks: vi.fn(),
@@ -10,9 +10,9 @@ vi.mock('@/services/api', () => ({
   getProjects: vi.fn(),
   getAgents: vi.fn(),
   deleteTask: vi.fn(),
-}))
+}));
 
-const mockedApi = vi.mocked(api as any)
+const mockedApi = vi.mocked(api as any);
 
 const initialState = {
   tasks: [],
@@ -37,37 +37,75 @@ const initialState = {
   agents: [],
   pollingIntervalId: null,
   selectedTaskIds: [],
-}
+};
 
 describe('taskStore', () => {
   beforeEach(() => {
-    useTaskStore.setState(initialState as any)
-    vi.clearAllMocks()
-  })
+    useTaskStore.setState(initialState as any);
+    vi.clearAllMocks();
+  });
 
   it('fetchTasks loads tasks from API', async () => {
-    const tasks = [{ project_id: 'p1', task_number: 1, title: 'T1', status: TaskStatus.TO_DO, created_at: '2024' }]
-    mockedApi.getAllTasks.mockResolvedValueOnce(tasks)
+    const tasks = [
+      {
+        project_id: 'p1',
+        task_number: 1,
+        title: 'T1',
+        status: TaskStatus.TO_DO,
+        created_at: '2024',
+      },
+    ];
+    mockedApi.getAllTasks.mockResolvedValueOnce(tasks);
 
     await act(async () => {
-      await useTaskStore.getState().fetchTasks()
-    })
+      await useTaskStore.getState().fetchTasks();
+    });
 
-    expect(mockedApi.getAllTasks).toHaveBeenCalled()
-    expect(useTaskStore.getState().tasks).toEqual(tasks)
-  })
+    expect(mockedApi.getAllTasks).toHaveBeenCalled();
+    expect(useTaskStore.getState().tasks).toEqual(tasks);
+  });
 
   it('addTask adds task and calls API', async () => {
-    const newTask = { project_id: 'p1', task_number: 2, title: 'New', status: TaskStatus.TO_DO, created_at: '2024' }
-    mockedApi.createTask.mockResolvedValueOnce(newTask)
-    mockedApi.getProjects.mockResolvedValueOnce([])
-    mockedApi.getAgents.mockResolvedValueOnce([])
+    const newTask = {
+      project_id: 'p1',
+      task_number: 2,
+      title: 'New',
+      status: TaskStatus.TO_DO,
+      created_at: '2024',
+    };
+    mockedApi.createTask.mockResolvedValueOnce(newTask);
+    mockedApi.getProjects.mockResolvedValueOnce([]);
+    mockedApi.getAgents.mockResolvedValueOnce([]);
 
     await act(async () => {
-      await useTaskStore.getState().addTask({ project_id: 'p1', title: 'New' } as any)
-    })
+      await useTaskStore
+        .getState()
+        .addTask({ project_id: 'p1', title: 'New' } as any);
+    });
 
-    expect(mockedApi.createTask).toHaveBeenCalledWith('p1', { project_id: 'p1', title: 'New' })
-    expect(useTaskStore.getState().tasks[0]).toEqual(newTask)
-  })
-})
+    expect(mockedApi.createTask).toHaveBeenCalledWith('p1', {
+      project_id: 'p1',
+      title: 'New',
+    });
+    expect(useTaskStore.getState().tasks[0]).toEqual(newTask);
+  });
+
+  it('rehydrates tasks from localStorage', async () => {
+    vi.resetModules();
+    const tasks = [
+      {
+        project_id: 'p1',
+        task_number: 3,
+        title: 'Persisted',
+        status: TaskStatus.TO_DO,
+        created_at: '2024',
+      },
+    ];
+    localStorage.setItem(
+      'task-store',
+      JSON.stringify({ state: { ...initialState, tasks }, version: 1 })
+    );
+    const { useTaskStore: rehydrated } = await import('../taskStore');
+    expect(rehydrated.getState().tasks).toEqual(tasks);
+  });
+});


### PR DESCRIPTION
## Summary
- wrap `useTaskStore` with Zustand `persist` middleware
- define task store version and default filters
- migrate persisted state when version changes
- test that tasks rehydrate from localStorage

## Testing
- `npm run test:run` *(fails: observer.observe is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6841c97e9ea8832c8d229142fb1ef48c