### PR TITLE
Add custom error pages

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -69,6 +69,7 @@ This frontend application provides a modern and responsive user interface for ma
 *   **Error Protocol Management:** Add, list, and remove protocols through `/mcp-tools/error-protocol/*` routes.
 *   **User Role Assignment:** Assign or remove roles using `/api/users/{user_id}/roles`.
 *   **Knowledge Graph Visualization:** View the memory graph via `/api/memory/entities/graph`.
+*   **Friendly Error Pages:** `src/app/not-found.tsx` handles missing routes with a helpful message and link home, while `src/app/error.tsx` displays a generic error message when unexpected issues occur.
 
 ---
 

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import React, { useEffect } from "react";
+import { Button, Flex, Heading, Text } from "@chakra-ui/react";
+import Link from "next/link";
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <Flex direction="column" align="center" justify="center" minH="100vh" gap={6}>
+      <Heading as="h1" size="lg">Something went wrong</Heading>
+      <Text>We encountered an unexpected error.</Text>
+      <Button onClick={reset} colorScheme="blue">
+        Try Again
+      </Button>
+      <Button as={Link} href="/" variant="outline" colorScheme="blue">
+        Go Home
+      </Button>
+    </Flex>
+  );
+}

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -7,10 +7,8 @@ import Link from "next/link";
 export default function NotFound() {
   return (
     <Flex direction="column" align="center" justify="center" minH="100vh" gap={6}>
-      <Heading as="h1" size="lg">
-        404 - Page Not Found
-      </Heading>
-      <Text>Sorry, the page you are looking for does not exist.</Text>
+      <Heading as="h1" size="lg">Oops! Page Not Found</Heading>
+      <Text>The page you requested could not be found.</Text>
       <Button as={Link} href="/" colorScheme="blue">
         Go Home
       </Button>


### PR DESCRIPTION
## Summary
- improve 404 page copy
- add global error page for unexpected failures
- document these pages in the frontend README

## Testing
- `npm run lint`
- `npm run type-check` *(fails: TS errors)*
- `npm test` *(fails: multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6841c97cd0bc832cbffabcdd92668035