### PR TITLE
feat: add reusable DataTable component

### DIFF
--- a/frontend/src/app/user-roles/page.tsx
+++ b/frontend/src/app/user-roles/page.tsx
@@ -2,13 +2,6 @@
 import React, { useEffect, useState } from 'react';
 import {
   Box,
-  Table,
-  Thead,
-  Tbody,
-  Tr,
-  Th,
-  Td,
-  TableContainer,
   Select,
   Button,
   Flex,
@@ -17,6 +10,7 @@ import { getUsers } from '@/services/api/users';
 import { userRolesApi } from '@/services/api/user_roles';
 import { User, UserRole } from '@/types/user';
 import { handleApiError } from '@/lib/apiErrorHandler';
+import DataTable, { Column, Action } from '@/components/common/DataTable';
 
 const UserRolesPage: React.FC = () => {
   const [users, setUsers] = useState<User[]>([]);
@@ -65,72 +59,68 @@ const UserRolesPage: React.FC = () => {
     }
   };
 
+  const columns: Column<User>[] = [
+    { header: 'Username', accessor: 'username' },
+    {
+      header: 'Roles',
+      accessor: (u) => (
+        <Flex wrap="wrap" gap="2">
+          {u.user_roles.map((r) => (
+            <Button
+              key={r.role_name}
+              size="xs"
+              onClick={() => handleRemove(u.id, r.role_name)}
+              data-testid={`remove-${u.id}-${r.role_name}`}
+            >
+              {r.role_name} ✕
+            </Button>
+          ))}
+        </Flex>
+      ),
+    },
+  ];
+
+  const actions: Action<User>[] = [
+    {
+      label: 'assign',
+      render: (u) => (
+        <Flex>
+          <Select
+            size="sm"
+            value={selectedRoles[u.id] || ''}
+            onChange={(e) =>
+              setSelectedRoles((prev) => ({
+                ...prev,
+                [u.id]: e.target.value as UserRole,
+              }))
+            }
+            placeholder="Select role"
+            mr="2"
+            data-testid={`select-${u.id}`}
+          >
+            {Object.values(UserRole).map((r) => (
+              <option key={r} value={r}>
+                {r}
+              </option>
+            ))}
+          </Select>
+          <Button
+            size="sm"
+            onClick={() => handleAssign(u.id)}
+            isDisabled={!selectedRoles[u.id]}
+            isLoading={loading}
+            data-testid={`assign-${u.id}`}
+          >
+            Add
+          </Button>
+        </Flex>
+      ),
+    },
+  ];
+
   return (
     <Box p="4">
-      <TableContainer>
-        <Table variant="simple" size="sm">
-          <Thead>
-            <Tr>
-              <Th>Username</Th>
-              <Th>Roles</Th>
-              <Th>Assign Role</Th>
-            </Tr>
-          </Thead>
-          <Tbody>
-            {users.map((u) => (
-              <Tr key={u.id} data-testid="user-row">
-                <Td>{u.username}</Td>
-                <Td>
-                  <Flex wrap="wrap" gap="2">
-                    {u.user_roles.map((r) => (
-                      <Button
-                        key={r.role_name}
-                        size="xs"
-                        onClick={() => handleRemove(u.id, r.role_name)}
-                        data-testid={`remove-${u.id}-${r.role_name}`}
-                      >
-                        {r.role_name} ✕
-                      </Button>
-                    ))}
-                  </Flex>
-                </Td>
-                <Td>
-                  <Flex>
-                    <Select
-                      size="sm"
-                      value={selectedRoles[u.id] || ''}
-                      onChange={(e) =>
-                        setSelectedRoles((prev) => ({
-                          ...prev,
-                          [u.id]: e.target.value as UserRole,
-                        }))
-                      }
-                      placeholder="Select role"
-                      mr="2"
-                      data-testid={`select-${u.id}`}
-                    >
-                      {Object.values(UserRole).map((r) => (
-                        <option key={r} value={r}>
-                          {r}
-                        </option>
-                      ))}
-                    </Select>
-                    <Button
-                      size="sm"
-                      onClick={() => handleAssign(u.id)}
-                      isDisabled={!selectedRoles[u.id]}
-                      isLoading={loading}
-                      data-testid={`assign-${u.id}`}
-                    >
-                      Add
-                    </Button>
-                  </Flex>
-                </Td>
-              </Tr>
-            ))}
-          </Tbody>
-        </Table>
-      </TableContainer>
+      <DataTable data={users} columns={columns} actions={actions} />
     </Box>
   );
 };

