### PR TITLE
Implement template management components

### DIFF
--- a/frontend/src/app/templates/README.md
+++ b/frontend/src/app/templates/README.md
@@ -3,8 +3,8 @@
 This directory contains pages for managing project templates.
 
 - `page.tsx` – Lists existing templates using `TemplateList`.
-- `new/page.tsx` – Form for creating a template.
-- `[templateId]/edit/page.tsx` – Edit an existing template.
+- `new/page.tsx` – Form for creating a template using `TemplateForm`.
+- `[templateId]/edit/page.tsx` – Edit an existing template with `TemplateForm`.
 - `[templateId]/delete/page.tsx` – Deletes a template then redirects back to the list.
 
 <!-- File List Start -->

--- a/frontend/src/app/templates/[templateId]/edit/page.tsx
+++ b/frontend/src/app/templates/[templateId]/edit/page.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import { Button } from '@chakra-ui/react';
-import EditProjectTemplateForm from '@/components/forms/EditProjectTemplateForm';
+import TemplateForm from '@/components/templates/TemplateForm';
 import { useTemplateStore } from '@/store/templateStore';
 
 const EditTemplatePage: React.FC = () => {
@@ -40,7 +40,7 @@ const EditTemplatePage: React.FC = () => {
 
   return (
     <>
-      <EditProjectTemplateForm
+      <TemplateForm
         template={template}
         onSubmit={handleSubmit}
         onCancel={() => router.push('/templates')}

--- a/frontend/src/app/templates/new/page.tsx
+++ b/frontend/src/app/templates/new/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 import React from 'react';
 import { useRouter } from 'next/navigation';
-import AddProjectTemplateForm from '@/components/forms/AddProjectTemplateForm';
+import TemplateForm from '@/components/templates/TemplateForm';
 import { useTemplateStore } from '@/store/templateStore';
 
 const NewTemplatePage: React.FC = () => {
@@ -14,7 +14,7 @@ const NewTemplatePage: React.FC = () => {
   };
 
   return (
-    <AddProjectTemplateForm
+    <TemplateForm
       onSubmit={handleSubmit}
       onCancel={() => router.push('/templates')}
     />

--- a/frontend/src/app/templates/page.tsx
+++ b/frontend/src/app/templates/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React from 'react';
-import TemplateList from '@/components/template/TemplateList';
+import TemplateList from '@/components/templates/TemplateList';
 
 const TemplatesPage: React.FC = () => {
   return <TemplateList />;

--- a/frontend/src/components/templates/README.md
+++ b/frontend/src/components/templates/README.md
@@ -1,0 +1,15 @@
+# Template Components (`frontend/src/components/templates/`)
+
+This directory contains components for managing project templates in the UI.
+
+- `TemplateList.tsx` – Displays a table of templates with edit/delete actions.
+- `TemplateForm.tsx` – Generic form used for creating and editing templates.
+
+<!-- File List Start -->
+
+## File List
+
+- `TemplateForm.tsx`
+- `TemplateList.tsx`
+
+<!-- File List End -->

--- a/frontend/src/components/templates/TemplateForm.tsx
+++ b/frontend/src/components/templates/TemplateForm.tsx
@@ -1,0 +1,139 @@
+'use client';
+import React from 'react';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Textarea,
+  VStack,
+  FormErrorMessage,
+  useToast,
+} from '@chakra-ui/react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  projectTemplateCreateSchema,
+  projectTemplateUpdateSchema,
+  ProjectTemplateCreateData,
+  ProjectTemplateUpdateData,
+  ProjectTemplate,
+} from '@/types/project_template';
+
+interface FormFields {
+  name?: string;
+  description?: string | null;
+  templateData: string;
+}
+
+interface TemplateFormProps {
+  template?: ProjectTemplate;
+  onSubmit: (
+    data: ProjectTemplateCreateData | ProjectTemplateUpdateData
+  ) => Promise<void>;
+  onCancel: () => void;
+}
+
+const TemplateForm: React.FC<TemplateFormProps> = ({
+  template,
+  onSubmit,
+  onCancel,
+}) => {
+  const isEdit = !!template;
+  const toast = useToast();
+  const schema = isEdit
+    ? projectTemplateUpdateSchema.extend({
+        template_data:
+          projectTemplateUpdateSchema.shape.template_data?.transform(
+            () => ({})
+          ),
+      })
+    : projectTemplateCreateSchema.extend({
+        template_data:
+          projectTemplateCreateSchema.shape.template_data.transform(() => ({})),
+      });
+
+  const defaultValues = isEdit
+    ? {
+        name: template?.name ?? '',
+        description: template?.description ?? '',
+        templateData: JSON.stringify(template?.template_data, null, 2),
+      }
+    : { name: '', description: '', templateData: '{}' };
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    reset,
+  } = useForm<FormFields>({
+    resolver: zodResolver(schema),
+    defaultValues,
+  });
+
+  const submitHandler = async (fields: FormFields) => {
+    try {
+      const payload = {
+        name: fields.name,
+        description: fields.description || undefined,
+        template_data: JSON.parse(fields.templateData || '{}'),
+      } as ProjectTemplateCreateData | ProjectTemplateUpdateData;
+      await onSubmit(payload);
+      if (!isEdit) reset();
+    } catch (err) {
+      toast({
+        title: isEdit ? 'Error updating template' : 'Error creating template',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  return (
+    <Box
+      as="form"
+      onSubmit={handleSubmit(submitHandler)}
+      p="6"
+      bg="bgSurface"
+      borderRadius="lg"
+      borderWidth="DEFAULT"
+      borderColor="borderDecorative"
+    >
+      <VStack spacing="4" align="stretch">
+        <FormControl isInvalid={!!errors.name} isRequired>
+          <FormLabel>Template Name</FormLabel>
+          <Input {...register('name')} placeholder="Name" />
+          {errors.name && (
+            <FormErrorMessage>{errors.name.message}</FormErrorMessage>
+          )}
+        </FormControl>
+        <FormControl>
+          <FormLabel>Description</FormLabel>
+          <Input {...register('description')} placeholder="Description" />
+        </FormControl>
+        <FormControl isInvalid={!!errors.templateData} isRequired>
+          <FormLabel>Template JSON</FormLabel>
+          <Textarea
+            {...register('templateData')}
+            rows={6}
+            fontFamily="monospace"
+          />
+          {errors.templateData && (
+            <FormErrorMessage>{errors.templateData.message}</FormErrorMessage>
+          )}
+        </FormControl>
+        <Button type="submit" isLoading={isSubmitting} colorScheme="blue">
+          {isEdit ? 'Update Template' : 'Create Template'}
+        </Button>
+        <Button variant="ghost" onClick={onCancel} isDisabled={isSubmitting}>
+          Cancel
+        </Button>
+      </VStack>
+    </Box>
+  );
+};
+
+export default TemplateForm;

--- a/frontend/src/components/templates/TemplateList.tsx
+++ b/frontend/src/components/templates/TemplateList.tsx
@@ -1,0 +1,90 @@
+'use client';
+import React, { useEffect } from 'react';
+import Link from 'next/link';
+import {
+  Box,
+  Button,
+  Flex,
+  Heading,
+  IconButton,
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+  useToast,
+} from '@chakra-ui/react';
+import { DeleteIcon, EditIcon } from '@chakra-ui/icons';
+import { useTemplateStore } from '@/store/templateStore';
+
+const TemplateList: React.FC = () => {
+  const templates = useTemplateStore((s) => s.templates);
+  const fetchTemplates = useTemplateStore((s) => s.fetchTemplates);
+  const removeTemplate = useTemplateStore((s) => s.removeTemplate);
+  const toast = useToast();
+
+  useEffect(() => {
+    fetchTemplates();
+  }, [fetchTemplates]);
+
+  const handleDelete = async (id: string) => {
+    try {
+      await removeTemplate(id);
+      toast({ title: 'Template deleted', status: 'success', duration: 3000 });
+    } catch (err) {
+      toast({
+        title: 'Error deleting template',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+      });
+    }
+  };
+
+  return (
+    <Box p="4">
+      <Flex justify="space-between" align="center" mb="4">
+        <Heading size="md">Project Templates</Heading>
+        <Button as={Link} href="/templates/new" colorScheme="blue">
+          Create Template
+        </Button>
+      </Flex>
+      <Table variant="simple">
+        <Thead>
+          <Tr>
+            <Th>Name</Th>
+            <Th>Description</Th>
+            <Th>Actions</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {templates.map((t) => (
+            <Tr key={t.id} data-testid="template-row">
+              <Td>{t.name}</Td>
+              <Td>{t.description}</Td>
+              <Td>
+                <IconButton
+                  as={Link}
+                  href={`/templates/${t.id}/edit`}
+                  aria-label="Edit"
+                  icon={<EditIcon />}
+                  size="sm"
+                  mr="2"
+                />
+                <IconButton
+                  aria-label="Delete"
+                  icon={<DeleteIcon />}
+                  size="sm"
+                  onClick={() => handleDelete(t.id)}
+                />
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </Box>
+  );
+};
+
+export default TemplateList;

--- a/frontend/src/components/templates/__tests__/TemplateForm.test.tsx
+++ b/frontend/src/components/templates/__tests__/TemplateForm.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen, TestWrapper } from '@/__tests__/utils/test-utils';
+import TemplateForm from '../TemplateForm';
+import { ProjectTemplate } from '@/types/project_template';
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual('@chakra-ui/react');
+  return {
+    ...actual,
+    useToast: () => vi.fn(),
+    useColorModeValue: (l: any, d: any) => l,
+  };
+});
+
+describe('TemplateForm', () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders in create mode', () => {
+    render(
+      <TestWrapper>
+        <TemplateForm onSubmit={vi.fn()} onCancel={vi.fn()} />
+      </TestWrapper>
+    );
+    expect(document.body).toBeInTheDocument();
+  });
+
+  it('renders with template data in edit mode', () => {
+    const template: ProjectTemplate = {
+      id: '1',
+      name: 'T1',
+      description: null,
+      template_data: {},
+      created_at: '',
+      updated_at: '',
+    };
+    render(
+      <TestWrapper>
+        <TemplateForm
+          template={template}
+          onSubmit={vi.fn()}
+          onCancel={vi.fn()}
+        />
+      </TestWrapper>
+    );
+    expect(screen.getByDisplayValue('T1')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/templates/__tests__/TemplateList.test.tsx
+++ b/frontend/src/components/templates/__tests__/TemplateList.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  render,
+  screen,
+  fireEvent,
+  TestWrapper,
+} from '@/__tests__/utils/test-utils';
+import TemplateList from '../TemplateList';
+import { useTemplateStore } from '@/store/templateStore';
+
+vi.mock('@/store/templateStore');
+
+const mockUseTemplateStore = useTemplateStore as vi.MockedFunction<
+  typeof useTemplateStore
+>;
+
+describe('TemplateList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseTemplateStore.mockImplementation((selector) =>
+      selector({
+        templates: [
+          { id: 't1', name: 'Temp1', description: '', template_data: {} },
+        ],
+        fetchTemplates: vi.fn(),
+        removeTemplate: vi.fn(),
+      } as any)
+    );
+  });
+
+  it('calls removeTemplate when delete button clicked', () => {
+    const state = {
+      templates: [
+        { id: 't1', name: 'Temp1', description: '', template_data: {} },
+      ],
+      fetchTemplates: vi.fn(),
+      removeTemplate: vi.fn(),
+    };
+    mockUseTemplateStore.mockImplementation((selector) =>
+      selector(state as any)
+    );
+
+    render(<TemplateList />, { wrapper: TestWrapper });
+
+    const deleteBtn = screen.getByLabelText('Delete');
+    fireEvent.click(deleteBtn);
+
+    expect(state.removeTemplate).toHaveBeenCalledWith('t1');
+  });
+});

--- a/frontend/src/services/api/config.ts
+++ b/frontend/src/services/api/config.ts
@@ -2,29 +2,31 @@
  * Central API configuration for consistent base URLs across all API services
  */
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000";
-const API_VERSION = "/api"; // Backend uses /api, not /api/v1
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+const API_VERSION = '/api'; // Backend uses /api, not /api/v1
 
 export const API_CONFIG = {
   BASE_URL: `${API_BASE_URL}${API_VERSION}`,
   ENDPOINTS: {
-    PROJECTS: "/projects/",
-    TASKS: "/tasks/", // This might need adjustment for nested structure
-    AGENTS: "/agents",
-    USERS: "/users",
-    AUTH: "/auth",
-    AUDIT_LOGS: "/audit-logs",
-    COMMENTS: "/comments",
-    MEMORY: "/memory",
-    RULES: "/rules",
-    MCP_TOOLS: "/mcp-tools",
-    VERIFICATION_REQUIREMENTS: "/verification-requirements",
+    PROJECTS: '/projects/',
+    TASKS: '/tasks/', // This might need adjustment for nested structure
+    AGENTS: '/agents',
+    USERS: '/users',
+    AUTH: '/auth',
+    AUDIT_LOGS: '/audit-logs',
+    COMMENTS: '/comments',
+    MEMORY: '/memory',
+    RULES: '/rules',
+    MCP_TOOLS: '/mcp-tools',
+    PROJECT_TEMPLATES: '/project-templates/',
+    VERIFICATION_REQUIREMENTS: '/verification-requirements',
   },
 } as const;
 
 /**
  * Helper function to build API URLs
  */
-export const buildApiUrl = (endpoint: string, path: string = ""): string => {
+export const buildApiUrl = (endpoint: string, path: string = ''): string => {
   return `${API_CONFIG.BASE_URL}${endpoint}${path}`;
 };

--- a/frontend/src/services/api/project_templates.ts
+++ b/frontend/src/services/api/project_templates.ts
@@ -1,53 +1,66 @@
-import { request } from "./request";
-import { buildApiUrl } from "./config";
+import { request } from './request';
+import { buildApiUrl, API_CONFIG } from './config';
 import {
   ProjectTemplate,
   ProjectTemplateCreateData,
   ProjectTemplateUpdateData,
-} from "@/types/project_template";
+} from '@/types/project_template';
 
 /**
  * Thin REST wrapper for /project-templates endpoints.
  * Fully typed, portable, and encapsulated logic.
  */
 export async function deleteTemplate(
-  templateId: string,
+  templateId: string
 ): Promise<{ message: string }> {
   return request<{ message: string }>(
-    buildApiUrl("/project-templates/", `/${templateId}`),
-    { method: "DELETE" },
+    buildApiUrl(API_CONFIG.ENDPOINTS.PROJECT_TEMPLATES, `/${templateId}`),
+    { method: 'DELETE' }
   );
 }
 
 export const projectTemplatesApi = {
   /** Create a new project template */
   async create(data: ProjectTemplateCreateData): Promise<ProjectTemplate> {
-    return request<ProjectTemplate>(buildApiUrl("/project-templates/"), {
-      method: "POST",
-      body: JSON.stringify(data),
-    });
+    return request<ProjectTemplate>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.PROJECT_TEMPLATES),
+      {
+        method: 'POST',
+        body: JSON.stringify(data),
+      }
+    );
   },
 
   /** List project templates with basic pagination */
   async list(skip = 0, limit = 100): Promise<ProjectTemplate[]> {
-    const params = new URLSearchParams({ skip: String(skip), limit: String(limit) });
-    return request<ProjectTemplate[]>(buildApiUrl("/project-templates/", `?${params}`));
+    const params = new URLSearchParams({
+      skip: String(skip),
+      limit: String(limit),
+    });
+    return request<ProjectTemplate[]>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.PROJECT_TEMPLATES, `?${params}`)
+    );
   },
 
   /** Retrieve a single project template */
   async get(templateId: string): Promise<ProjectTemplate> {
-    return request<ProjectTemplate>(buildApiUrl("/project-templates/", `/${templateId}`));
+    return request<ProjectTemplate>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.PROJECT_TEMPLATES, `/${templateId}`)
+    );
   },
 
   /** Update a project template */
   async update(
     templateId: string,
-    data: ProjectTemplateUpdateData,
+    data: ProjectTemplateUpdateData
   ): Promise<ProjectTemplate> {
-    return request<ProjectTemplate>(buildApiUrl("/project-templates/", `/${templateId}`), {
-      method: "PUT",
-      body: JSON.stringify(data),
-    });
+    return request<ProjectTemplate>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.PROJECT_TEMPLATES, `/${templateId}`),
+      {
+        method: 'PUT',
+        body: JSON.stringify(data),
+      }
+    );
   },
 
   /** Delete a project template */


### PR DESCRIPTION
## Summary
- add TemplateForm and TemplateList under new `templates` folder
- expose `PROJECT_TEMPLATES` API endpoint
- extend project template API wrapper with new endpoint constant
- update templates pages to use new components
- include component unit tests

## Testing
- `npm run lint`
- `npx vitest run src/components/templates/__tests__/TemplateList.test.tsx src/components/templates/__tests__/TemplateForm.test.tsx` *(failed: No test files found)*
- `npm test` *(failed: integration tests missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6841c97d8518832cad49fb219e483c34