### PR TITLE
Add migrate and format Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup-backend setup-frontend test lint dev
+.PHONY: setup-backend setup-frontend test lint dev migrate format
 
 setup-backend:
 	python -m venv backend/.venv
@@ -21,3 +21,10 @@ lint:
 
 dev:
 	python start_system.py
+
+migrate:
+	cd backend && ../backend/.venv/bin/alembic upgrade head
+
+format:
+	cd backend && ../backend/.venv/bin/python comprehensive_flake8_fixer.py
+	cd frontend && npm run format

--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ npm install
 npm run dev
 ```
 
+### Makefile Commands
+
+The root `Makefile` provides shortcuts for common tasks:
+
+```bash
+make migrate   # apply database migrations
+make format    # auto-fix Python and frontend code style
+```
+
 ---
 
 ## 🧪 Testing


### PR DESCRIPTION
## Summary
- add `migrate` and `format` targets to Makefile
- document new targets in README

## Testing
- `make test` *(fails: ../backend/.venv/bin/pytest: not found)*
- `make lint` *(fails: ../backend/.venv/bin/flake8: not found)*
- `make format` *(fails: ../backend/.venv/bin/python: not found)*
- `make migrate` *(fails: IndentationError in alembic env)*

------
https://chatgpt.com/codex/tasks/task_e_6841c9705c5c832cb4cee5354ce18181