### PR TITLE
Implement polling hook for task updates

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -46,8 +46,6 @@ import { TaskCreateData } from "../types";
 export default function Home() {
   const error = useTaskStore((state: TaskState) => state.error);
   const fetchTasks = useTaskStore((state: TaskState) => state.fetchTasks);
-  const startPolling = useTaskStore((state: TaskState) => state.startPolling);
-  const stopPolling = useTaskStore((state: TaskState) => state.stopPolling);
   const fetchProjects = useProjectStore(
     (state: ProjectState) => state.fetchProjects,
   );
@@ -102,13 +100,9 @@ export default function Home() {
   };
 
   useEffect(() => {
-    startPolling();
     fetchAgents(0, 100); // Add default skip and limit parameters
     fetchProjects();
-    return () => {
-      stopPolling();
-    };
-  }, [startPolling, stopPolling, fetchAgents, fetchProjects]);
+  }, [fetchAgents, fetchProjects]);
 
   useEffect(() => {
     if (error) {

--- a/frontend/src/components/TaskList.tsx
+++ b/frontend/src/components/TaskList.tsx
@@ -25,12 +25,15 @@ import TaskLoading from "./TaskLoading";
 import TaskError from "./TaskError";
 import NoTasks from "./NoTasks";
 import TaskPagination from "./task/TaskPagination";
+import useTaskPolling from "@/hooks/useTaskPolling";
 
 import { applyAllFilters, groupTasksByStatus } from "./TaskList.utils";
 
 type ViewMode = "list" | "kanban";
 
 const TaskList: React.FC = () => {
+  // Start polling for task updates while this component is mounted
+  useTaskPolling();
   const tasks = useTaskStore((state) => state.tasks);
   const loading = useTaskStore((state) => state.loading);
   const error = useTaskStore((state) => state.error);

--- a/frontend/src/hooks/__tests__/useTaskPolling.test.tsx
+++ b/frontend/src/hooks/__tests__/useTaskPolling.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useTaskPolling } from '../useTaskPolling';
+import { useTaskStore } from '@/store/taskStore';
+
+vi.mock('@/store/taskStore');
+
+describe('useTaskPolling', () => {
+  const startPolling = vi.fn();
+  const stopPolling = vi.fn();
+
+  beforeEach(() => {
+    (useTaskStore as unknown as vi.Mock).mockReturnValue({
+      startPolling,
+      stopPolling,
+    });
+    vi.clearAllMocks();
+  });
+
+  it('starts polling on mount and stops on unmount', () => {
+    const { unmount } = renderHook(() => useTaskPolling());
+    expect(startPolling).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(stopPolling).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/hooks/useTaskPolling.ts
+++ b/frontend/src/hooks/useTaskPolling.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import { useTaskStore } from '@/store/taskStore';
+
+/**
+ * Start periodic polling for task updates on mount and
+ * stop polling when the component using this hook unmounts.
+ */
+export const useTaskPolling = (): void => {
+  const startPolling = useTaskStore((state) => state.startPolling);
+  const stopPolling = useTaskStore((state) => state.stopPolling);
+
+  useEffect(() => {
+    startPolling();
+    return () => {
+      stopPolling();
+    };
+  }, [startPolling, stopPolling]);
+};
+
+export default useTaskPolling;


### PR DESCRIPTION
## Summary
- add `useTaskPolling` hook to start/stop polling via store
- update `TaskList` to use the new hook
- remove polling logic from `page.tsx`
- test hook behavior with vitest

## Testing
- `npm --prefix frontend run lint` *(fails: `next` not found)*
- `npm --prefix frontend run test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e6003d08832cb44fbc448bbce319