### PR TITLE
Add template detail page

### DIFF
--- a/frontend/src/app/templates/README.md
+++ b/frontend/src/app/templates/README.md
@@ -6,6 +6,7 @@ This directory contains pages for managing project templates.
 - `new/page.tsx` – Form for creating a template.
 - `[templateId]/edit/page.tsx` – Edit an existing template.
 - `[templateId]/delete/page.tsx` – Deletes a template then redirects back to the list.
+- `[templateId]/page.tsx` – View template details.
 
 <!-- File List Start -->
 
@@ -15,5 +16,6 @@ This directory contains pages for managing project templates.
 - `new/page.tsx`
 - `[templateId]/edit/page.tsx`
 - `[templateId]/delete/page.tsx`
+- `[templateId]/page.tsx`
 
 <!-- File List End -->

--- a/frontend/src/app/templates/[templateId]/page.tsx
+++ b/frontend/src/app/templates/[templateId]/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+import React from 'react';
+import TemplateDetail from '@/components/template/TemplateDetail';
+
+const TemplateDetailPage: React.FC = () => {
+  return <TemplateDetail />;
+};
+
+export default TemplateDetailPage;

--- a/frontend/src/components/template/README.md
+++ b/frontend/src/components/template/README.md
@@ -4,14 +4,16 @@ This directory contains components for managing project templates in the UI.
 
 - `TemplateList.tsx` – Displays a table of templates with actions to edit or delete.
   It relies on `useTemplateStore` for data fetching and mutations.
+- `TemplateDetail.tsx` – Shows a single template fetched from the API.
 
 Additional form components for creating and editing templates reside in
 `frontend/src/components/forms/`.
 
 <!-- File List Start -->
+
 ## File List
 
 - `TemplateList.tsx`
+- `TemplateDetail.tsx`
 
 <!-- File List End -->
-

--- a/frontend/src/components/template/TemplateDetail.tsx
+++ b/frontend/src/components/template/TemplateDetail.tsx
@@ -1,0 +1,56 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { Box, Button, Code, Heading, Text } from '@chakra-ui/react';
+import { projectTemplatesApi } from '@/services/api';
+import { ProjectTemplate } from '@/types/project_template';
+
+const TemplateDetail: React.FC = () => {
+  const params = useParams();
+  const router = useRouter();
+  const templateId = Array.isArray(params.templateId)
+    ? params.templateId[0]
+    : (params.templateId as string);
+
+  const [template, setTemplate] = useState<ProjectTemplate | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchTemplate = async () => {
+      try {
+        const data = await projectTemplatesApi.get(templateId);
+        setTemplate(data);
+      } catch (err) {
+        setError('Failed to load template');
+        console.error(err);
+      }
+    };
+    if (templateId) fetchTemplate();
+  }, [templateId]);
+
+  if (error) return <p>{error}</p>;
+  if (!template) return <p>Loading...</p>;
+
+  return (
+    <Box p="4">
+      <Heading size="md" mb="2">
+        {template.name}
+      </Heading>
+      {template.description && <Text mb="4">{template.description}</Text>}
+      <Heading size="sm" mb="2">
+        Template Data
+      </Heading>
+      <Code display="block" whiteSpace="pre" p="2" mb="4">
+        {JSON.stringify(template.template_data, null, 2)}
+      </Code>
+      <Button
+        onClick={() => router.push(`/templates/${template.id}/edit`)}
+        colorScheme="blue"
+      >
+        Edit Template
+      </Button>
+    </Box>
+  );
+};
+
+export default TemplateDetail;

--- a/frontend/src/components/template/__tests__/TemplateDetail.test.tsx
+++ b/frontend/src/components/template/__tests__/TemplateDetail.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, TestWrapper } from '@/__tests__/utils/test-utils';
+import TemplateDetail from '../TemplateDetail';
+import { projectTemplatesApi } from '@/services/api';
+
+vi.mock('@/services/api', () => ({
+  projectTemplatesApi: {
+    get: vi.fn(),
+  },
+}));
+
+const mockedApi = vi.mocked(projectTemplatesApi);
+
+describe('TemplateDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedApi.get.mockResolvedValue({
+      id: 't1',
+      name: 'Temp',
+      description: '',
+      template_data: {},
+      created_at: '',
+      updated_at: '',
+    });
+  });
+
+  it('renders fetched template', async () => {
+    render(
+      <TestWrapper>
+        <TemplateDetail />
+      </TestWrapper>
+    );
+    expect(await screen.findByText('Temp')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add detail page for project templates
- expose TemplateDetail component and tests
- document new page and component

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend run test:components` *(fails: No test files found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6841e5f9d3c4832ca8287ce0d91ebcdb