--- a/frontend/src/components/common/DataTable.tsx
+++ b/frontend/src/components/common/DataTable.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import {
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  TableContainer,
+  Box,
+} from '@chakra-ui/react';
+import TaskPagination from '../task/TaskPagination';
+
+export interface Column<T> {
+  header: string;
+  accessor: keyof T | ((row: T) => React.ReactNode);
+  isNumeric?: boolean;
+}
+
+export interface Action<T> {
+  label: string;
+  render: (row: T) => React.ReactNode;
+}
+
+export interface PaginationProps {
+  currentPage: number;
+  itemsPerPage: number;
+  totalItems: number;
+  onPrevious: () => void;
+  onNext: () => void;
+}
+
+interface DataTableProps<T> {
+  data: T[];
+  columns: Column<T>[];
+  actions?: Action<T>[];
+  pagination?: PaginationProps;
+  containerProps?: React.ComponentProps<typeof Box>;
+}
+
+export function DataTable<T extends { id?: string | number }>({
+  data,
+  columns,
+  actions,
+  pagination,
+  containerProps,
+}: DataTableProps<T>) {
+  return (
+    <Box {...containerProps}>
+      <TableContainer>
+        <Table variant="simple" size="sm">
+          <Thead>
+            <Tr>
+              {columns.map((col) => (
+                <Th key={col.header} isNumeric={col.isNumeric}>
+                  {col.header}
+                </Th>
+              ))}
+              {actions && <Th>Actions</Th>}
+            </Tr>
+          </Thead>
+          <Tbody>
+            {data.map((row, idx) => (
+              <Tr key={row.id ?? idx} data-testid="table-row">
+                {columns.map((col) => (
+                  <Td key={String(col.header)} isNumeric={col.isNumeric}>
+                    {typeof col.accessor === 'function'
+                      ? col.accessor(row)
+                      : (row as any)[col.accessor]}
+                  </Td>
+                ))}
+                {actions && (
+                  <Td>
+                    {actions.map((action) => (
+                      <React.Fragment key={action.label}>
+                        {action.render(row)}
+                      </React.Fragment>
+                    ))}
+                  </Td>
+                )}
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      </TableContainer>
+      {pagination && (
+        <TaskPagination
+          currentPage={pagination.currentPage}
+          itemsPerPage={pagination.itemsPerPage}
+          totalItems={pagination.totalItems}
+          onPrevious={pagination.onPrevious}
+          onNext={pagination.onNext}
+        />
+      )}
+    </Box>
+  );
+}
+
+export default DataTable;

--- a/frontend/src/components/template/TemplateList.tsx
+++ b/frontend/src/components/template/TemplateList.tsx
@@ -7,16 +7,11 @@ import {
   Flex,
   Heading,
   IconButton,
-  Table,
-  Tbody,
-  Td,
-  Th,
-  Thead,
-  Tr,
   useToast,
 } from '@chakra-ui/react';
 import { DeleteIcon, EditIcon } from '@chakra-ui/icons';
 import { useTemplateStore } from '@/store/templateStore';
+import DataTable, { Column, Action } from '../common/DataTable';
 
 const TemplateList: React.FC = () => {
   const templates = useTemplateStore((s) => s.templates);
@@ -42,6 +37,38 @@ const TemplateList: React.FC = () => {
     }
   };
 
+  const columns: Column<typeof templates[number]>[] = [
+    { header: 'Name', accessor: 'name' },
+    { header: 'Description', accessor: 'description' },
+  ];
+
+  const actions: Action<typeof templates[number]>[] = [
+    {
+      label: 'edit',
+      render: (t) => (
+        <IconButton
+          as={Link}
+          href={`/templates/${t.id}/edit`}
+          aria-label="Edit"
+          icon={<EditIcon />}
+          size="sm"
+          mr="2"
+        />
+      ),
+    },
+    {
+      label: 'delete',
+      render: (t) => (
+        <IconButton
+          aria-label="Delete"
+          icon={<DeleteIcon />}
+          size="sm"
+          onClick={() => handleDelete(t.id)}
+        />
+      ),
+    },
+  ];
+
   return (
     <Box p="4">
       <Flex justify="space-between" align="center" mb="4">
@@ -50,39 +77,7 @@ const TemplateList: React.FC = () => {
           Create Template
         </Button>
       </Flex>
-      <Table variant="simple">
-        <Thead>
-          <Tr>
-            <Th>Name</Th>
-            <Th>Description</Th>
-            <Th>Actions</Th>
-          </Tr>
-        </Thead>
-        <Tbody>
-          {templates.map((t) => (
-            <Tr key={t.id} data-testid="template-row">
-              <Td>{t.name}</Td>
-              <Td>{t.description}</Td>
-              <Td>
-                <IconButton
-                  as={Link}
-                  href={`/templates/${t.id}/edit`}
-                  aria-label="Edit"
-                  icon={<EditIcon />}
-                  size="sm"
-                  mr="2"
-                />
-                <IconButton
-                  aria-label="Delete"
-                  icon={<DeleteIcon />}
-                  size="sm"
-                  onClick={() => handleDelete(t.id)}
-                />
-              </Td>
-            </Tr>
-          ))}
-        </Tbody>
-      </Table>
+      <DataTable data={templates} columns={columns} actions={actions} />
     </Box>
   );
 };


### PR DESCRIPTION
## Summary
- create `DataTable` component for generic table layouts
- refactor `TemplateList` to use `DataTable`
- refactor `user-roles` page to reuse `DataTable`

## Testing
- `npm run lint`
- `npm run test:coverage` *(fails: Command failed with exit code 2)*

------
https://chatgpt.com/codex/tasks/task_e_6841e5fbcb94832c86ab9ab83407ddea