### PR TITLE
Add isoformat serialization and date parser

### DIFF
--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -1,6 +1,10 @@
 """
 Schemas package - contains Pydantic models for API requests/responses.
 """
+from datetime import datetime
+from pydantic.json import ENCODERS_BY_TYPE
+
+ENCODERS_BY_TYPE[datetime] = lambda v: v.isoformat()
 
 # Import and export project schemas
 from .project import (

--- a/frontend/src/__tests__/utils/date.test.ts
+++ b/frontend/src/__tests__/utils/date.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { parseDate } from '@/utils/date';
+
+describe('parseDate', () => {
+  it('parses ISO strings with timezone offsets correctly', () => {
+    const dt = parseDate('2024-05-01T08:00:00-04:00');
+    expect(dt.toISOString()).toBe('2024-05-01T12:00:00.000Z');
+  });
+
+  it('returns Date instances unchanged', () => {
+    const now = new Date('2024-05-01T12:00:00Z');
+    expect(parseDate(now)).toBe(now);
+  });
+});

--- a/frontend/src/components/audit/AuditLogViewer.tsx
+++ b/frontend/src/components/audit/AuditLogViewer.tsx
@@ -13,6 +13,7 @@ import {
   Button,
   Flex,
 } from '@chakra-ui/react';
+import { parseDate } from '@/utils/date';
 import { AuditLog } from '@/types/audit_log';
 import { getAuditLogs } from '@/services/api/audit_logs';
 
@@ -75,7 +76,7 @@ const AuditLogViewer: React.FC = () => {
               <Td>{log.id}</Td>
               <Td>{log.action}</Td>
               <Td>{log.user_id || '-'}</Td>
-              <Td>{new Date(log.timestamp).toLocaleString()}</Td>
+              <Td>{parseDate(log.timestamp).toLocaleString()}</Td>
             </Tr>
           ))}
         </Tbody>

--- a/frontend/src/components/audit_logs/AuditLogListForEntity.tsx
+++ b/frontend/src/components/audit_logs/AuditLogListForEntity.tsx
@@ -13,6 +13,7 @@ import {
   Td,
   TableContainer,
 } from "@chakra-ui/react";
+import { parseDate } from "@/utils/date";
 import { getAuditLogsByEntity } from "@/services/api/audit_logs";
 import { AuditLog } from "@/types/audit_log";
 
