### PR TITLE
Add status transition admin feature

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -54,6 +54,7 @@ def include_app_routers(app: FastAPI):
         mcp,
         rules,
         project_templates,
+        status_transitions,
         audit_logs,
         workflows,
     )
@@ -65,6 +66,7 @@ def include_app_routers(app: FastAPI):
     app.include_router(auth_router, prefix="/api/v1", tags=["auth"])
     app.include_router(projects.router, prefix="/api/v1/projects", tags=["projects"])
     app.include_router(tasks.router, prefix="/api/v1/tasks", tags=["tasks"])
+    app.include_router(status_transitions.router, prefix="/api/v1/status-transitions", tags=["status-transitions"])
     app.include_router(comments.router, prefix="/api/comments", tags=["comments"])
     app.include_router(agents.router, prefix="/api/v1/agents", tags=["agents"])
     app.include_router(memory.router, prefix="/api/memory", tags=["memory"])

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -44,6 +44,7 @@ from .agent_verification_requirement import AgentVerificationRequirement
 # Import task-related models
 from .task_dependency import TaskDependency
 from .task_file_association import TaskFileAssociation
+from .status_transition import StatusTransition
 
 # Import comment model
 from .comment import Comment
@@ -81,6 +82,7 @@ __all__ = [
     'TaskStatus',
     'TaskDependency',
     'TaskFileAssociation',
+    'StatusTransition',
 
     # Agent models
     'AgentRule',

--- a/backend/models/status_transition.py
+++ b/backend/models/status_transition.py
@@ -1,0 +1,13 @@
+from sqlalchemy import Integer, Enum
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base
+from ..enums import TaskStatusEnum
+
+class StatusTransition(Base):
+    """Allowed status transitions for tasks."""
+    __tablename__ = "status_transitions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    from_status: Mapped[TaskStatusEnum] = mapped_column(Enum(TaskStatusEnum))
+    to_status: Mapped[TaskStatusEnum] = mapped_column(Enum(TaskStatusEnum))

--- a/backend/routers/status_transitions.py
+++ b/backend/routers/status_transitions.py
@@ -1,0 +1,44 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from backend.database import get_db
+from backend.schemas.status_transition import StatusTransition, StatusTransitionCreate
+from backend.services.status_transition_service import StatusTransitionService
+from backend.auth import get_current_active_user, RoleChecker
+from backend.enums import UserRoleEnum
+from backend.models import User as UserModel
+
+router = APIRouter(
+    prefix="/status-transitions",
+    tags=["StatusTransitions"],
+    dependencies=[Depends(RoleChecker([UserRoleEnum.ADMIN]))],
+)
+
+def get_service(db: Session = Depends(get_db)) -> StatusTransitionService:
+    return StatusTransitionService(db)
+
+@router.get("/", response_model=list[StatusTransition])
+async def list_transitions(
+    service: StatusTransitionService = Depends(get_service),
+    current_user: UserModel = Depends(get_current_active_user),
+):
+    return service.get_transitions()
+
+@router.post("/", response_model=StatusTransition)
+async def create_transition(
+    transition: StatusTransitionCreate,
+    service: StatusTransitionService = Depends(get_service),
+    current_user: UserModel = Depends(get_current_active_user),
+):
+    return service.create_transition(transition)
+
+@router.delete("/{transition_id}")
+async def delete_transition(
+    transition_id: int,
+    service: StatusTransitionService = Depends(get_service),
+    current_user: UserModel = Depends(get_current_active_user),
+):
+    success = service.delete_transition(transition_id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Transition not found")
+    return {"message": "Deleted"}

--- a/backend/schemas/status_transition.py
+++ b/backend/schemas/status_transition.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel, ConfigDict
+from ..enums import TaskStatusEnum
+
+class StatusTransitionBase(BaseModel):
+    from_status: TaskStatusEnum
+    to_status: TaskStatusEnum
+
+class StatusTransitionCreate(StatusTransitionBase):
+    pass
+
+class StatusTransition(StatusTransitionBase):
+    id: int
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/services/status_transition_service.py
+++ b/backend/services/status_transition_service.py
@@ -1,0 +1,27 @@
+from sqlalchemy.orm import Session
+from typing import List, Optional
+
+from ..models import StatusTransition
+from ..schemas.status_transition import StatusTransitionCreate
+
+class StatusTransitionService:
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def get_transitions(self) -> List[StatusTransition]:
+        return self.db.query(StatusTransition).all()
+
+    def create_transition(self, transition: StatusTransitionCreate) -> StatusTransition:
+        db_obj = StatusTransition(**transition.model_dump())
+        self.db.add(db_obj)
+        self.db.commit()
+        self.db.refresh(db_obj)
+        return db_obj
+
+    def delete_transition(self, transition_id: int) -> bool:
+        obj = self.db.query(StatusTransition).get(transition_id)
+        if not obj:
+            return False
+        self.db.delete(obj)
+        self.db.commit()
+        return True

--- a/frontend/src/app/status-transitions/page.tsx
+++ b/frontend/src/app/status-transitions/page.tsx
@@ -1,0 +1,126 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  TableContainer,
+  Select,
+  Button,
+  Flex,
+} from '@chakra-ui/react';
+import { statusTransitionsApi } from '@/services/api/statusTransitions';
+import { TaskStatus } from '@/types/task';
+import { StatusTransition } from '@/types/statusTransition';
+import { handleApiError } from '@/lib/apiErrorHandler';
+
+const StatusTransitionsPage: React.FC = () => {
+  const [transitions, setTransitions] = useState<StatusTransition[]>([]);
+  const [fromStatus, setFromStatus] = useState<TaskStatus | ''>('');
+  const [toStatus, setToStatus] = useState<TaskStatus | ''>('');
+  const [loading, setLoading] = useState(false);
+
+  const fetchTransitions = async () => {
+    try {
+      const result = await statusTransitionsApi.list();
+      setTransitions(result);
+    } catch (err) {
+      handleApiError(err, 'Failed to load transitions');
+    }
+  };
+
+  useEffect(() => {
+    fetchTransitions();
+  }, []);
+
+  const handleAdd = async () => {
+    if (!fromStatus || !toStatus) return;
+    setLoading(true);
+    try {
+      await statusTransitionsApi.create(fromStatus as TaskStatus, toStatus as TaskStatus);
+      setFromStatus('');
+      setToStatus('');
+      await fetchTransitions();
+    } catch (err) {
+      handleApiError(err, 'Failed to add transition');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    setLoading(true);
+    try {
+      await statusTransitionsApi.remove(id);
+      await fetchTransitions();
+    } catch (err) {
+      handleApiError(err, 'Failed to delete transition');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box p="4">
+      <Flex mb="4" gap="2">
+        <Select
+          placeholder="From"
+          value={fromStatus}
+          onChange={(e) => setFromStatus(e.target.value as TaskStatus)}
+          size="sm"
+        >
+          {Object.values(TaskStatus).map((s) => (
+            <option key={`from-${s}`} value={s}>
+              {s}
+            </option>
+          ))}
+        </Select>
+        <Select
+          placeholder="To"
+          value={toStatus}
+          onChange={(e) => setToStatus(e.target.value as TaskStatus)}
+          size="sm"
+        >
+          {Object.values(TaskStatus).map((s) => (
+            <option key={`to-${s}`} value={s}>
+              {s}
+            </option>
+          ))}
+        </Select>
+        <Button size="sm" onClick={handleAdd} isLoading={loading}>
+          Add
+        </Button>
+      </Flex>
+      <TableContainer>
+        <Table size="sm">
+          <Thead>
+            <Tr>
+              <Th>From</Th>
+              <Th>To</Th>
+              <Th>Actions</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {transitions.map((t) => (
+              <Tr key={t.id} data-testid={`row-${t.id}`}>
+                <Td>{t.from_status}</Td>
+                <Td>{t.to_status}</Td>
+                <Td>
+                  <Button size="xs" onClick={() => handleDelete(t.id)} isLoading={loading}>
+                    Delete
+                  </Button>
+                </Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+};
+
+export default StatusTransitionsPage;

--- a/frontend/src/services/api/config.ts
+++ b/frontend/src/services/api/config.ts
@@ -19,6 +19,7 @@ export const API_CONFIG = {
     RULES: "/rules",
     MCP_TOOLS: "/mcp-tools",
     VERIFICATION_REQUIREMENTS: "/verification-requirements",
+    STATUS_TRANSITIONS: "/status-transitions",
   },
 } as const;
 

--- a/frontend/src/services/api/statusTransitions.ts
+++ b/frontend/src/services/api/statusTransitions.ts
@@ -1,0 +1,21 @@
+import { request } from './request';
+import { buildApiUrl, API_CONFIG } from './config';
+import { StatusTransition } from '@/types/statusTransition';
+import { TaskStatus } from '@/types/task';
+
+export const statusTransitionsApi = {
+  async list(): Promise<StatusTransition[]> {
+    return request<StatusTransition[]>(buildApiUrl(API_CONFIG.ENDPOINTS.STATUS_TRANSITIONS));
+  },
+  async create(from_status: TaskStatus, to_status: TaskStatus): Promise<StatusTransition> {
+    return request<StatusTransition>(buildApiUrl(API_CONFIG.ENDPOINTS.STATUS_TRANSITIONS), {
+      method: 'POST',
+      body: JSON.stringify({ from_status, to_status }),
+    });
+  },
+  async remove(id: number): Promise<{ message: string }> {
+    return request<{ message: string }>(buildApiUrl(API_CONFIG.ENDPOINTS.STATUS_TRANSITIONS, `/${id}`), {
+      method: 'DELETE',
+    });
+  },
+};

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -12,6 +12,7 @@ export * from './project_template';
 export * from './agent_prompt_template';
 export * from './handoff';
 export * from './verification_requirement';
+export * from './statusTransition';
 
 // Common types used across the application
 // Canonical shared sort direction type for all entities

--- a/frontend/src/types/statusTransition.ts
+++ b/frontend/src/types/statusTransition.ts
@@ -1,0 +1,7 @@
+import { TaskStatus } from './task';
+
+export interface StatusTransition {
+  id: number;
+  from_status: TaskStatus;
+  to_status: TaskStatus;
+}

--- a/scripts/generate_ts_enums.py
+++ b/scripts/generate_ts_enums.py
@@ -38,6 +38,23 @@ def main() -> None:
     out_path.write_text("\n".join(lines) + "\n")
     print(f"generated {out_path}")
 
+    # Update statusUtils.ts with any missing statuses
+    task_statuses = [member.value for member in getattr(module, "TaskStatusEnum")]
+    utils_path = Path("frontend/src/lib/statusUtils.ts")
+    if utils_path.exists():
+        utils_text = utils_path.read_text()
+        for status in task_statuses:
+            if status not in utils_text:
+                # Append to StatusID union and STATUS_MAP with generic attrs
+                utils_text = utils_text.replace(
+                    "| \"PENDING_RECOVERY_ATTEMPT\";",
+                    f"| \"PENDING_RECOVERY_ATTEMPT\"\n  | \"{status}\"\n  | \"{status.upper().replace(' ', '_')}\";",
+                )
+                insert_index = utils_text.find("} as const")
+                snippet = f"  \"{status}\": {{\n    id: \"{status}\",\n    displayName: \"{status}\",\n    category: \"todo\",\n    description: \"\",\n    colorScheme: \"gray\",\n    icon: \"InfoIcon\",\n    isTerminal: False,\n    isDynamic: False,\n  }},\n  {status.upper().replace(' ', '_')}: {{\n    id: \"{status}\",\n    displayName: \"{status}\",\n    category: \"todo\",\n    description: \"\",\n    colorScheme: \"gray\",\n    icon: \"InfoIcon\",\n    isTerminal: False,\n    isDynamic: False,\n  }},\n"
+                utils_text = utils_text[:insert_index] + snippet + utils_text[insert_index:]
+        utils_path.write_text(utils_text)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- add model and API for task status transitions
- update enum generation script to sync new statuses
- export new endpoint in API config
- add admin page to manage transitions

## Testing
- `flake8 backend`
- `pytest backend` *(fails: ModuleNotFoundError)*
- `npm run lint`
- `npm run test:coverage` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6841e5fcc6ac832cbd668f28a4bf122c