### PR TITLE
Add rule template selection to agent detail

### DIFF
--- a/frontend/src/app/agents/[agentId]/README.md
+++ b/frontend/src/app/agents/[agentId]/README.md
@@ -1,0 +1,11 @@
+# Agent Detail Page (`frontend/src/app/agents/[agentId]`)
+
+This directory contains the page component for displaying the details of a specific agent, identified by its `agentId` in the URL. It renders the `AgentDetail` component which allows viewing the agent information and applying rule templates.
+
+<!-- File List Start -->
+
+## File List
+
+- `page.tsx`
+
+<!-- File List End -->

--- a/frontend/src/app/agents/[agentId]/page.tsx
+++ b/frontend/src/app/agents/[agentId]/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+import React from 'react';
+import AgentDetail from '@/components/agent/AgentDetail';
+
+const AgentDetailPage: React.FC = () => {
+  return <AgentDetail />;
+};
+
+export default AgentDetailPage;

--- a/frontend/src/components/agent/AgentDetail.tsx
+++ b/frontend/src/components/agent/AgentDetail.tsx
@@ -1,0 +1,92 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import {
+  Box,
+  Heading,
+  Select,
+  Button,
+  VStack,
+  useToast,
+} from '@chakra-ui/react';
+import { getAgentById } from '@/services/api/agents';
+import { rulesApi } from '@/services/api/rules';
+import type { Agent } from '@/types/agent';
+import type { AgentPromptTemplate } from '@/types/agent_prompt_template';
+
+const AgentDetail: React.FC = () => {
+  const { agentId } = useParams<{ agentId: string }>();
+  const toast = useToast();
+  const [agent, setAgent] = useState<Agent | null>(null);
+  const [templates, setTemplates] = useState<AgentPromptTemplate[]>([]);
+  const [selectedTemplate, setSelectedTemplate] = useState('');
+
+  useEffect(() => {
+    if (!agentId) return;
+    const fetchData = async () => {
+      try {
+        const [agentData, tmplData] = await Promise.all([
+          getAgentById(agentId),
+          rulesApi.templates.list(),
+        ]);
+        setAgent(agentData);
+        setTemplates(tmplData);
+      } catch (err) {
+        toast({
+          title: 'Failed to load agent',
+          description: err instanceof Error ? err.message : String(err),
+          status: 'error',
+          duration: 5000,
+        });
+      }
+    };
+    fetchData();
+  }, [agentId, toast]);
+
+  const handleApply = async () => {
+    if (!agentId || !selectedTemplate) return;
+    try {
+      await rulesApi.templates.apply(agentId, selectedTemplate);
+      toast({ title: 'Template applied', status: 'success', duration: 3000 });
+    } catch (err) {
+      toast({
+        title: 'Failed to apply template',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+      });
+    }
+  };
+
+  if (!agent) return <div>Loading...</div>;
+
+  return (
+    <Box p="4">
+      <Heading size="md" mb="4">
+        Agent: {agent.name}
+      </Heading>
+      <VStack align="start" spacing="4">
+        <Select
+          placeholder="Select template"
+          value={selectedTemplate}
+          onChange={(e) => setSelectedTemplate(e.target.value)}
+        >
+          {templates.map((t) => (
+            <option key={t.id} value={t.id}>
+              {t.template_name}
+            </option>
+          ))}
+        </Select>
+        <Button
+          colorScheme="blue"
+          onClick={handleApply}
+          isDisabled={!selectedTemplate}
+        >
+          Apply Template
+        </Button>
+      </VStack>
+    </Box>
+  );
+};
+
+export default AgentDetail;

--- a/frontend/src/components/agent/README.md
+++ b/frontend/src/components/agent/README.md
@@ -29,6 +29,7 @@ graph TD
 - `AgentListHeader.tsx`
 - `CliPromptModal.tsx`
 - `EditAgentModal.tsx`
+- `AgentDetail.tsx`
 
 <!-- File List End -->
 

--- a/frontend/src/components/agent/__tests__/AgentDetail.test.tsx
+++ b/frontend/src/components/agent/__tests__/AgentDetail.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  TestWrapper,
+} from '@/__tests__/utils/test-utils';
+import AgentDetail from '../AgentDetail';
+import { rulesApi } from '@/services/api/rules';
+import { getAgentById } from '@/services/api/agents';
+
+const applyMock = vi.fn();
+const listMock = vi.fn();
+vi.mock('@/services/api/rules', () => ({
+  rulesApi: { templates: { list: listMock, apply: applyMock } },
+}));
+const getMock = vi.fn();
+vi.mock('@/services/api/agents', () => ({
+  getAgentById: getMock,
+}));
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ agentId: 'a1' }),
+}));
+
+const toastMock = vi.fn();
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual('@chakra-ui/react');
+  return { ...actual, useToast: () => toastMock };
+});
+
+describe('AgentDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getMock.mockResolvedValue({ id: 'a1', name: 'Agent One' });
+    listMock.mockResolvedValue([
+      { id: 't1', template_name: 'Temp1', template_content: '' },
+    ]);
+  });
+
+  it('applies template on click', async () => {
+    render(<AgentDetail />, { wrapper: TestWrapper });
+
+    await screen.findByText(/Agent: Agent One/);
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 't1' } });
+    fireEvent.click(screen.getByRole('button', { name: /Apply Template/i }));
+
+    await waitFor(() => expect(applyMock).toHaveBeenCalledWith('a1', 't1'));
+  });
+});


### PR DESCRIPTION
## Summary
- show agent details in new page and load available rule templates
- apply selected template via rules API
- document new AgentDetail component
- add basic test for template attachment

## Testing
- `npm run fix` *(fails: cannot find module '@eslint/eslintrc')*
- `npm run format`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm run test:coverage` *(fails: observer.observe is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6841e5f8181c832ca1a9522914043456