@@ -88,7 +89,7 @@ const AuditLogListForEntity: React.FC<AuditLogListForEntityProps> = ({
               <Tbody>
                 {logs.map((log) => (
                   <Tr key={log.id}>
-                    <Td>{new Date(log.timestamp).toLocaleString()}</Td>
+                    <Td>{parseDate(log.timestamp).toLocaleString()}</Td>
                     <Td>{log.action}</Td>
                     <Td>{log.user_id || "System"}</Td>
                     <Td>

--- a/frontend/src/components/dashboard/RecentActivityList.tsx
+++ b/frontend/src/components/dashboard/RecentActivityList.tsx
@@ -15,6 +15,7 @@ import AppIcon from "../common/AppIcon";
 
 // Import tokens
 import { sizing, shadows, typography } from "../../tokens";
+import { parseDate } from "@/utils/date";
 
 interface ActivityItem {
   type: string;
@@ -125,7 +126,7 @@ const RecentActivityList: React.FC<RecentActivityListProps> = ({
                   fontSize={typography.fontSize.xs}
                   color="textSecondary"
                 >
-                  {item.date ? new Date(item.date).toLocaleString() : ""}
+                  {item.date ? parseDate(item.date).toLocaleString() : ""}
                 </Text>
               </Flex>
             </Box>

--- a/frontend/src/components/modals/TaskDetailsModal.tsx
+++ b/frontend/src/components/modals/TaskDetailsModal.tsx
@@ -29,6 +29,7 @@ import {
   useDisclosure,
   Badge,
 } from "@chakra-ui/react";
+import { parseDate } from "@/utils/date";
 import { Task } from "@/types"; // Corrected import for Task
 import { getTaskById } from "@/services/api"; // Assuming getTaskById exists
 import { useTaskStore } from "@/store/taskStore"; // To potentially get project/agent names if not in task detail
@@ -429,12 +430,12 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({
                     Timestamps
                   </Heading>
                   <Text color="textPrimary" fontSize="base">
-                    Created: {new Date(task.created_at).toLocaleString()}
+                    Created: {parseDate(task.created_at).toLocaleString()}
                   </Text>
                   <Text color="textPrimary" fontSize="base">
                     Updated:{" "}
                     {task.updated_at
-                      ? new Date(task.updated_at).toLocaleString()
+                      ? parseDate(task.updated_at).toLocaleString()
                       : "N/A"}
                   </Text>
                 </Box>

--- a/frontend/src/components/project/ProjectCard.tsx
+++ b/frontend/src/components/project/ProjectCard.tsx
@@ -10,6 +10,7 @@ import {
 } from '@chakra-ui/react';
 import { CheckCircleIcon, RepeatClockIcon, TimeIcon } from '@chakra-ui/icons';
 import { format, formatRelative } from 'date-fns';
+import { parseDate } from '@/utils/date';
 import { ProjectWithMeta, Project } from '@/types';
 import { colorPrimitives } from '@/tokens/colors';
 import AppIcon from '../common/AppIcon';
@@ -177,10 +178,10 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
         )}
         <Flex justifyContent="space-between" alignItems="center" mt="auto" pt="3">
           <Text fontSize="xs" color="textSecondary">
-            Created: {project.created_at ? format(new Date(project.created_at), 'MMM d, yy') : 'N/A'}
+            Created: {project.created_at ? format(parseDate(project.created_at), 'MMM d, yy') : 'N/A'}
           </Text>
           <Text fontSize="xs" color="textSecondary">
-            Updated: {project.updated_at ? formatRelative(new Date(project.updated_at), new Date()) : 'Never'}
+            Updated: {project.updated_at ? formatRelative(parseDate(project.updated_at), new Date()) : 'Never'}
           </Text>
         </Flex>
       </VStack>

--- a/frontend/src/components/task/TaskItemDetailsSection.tsx
+++ b/frontend/src/components/task/TaskItemDetailsSection.tsx
@@ -30,6 +30,7 @@ import {
   Textarea,
 } from "@chakra-ui/react";
 import { DeleteIcon } from '@chakra-ui/icons';
+import { parseDate } from '@/utils/date';
 import TaskStatusTag from "../common/TaskStatusTag";
 import TaskProjectTag from "../common/TaskProjectTag";
 import TaskAgentTag from "../TaskAgentTag";
@@ -488,7 +489,7 @@ const TaskItemDetailsSection: React.FC<Omit<TaskItemDetailsSectionProps, 'status
                {comments.map((comment) => (
                  <Box key={comment.id} p={3} borderWidth="1px" borderRadius="md" bg="gray.50">
                    <Text fontSize="sm" mb={1}><strong>{comment.user_id || "Unknown User"}:</strong> {comment.content}</Text>
-                   <Text fontSize="xs" color="gray.500">{new Date(comment.created_at).toLocaleString()}</Text>
+                   <Text fontSize="xs" color="gray.500">{parseDate(comment.created_at).toLocaleString()}</Text>
                  </Box>
                ))}
              </VStack>

--- a/frontend/src/utils/README.md
+++ b/frontend/src/utils/README.md
@@ -18,6 +18,8 @@ graph TD
 <!-- File List Start -->
 ## File List
 
+- `date.ts`
+
 
 <!-- File List End -->
 

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -1,0 +1,11 @@
+import { parseISO } from 'date-fns';
+
+export function parseDate(value: string | number | Date): Date {
+  if (value instanceof Date) {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return new Date(value);
+  }
+  return parseISO(value);
+}


### PR DESCRIPTION
## Summary
- ensure global ISO datetime serialization in backend schemas
- add date parsing util with tests
- update UI to use new date parser

## Testing
- `npm run lint`
- `npm run test:coverage` *(fails: observer.observe is not a function)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6841c976378c832c9a67b3acde2823e5