### PR TITLE
Add memory file upload endpoint and UI

### DIFF
--- a/backend/routers/memory/__init__.py
+++ b/backend/routers/memory/__init__.py
@@ -6,6 +6,7 @@ from ...services.memory_service import MemoryService
 from ...schemas.memory import MemoryEntity, KnowledgeGraph
 from ...auth import get_current_active_user
 from ...models import User as UserModel
+from fastapi import UploadFile, File
 from .core.core import (
     router as core_router,
     UrlIngestInput,
@@ -59,6 +60,25 @@ def ingest_text_root(
         )
     except Exception as e:  # pragma: no cover - pass through any service errors
         raise HTTPException(status_code=500, detail=f"Failed to ingest text: {e}")
+
+
+@router.post("/ingest", response_model=MemoryEntity, status_code=status.HTTP_201_CREATED)
+async def ingest_file_upload(
+    file: UploadFile = File(...),
+    memory_service: MemoryService = Depends(get_memory_service),
+    current_user: UserModel = Depends(get_current_active_user),
+):
+    """Upload a file and store it as a MemoryEntity."""
+    try:
+        content = await file.read()
+        return memory_service.ingest_uploaded_file(
+            filename=file.filename,
+            content=content,
+            content_type=file.content_type or "application/octet-stream",
+            user_id=current_user.id,
+        )
+    except Exception as e:  # pragma: no cover
+        raise HTTPException(status_code=500, detail=f"Failed to ingest file: {e}")
 
 
 @router.get("/graph", response_model=KnowledgeGraph)

--- a/frontend/src/components/memory/MemoryIngestForm.tsx
+++ b/frontend/src/components/memory/MemoryIngestForm.tsx
@@ -19,7 +19,7 @@ import { memoryApi } from "@/services/api";
 const MemoryIngestForm: React.FC = () => {
   const toast = useToast();
   const [mode, setMode] = useState<"file" | "url" | "text">("file");
-  const [filePath, setFilePath] = useState("");
+  const [file, setFile] = useState<File | null>(null);
   const [url, setUrl] = useState("");
   const [text, setText] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -29,19 +29,35 @@ const MemoryIngestForm: React.FC = () => {
     setIsLoading(true);
     try {
       if (mode === "file") {
-        await memoryApi.ingestFile(filePath);
+        if (!file) throw new Error("No file selected");
+        const entity = await memoryApi.uploadFile(file);
+        toast({
+          title: "Ingestion successful",
+          description: `ID: ${entity.id}`,
+          status: "success",
+          duration: 3000,
+          isClosable: true,
+        });
       } else if (mode === "url") {
-        await memoryApi.ingestUrl(url);
+        const entity = await memoryApi.ingestUrl(url);
+        toast({
+          title: "Ingestion successful",
+          description: `ID: ${entity.id}`,
+          status: "success",
+          duration: 3000,
+          isClosable: true,
+        });
       } else {
-        await memoryApi.ingestText(text);
+        const entity = await memoryApi.ingestText(text);
+        toast({
+          title: "Ingestion successful",
+          description: `ID: ${entity.id}`,
+          status: "success",
+          duration: 3000,
+          isClosable: true,
+        });
       }
-      toast({
-        title: "Ingestion successful",
-        status: "success",
-        duration: 3000,
-        isClosable: true,
-      });
-      setFilePath("");
+      setFile(null);
       setUrl("");
       setText("");
     } catch (err) {
@@ -77,11 +93,10 @@ const MemoryIngestForm: React.FC = () => {
 
         {mode === "file" && (
           <FormControl>
-            <FormLabel>File Path</FormLabel>
+            <FormLabel>File</FormLabel>
             <Input
-              value={filePath}
-              onChange={(e) => setFilePath(e.target.value)}
-              placeholder="/path/to/file.txt"
+              type="file"
+              onChange={(e) => setFile(e.target.files?.[0] || null)}
             />
           </FormControl>
         )}

--- a/frontend/src/components/memory/__tests__/MemoryIngestForm.test.tsx
+++ b/frontend/src/components/memory/__tests__/MemoryIngestForm.test.tsx
@@ -15,6 +15,7 @@ vi.mock('@chakra-ui/react', async () => {
 vi.mock('@/services/api', () => ({
   memoryApi: {
     ingestFile: vi.fn(),
+    uploadFile: vi.fn(),
     ingestUrl: vi.fn(),
     ingestText: vi.fn(),
   },

--- a/frontend/src/services/api/memory.ts
+++ b/frontend/src/services/api/memory.ts
@@ -103,6 +103,31 @@ export const memoryApi = {
     return response.data;
   },
 
+  // Upload a file directly
+  uploadFile: async (file: File): Promise<MemoryEntity> => {
+    const formData = new FormData();
+    formData.append('file', file);
+    const headers: HeadersInit = {};
+    const token =
+      typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+    if (token) {
+      (headers as Record<string, string>).Authorization = `Bearer ${token}`;
+    }
+    const resp = await fetch(
+      buildApiUrl(API_CONFIG.ENDPOINTS.MEMORY, '/ingest'),
+      {
+        method: 'POST',
+        body: formData,
+        headers,
+      }
+    );
+    if (!resp.ok) {
+      const data = await resp.json().catch(() => ({}));
+      throw new Error(data.detail || resp.statusText);
+    }
+    return (await resp.json()) as MemoryEntity;
+  },
+
   // Ingest content directly from a URL
   ingestUrl: async (url: string): Promise<MemoryEntity> => {
     const response = await request<MemoryEntityResponse>(

--- a/frontend/src/store/__tests__/memoryStore.test.ts
+++ b/frontend/src/store/__tests__/memoryStore.test.ts
@@ -7,6 +7,7 @@ vi.mock('@/services/api', () => ({
   memoryApi: {
     listEntities: vi.fn(),
     ingestFile: vi.fn(),
+    uploadFile: vi.fn(),
     ingestUrl: vi.fn(),
     ingestText: vi.fn(),
     deleteEntity: vi.fn(),
@@ -63,6 +64,23 @@ describe('memoryStore', () => {
     expect(mockedApi.ingestFile).toHaveBeenCalledWith('/tmp/test.txt');
     expect(useMemoryStore.getState().entities[0]).toEqual(entity);
     expect(useMemoryStore.getState().ingestionLoading).toBe(false);
+  });
+
+  it('uploadFile prepends new entity', async () => {
+    const entity = {
+      id: 5,
+      entity_type: 'file',
+      content: 'c',
+      created_at: '2024',
+    };
+    (mockedApi.uploadFile as any).mockResolvedValueOnce(entity);
+
+    await act(async () => {
+      await useMemoryStore.getState().uploadFile(new File(['c'], 'c.txt'));
+    });
+
+    expect(mockedApi.uploadFile).toHaveBeenCalled();
+    expect(useMemoryStore.getState().entities[0]).toEqual(entity);
   });
 
   it('deleteEntity removes entity', async () => {

--- a/frontend/src/store/memoryStore.ts
+++ b/frontend/src/store/memoryStore.ts
@@ -7,6 +7,7 @@ import type { MemoryEntity, MemoryEntityFilters } from '@/types/memory';
 interface MemoryActions {
   fetchEntities: (filters?: MemoryEntityFilters) => Promise<void>;
   ingestFile: (filePath: string) => Promise<void>;
+  uploadFile: (file: File) => Promise<void>;
   ingestUrl: (url: string) => Promise<void>;
   ingestText: (text: string) => Promise<void>;
   deleteEntity: (id: number) => Promise<void>;
@@ -46,6 +47,20 @@ const actionsCreator = (
     set({ ingestionLoading: true, ingestionError: null });
     try {
       const entity = await memoryApi.ingestFile(filePath);
+      set((state) => ({
+        entities: [entity, ...state.entities],
+        ingestionLoading: false,
+      }));
+    } catch (err) {
+      handleApiError(err);
+      set({ ingestionError: err instanceof Error ? err.message : String(err), ingestionLoading: false });
+      throw err;
+    }
+  },
+  uploadFile: async (file: File) => {
+    set({ ingestionLoading: true, ingestionError: null });
+    try {
+      const entity = await memoryApi.uploadFile(file);
       set((state) => ({
         entities: [entity, ...state.entities],
         ingestionLoading: false,


### PR DESCRIPTION
## Summary
- support file upload ingestion in backend `/api/memory/ingest`
- expose `uploadFile` API helper
- add upload actions to memory store
- update memory ingest form to use file selector and show memory ID
- adjust unit tests

## Testing
- `pytest -q` *(fails: AttributeError, IndentationError)*
- `npm --prefix frontend run test:components` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e5fdcf2c832c88e3eafd557008dc