### PR TITLE
Add snapshot tests for key components

### DIFF
--- a/frontend/src/components/__tests__/ProjectList.snapshot.test.tsx
+++ b/frontend/src/components/__tests__/ProjectList.snapshot.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, TestWrapper } from '@/__tests__/utils/test-utils';
+import ProjectList from '../project/ProjectList';
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual<typeof import('@chakra-ui/react')>('@chakra-ui/react');
+  return {
+    ...actual,
+    useToast: () => vi.fn(),
+    useColorModeValue: (light: any, dark: any) => light,
+  };
+});
+
+describe('ProjectList snapshot', () => {
+  it('renders consistently', () => {
+    const { asFragment } = render(
+      <TestWrapper>
+        <ProjectList />
+      </TestWrapper>
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/src/components/__tests__/TaskItem.snapshot.test.tsx
+++ b/frontend/src/components/__tests__/TaskItem.snapshot.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, TestWrapper } from '@/__tests__/utils/test-utils';
+import { createMockTask } from '@/__tests__/factories';
+import TaskItem from '../task/TaskItem';
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual<typeof import('@chakra-ui/react')>('@chakra-ui/react');
+  return {
+    ...actual,
+    useToast: () => vi.fn(),
+    useColorModeValue: (light: any, dark: any) => light,
+  };
+});
+
+describe('TaskItem snapshot', () => {
+  it('renders consistently', () => {
+    const task = createMockTask({
+      project_id: 'project-id',
+      task_number: 1,
+      title: 'Snapshot Task',
+      description: 'Snapshot description',
+      created_at: '2024-01-01T00:00:00.000Z',
+      updated_at: '2024-01-01T00:00:00.000Z',
+      agent_id: null,
+    });
+    const { asFragment } = render(
+      <TestWrapper>
+        <TaskItem task={task} projectName="Project" onDeleteInitiate={() => {}} />
+      </TestWrapper>
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/src/components/__tests__/__snapshots__/ProjectList.snapshot.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/ProjectList.snapshot.test.tsx.snap
@@ -1,0 +1,32 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ProjectList snapshot > renders consistently 1`] = `
+<DocumentFragment>
+  <div
+    class="css-jgsorh"
+  >
+    <div
+      class="chakra-spinner css-noztm"
+    >
+      <span
+        class="css-8b45rq"
+      >
+        Loading...
+      </span>
+    </div>
+    <p
+      class="chakra-text css-k1bh69"
+    >
+      Loading projects...
+    </p>
+  </div>
+  <span
+    hidden=""
+    id="__chakra_env"
+  />
+  <span
+    hidden=""
+    id="__chakra_env"
+  />
+</DocumentFragment>
+`;

--- a/frontend/src/components/__tests__/__snapshots__/TaskItem.snapshot.test.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/TaskItem.snapshot.test.tsx.snap
@@ -1,0 +1,124 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`TaskItem snapshot > renders consistently 1`] = `
+<DocumentFragment>
+  <div
+    class="css-1t1yp2j"
+  >
+    <div
+      class="chakra-stack css-y10l5h"
+    >
+      <div
+        class="css-1ydq2kx"
+      >
+        <label
+          class="chakra-checkbox css-1577qb8"
+        >
+          <input
+            aria-checked="false"
+            aria-label="Mark task Snapshot Task as complete"
+            class="chakra-checkbox__input"
+            style="border: 0px; clip: rect(0px, 0px, 0px, 0px); height: 1px; width: 1px; margin: -1px; padding: 0px; overflow: hidden; white-space: nowrap; position: absolute;"
+            type="checkbox"
+            value=""
+          />
+          <span
+            aria-hidden="true"
+            class="chakra-checkbox__control css-olidhu"
+          />
+        </label>
+      </div>
+      <div
+        class="chakra-stack css-1w5ylqm"
+      >
+        <div
+          class="chakra-stack css-1w5ylqm"
+        >
+          <div
+            class="css-8atqhb"
+          >
+            <p
+              class="chakra-text css-ru5nt8"
+            >
+              Snapshot Task
+            </p>
+          </div>
+          <p
+            class="chakra-text css-khfcme"
+          >
+            Snapshot description
+          </p>
+          <div
+            class="chakra-stack css-wpcv6r"
+          >
+            <div
+              class="chakra-stack css-h2mol3"
+            >
+              <span
+                class="css-4owlnz"
+              >
+                <svg
+                  class="chakra-icon chakra-icon css-l30hbq"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <g
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-width="2"
+                  >
+                    <path
+                      d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"
+                    />
+                    <path
+                      d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"
+                    />
+                  </g>
+                </svg>
+                <span
+                  class="css-1ny2kle"
+                >
+                  To Do
+                </span>
+              </span>
+            </div>
+            <div
+              class="css-0"
+            >
+              <div
+                class="chakra-spinner css-hno8u4"
+              >
+                <span
+                  class="css-8b45rq"
+                >
+                  Loading...
+                </span>
+              </div>
+              <p
+                class="chakra-text css-6n7j50"
+              >
+                Loading task details...
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <button
+      class="chakra-button css-l7xuv7"
+      type="button"
+    >
+      Archive
+    </button>
+  </div>
+  <span
+    hidden=""
+    id="__chakra_env"
+  />
+  <span
+    hidden=""
+    id="__chakra_env"
+  />
+</DocumentFragment>
+`;

--- a/frontend/src/types/error_protocol.ts
+++ b/frontend/src/types/error_protocol.ts
@@ -1,0 +1,9 @@
+export {
+  errorProtocolBaseSchema,
+  errorProtocolCreateSchema,
+  errorProtocolUpdateSchema,
+  errorProtocolSchema,
+  type ErrorProtocol,
+  type ErrorProtocolCreateData,
+  type ErrorProtocolUpdateData,
+} from './agents';

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/__tests__/setup.ts'],
     include: [
+      'src/components/__tests__/*.test.tsx',
       'src/lib/__tests__/utils.test.tsx',
       'src/store/__tests__/*.test.ts',
       'src/hooks/__tests__/*.test.tsx',


### PR DESCRIPTION
## Summary
- snapshot `TaskItem` and `ProjectList` with vitest
- store snapshots under `src/components/__tests__/__snapshots__`
- include component tests in vitest config
- add missing `error_protocol` type module used by index

## Testing
- `npx vitest run src/components/__tests__/TaskItem.snapshot.test.tsx src/components/__tests__/ProjectList.snapshot.test.tsx`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841c9758a84832c974f825b9a28b318