### PR TITLE
Add rule management pages

### DIFF
--- a/frontend/src/app/rules/README.md
+++ b/frontend/src/app/rules/README.md
@@ -1,0 +1,22 @@
+# Rule Pages (`frontend/src/app/rules/`)
+
+This directory contains pages for managing rule templates and universal mandates.
+
+- `templates/page.tsx` – Lists all rule templates using `RuleTemplateList`.
+- `templates/new/page.tsx` – Form for creating a rule template.
+- `templates/[templateId]/edit/page.tsx` – Edit an existing template.
+- `mandates/page.tsx` – Lists universal mandates using `UniversalMandateList`.
+- `mandates/new/page.tsx` – Form for creating a mandate.
+- `mandates/[mandateId]/edit/page.tsx` – Edit an existing mandate.
+
+<!-- File List Start -->
+
+## File List
+- `templates/page.tsx`
+- `templates/new/page.tsx`
+- `templates/[templateId]/edit/page.tsx`
+- `mandates/page.tsx`
+- `mandates/new/page.tsx`
+- `mandates/[mandateId]/edit/page.tsx`
+
+<!-- File List End -->

--- a/frontend/src/app/rules/mandates/[mandateId]/edit/page.tsx
+++ b/frontend/src/app/rules/mandates/[mandateId]/edit/page.tsx
@@ -1,0 +1,55 @@
+'use client';
+import React, { useEffect } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import { Button } from '@chakra-ui/react';
+import EditUniversalMandateForm from '@/components/forms/EditUniversalMandateForm';
+import { useUniversalMandateStore } from '@/store/universalMandateStore';
+
+const EditMandatePage: React.FC = () => {
+  const params = useParams();
+  const mandateId = Array.isArray(params.mandateId)
+    ? params.mandateId[0]
+    : (params.mandateId as string);
+  const { mandates, fetchMandates, updateMandate, removeMandate } =
+    useUniversalMandateStore((s) => ({
+      mandates: s.mandates,
+      fetchMandates: s.fetchMandates,
+      updateMandate: s.updateMandate,
+      removeMandate: s.removeMandate,
+    }));
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!mandates.length) fetchMandates();
+  }, [fetchMandates, mandates.length]);
+
+  const mandate = mandates.find((m) => m.id === mandateId);
+  if (!mandate) {
+    return <p>Loading...</p>;
+  }
+
+  const handleSubmit = async (data: any) => {
+    await updateMandate(mandateId, data);
+    router.push('/rules/mandates');
+  };
+
+  const handleDelete = async () => {
+    await removeMandate(mandateId);
+    router.push('/rules/mandates');
+  };
+
+  return (
+    <>
+      <EditUniversalMandateForm
+        mandate={mandate}
+        onSubmit={handleSubmit}
+        onCancel={() => router.push('/rules/mandates')}
+      />
+      <Button colorScheme="red" mt="4" onClick={handleDelete}>
+        Delete Mandate
+      </Button>
+    </>
+  );
+};
+
+export default EditMandatePage;

--- a/frontend/src/app/rules/mandates/new/page.tsx
+++ b/frontend/src/app/rules/mandates/new/page.tsx
@@ -1,0 +1,24 @@
+'use client';
+import React from 'react';
+import { useRouter } from 'next/navigation';
+import AddUniversalMandateForm from '@/components/forms/AddUniversalMandateForm';
+import { useUniversalMandateStore } from '@/store/universalMandateStore';
+
+const NewMandatePage: React.FC = () => {
+  const addMandate = useUniversalMandateStore((s) => s.addMandate);
+  const router = useRouter();
+
+  const handleSubmit = async (data: any) => {
+    await addMandate(data);
+    router.push('/rules/mandates');
+  };
+
+  return (
+    <AddUniversalMandateForm
+      onSubmit={handleSubmit}
+      onCancel={() => router.push('/rules/mandates')}
+    />
+  );
+};
+
+export default NewMandatePage;

--- a/frontend/src/app/rules/mandates/page.tsx
+++ b/frontend/src/app/rules/mandates/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+import React from 'react';
+import UniversalMandateList from '@/components/rules/UniversalMandateList';
+
+const MandatesPage: React.FC = () => {
+  return <UniversalMandateList />;
+};
+
+export default MandatesPage;

--- a/frontend/src/app/rules/templates/[templateId]/edit/page.tsx
+++ b/frontend/src/app/rules/templates/[templateId]/edit/page.tsx
@@ -1,0 +1,55 @@
+'use client';
+import React, { useEffect } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import { Button } from '@chakra-ui/react';
+import EditRuleTemplateForm from '@/components/forms/EditRuleTemplateForm';
+import { useRuleTemplateStore } from '@/store/ruleTemplateStore';
+
+const EditRuleTemplatePage: React.FC = () => {
+  const params = useParams();
+  const templateId = Array.isArray(params.templateId)
+    ? params.templateId[0]
+    : (params.templateId as string);
+  const { templates, fetchTemplates, updateTemplate, removeTemplate } =
+    useRuleTemplateStore((s) => ({
+      templates: s.templates,
+      fetchTemplates: s.fetchTemplates,
+      updateTemplate: s.updateTemplate,
+      removeTemplate: s.removeTemplate,
+    }));
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!templates.length) fetchTemplates();
+  }, [fetchTemplates, templates.length]);
+
+  const template = templates.find((t) => t.id === templateId);
+  if (!template) {
+    return <p>Loading...</p>;
+  }
+
+  const handleSubmit = async (data: any) => {
+    await updateTemplate(templateId, data);
+    router.push('/rules/templates');
+  };
+
+  const handleDelete = async () => {
+    await removeTemplate(templateId);
+    router.push('/rules/templates');
+  };
+
+  return (
+    <>
+      <EditRuleTemplateForm
+        template={template}
+        onSubmit={handleSubmit}
+        onCancel={() => router.push('/rules/templates')}
+      />
+      <Button colorScheme="red" mt="4" onClick={handleDelete}>
+        Delete Template
+      </Button>
+    </>
+  );
+};
+
+export default EditRuleTemplatePage;

--- a/frontend/src/app/rules/templates/new/page.tsx
+++ b/frontend/src/app/rules/templates/new/page.tsx
@@ -1,0 +1,24 @@
+'use client';
+import React from 'react';
+import { useRouter } from 'next/navigation';
+import AddRuleTemplateForm from '@/components/forms/AddRuleTemplateForm';
+import { useRuleTemplateStore } from '@/store/ruleTemplateStore';
+
+const NewRuleTemplatePage: React.FC = () => {
+  const addTemplate = useRuleTemplateStore((s) => s.addTemplate);
+  const router = useRouter();
+
+  const handleSubmit = async (data: any) => {
+    await addTemplate(data);
+    router.push('/rules/templates');
+  };
+
+  return (
+    <AddRuleTemplateForm
+      onSubmit={handleSubmit}
+      onCancel={() => router.push('/rules/templates')}
+    />
+  );
+};
+
+export default NewRuleTemplatePage;

--- a/frontend/src/app/rules/templates/page.tsx
+++ b/frontend/src/app/rules/templates/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+import React from 'react';
+import RuleTemplateList from '@/components/rules/RuleTemplateList';
+
+const RuleTemplatesPage: React.FC = () => {
+  return <RuleTemplateList />;
+};
+
+export default RuleTemplatesPage;

--- a/frontend/src/components/forms/AddRuleTemplateForm.tsx
+++ b/frontend/src/components/forms/AddRuleTemplateForm.tsx
@@ -1,0 +1,122 @@
+'use client';
+import React from 'react';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Textarea,
+  VStack,
+  FormErrorMessage,
+  useToast,
+} from '@chakra-ui/react';
+import { useForm, type SubmitHandler } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  agentPromptTemplateCreateSchema,
+  AgentPromptTemplateCreateData,
+} from '@/types/agent_prompt_template';
+
+interface FormFields {
+  template_name: string;
+  template_content: string;
+  agent_role_id: string;
+  context_requirements?: string | null;
+}
+
+interface AddRuleTemplateFormProps {
+  onSubmit: (data: AgentPromptTemplateCreateData) => Promise<void>;
+  onCancel: () => void;
+}
+
+const AddRuleTemplateForm: React.FC<AddRuleTemplateFormProps> = ({
+  onSubmit,
+  onCancel,
+}) => {
+  const toast = useToast();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    reset,
+  } = useForm<FormFields>({
+    resolver: zodResolver(agentPromptTemplateCreateSchema as any),
+    defaultValues: {
+      template_name: '',
+      template_content: '',
+      agent_role_id: '',
+      context_requirements: '',
+    },
+  });
+
+  const submitHandler: SubmitHandler<FormFields> = async (fields) => {
+    try {
+      const payload: AgentPromptTemplateCreateData = {
+        template_name: fields.template_name,
+        template_content: fields.template_content,
+        agent_role_id: fields.agent_role_id,
+        context_requirements: fields.context_requirements || undefined,
+        is_active: true,
+      };
+      await onSubmit(payload);
+      reset();
+    } catch (err) {
+      toast({
+        title: 'Error creating template',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  return (
+    <Box
+      as="form"
+      onSubmit={handleSubmit(submitHandler)}
+      p="6"
+      bg="bgSurface"
+      borderRadius="lg"
+      borderWidth="DEFAULT"
+      borderColor="borderDecorative"
+    >
+      <VStack spacing="4" align="stretch">
+        <FormControl isInvalid={!!errors.template_name} isRequired>
+          <FormLabel>Name</FormLabel>
+          <Input {...register('template_name')} placeholder="Name" />
+          {errors.template_name && (
+            <FormErrorMessage>{errors.template_name.message}</FormErrorMessage>
+          )}
+        </FormControl>
+        <FormControl isInvalid={!!errors.agent_role_id} isRequired>
+          <FormLabel>Agent Role ID</FormLabel>
+          <Input {...register('agent_role_id')} placeholder="Agent Role ID" />
+          {errors.agent_role_id && (
+            <FormErrorMessage>{errors.agent_role_id.message}</FormErrorMessage>
+          )}
+        </FormControl>
+        <FormControl>
+          <FormLabel>Context Requirements</FormLabel>
+          <Input {...register('context_requirements')} placeholder="Context" />
+        </FormControl>
+        <FormControl isInvalid={!!errors.template_content} isRequired>
+          <FormLabel>Template Content</FormLabel>
+          <Textarea {...register('template_content')} rows={6} />
+          {errors.template_content && (
+            <FormErrorMessage>{errors.template_content.message}</FormErrorMessage>
+          )}
+        </FormControl>
+        <Button type="submit" isLoading={isSubmitting} colorScheme="blue">
+          Create Template
+        </Button>
+        <Button variant="ghost" onClick={onCancel} isDisabled={isSubmitting}>
+          Cancel
+        </Button>
+      </VStack>
+    </Box>
+  );
+};
+
+export default AddRuleTemplateForm;

--- a/frontend/src/components/forms/AddUniversalMandateForm.tsx
+++ b/frontend/src/components/forms/AddUniversalMandateForm.tsx
@@ -1,0 +1,111 @@
+'use client';
+import React from 'react';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Textarea,
+  VStack,
+  FormErrorMessage,
+  useToast,
+} from '@chakra-ui/react';
+import { useForm, type SubmitHandler } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  universalMandateCreateSchema,
+  UniversalMandateCreateData,
+} from '@/types/rules';
+
+interface FormFields {
+  title: string;
+  content: string;
+  priority: number;
+}
+
+interface AddUniversalMandateFormProps {
+  onSubmit: (data: UniversalMandateCreateData) => Promise<void>;
+  onCancel: () => void;
+}
+
+const AddUniversalMandateForm: React.FC<AddUniversalMandateFormProps> = ({
+  onSubmit,
+  onCancel,
+}) => {
+  const toast = useToast();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    reset,
+  } = useForm<FormFields>({
+    resolver: zodResolver(universalMandateCreateSchema as any),
+    defaultValues: {
+      title: '',
+      content: '',
+      priority: 5,
+    },
+  });
+
+  const submitHandler: SubmitHandler<FormFields> = async (fields) => {
+    try {
+      await onSubmit({
+        title: fields.title,
+        content: fields.content,
+        priority: fields.priority,
+        is_active: true,
+      });
+      reset();
+    } catch (err) {
+      toast({
+        title: 'Error creating mandate',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  return (
+    <Box
+      as="form"
+      onSubmit={handleSubmit(submitHandler)}
+      p="6"
+      bg="bgSurface"
+      borderRadius="lg"
+      borderWidth="DEFAULT"
+      borderColor="borderDecorative"
+    >
+      <VStack spacing="4" align="stretch">
+        <FormControl isInvalid={!!errors.title} isRequired>
+          <FormLabel>Title</FormLabel>
+          <Input {...register('title')} placeholder="Title" />
+          {errors.title && (
+            <FormErrorMessage>{errors.title.message}</FormErrorMessage>
+          )}
+        </FormControl>
+        <FormControl isInvalid={!!errors.content} isRequired>
+          <FormLabel>Description</FormLabel>
+          <Textarea {...register('content')} rows={4} />
+          {errors.content && (
+            <FormErrorMessage>{errors.content.message}</FormErrorMessage>
+          )}
+        </FormControl>
+        <FormControl isInvalid={!!errors.priority}>
+          <FormLabel>Priority</FormLabel>
+          <Input type="number" {...register('priority', { valueAsNumber: true })} />
+        </FormControl>
+        <Button type="submit" isLoading={isSubmitting} colorScheme="blue">
+          Create Mandate
+        </Button>
+        <Button variant="ghost" onClick={onCancel} isDisabled={isSubmitting}>
+          Cancel
+        </Button>
+      </VStack>
+    </Box>
+  );
+};
+
+export default AddUniversalMandateForm;

--- a/frontend/src/components/forms/EditRuleTemplateForm.tsx
+++ b/frontend/src/components/forms/EditRuleTemplateForm.tsx
@@ -1,0 +1,119 @@
+'use client';
+import React from 'react';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Textarea,
+  VStack,
+  FormErrorMessage,
+  useToast,
+} from '@chakra-ui/react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  agentPromptTemplateUpdateSchema,
+  AgentPromptTemplateUpdateData,
+  AgentPromptTemplate,
+} from '@/types/agent_prompt_template';
+
+interface FormFields {
+  template_name?: string;
+  template_content?: string;
+  agent_role_id?: string;
+  context_requirements?: string | null;
+}
+
+interface EditRuleTemplateFormProps {
+  template: AgentPromptTemplate;
+  onSubmit: (data: AgentPromptTemplateUpdateData) => Promise<void>;
+  onCancel: () => void;
+}
+
+const EditRuleTemplateForm: React.FC<EditRuleTemplateFormProps> = ({
+  template,
+  onSubmit,
+  onCancel,
+}) => {
+  const toast = useToast();
+  const { register, handleSubmit, formState: { errors, isSubmitting } } = useForm<FormFields>({
+    resolver: zodResolver(agentPromptTemplateUpdateSchema as any),
+    defaultValues: {
+      template_name: template.template_name,
+      template_content: template.template_content,
+      agent_role_id: template.agent_role_id,
+      context_requirements: template.context_requirements ?? '',
+    },
+  });
+
+  const submitHandler = async (fields: FormFields) => {
+    try {
+      const payload: AgentPromptTemplateUpdateData = {
+        template_name: fields.template_name,
+        template_content: fields.template_content,
+        agent_role_id: fields.agent_role_id,
+        context_requirements: fields.context_requirements,
+        is_active: template.is_active,
+      };
+      await onSubmit(payload);
+    } catch (err) {
+      toast({
+        title: 'Error updating template',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  return (
+    <Box
+      as="form"
+      onSubmit={handleSubmit(submitHandler)}
+      p="6"
+      bg="bgSurface"
+      borderRadius="lg"
+      borderWidth="DEFAULT"
+      borderColor="borderDecorative"
+    >
+      <VStack spacing="4" align="stretch">
+        <FormControl isInvalid={!!errors.template_name}>
+          <FormLabel>Name</FormLabel>
+          <Input {...register('template_name')} placeholder="Name" />
+          {errors.template_name && (
+            <FormErrorMessage>{errors.template_name.message}</FormErrorMessage>
+          )}
+        </FormControl>
+        <FormControl isInvalid={!!errors.agent_role_id}>
+          <FormLabel>Agent Role ID</FormLabel>
+          <Input {...register('agent_role_id')} placeholder="Agent Role ID" />
+          {errors.agent_role_id && (
+            <FormErrorMessage>{errors.agent_role_id.message}</FormErrorMessage>
+          )}
+        </FormControl>
+        <FormControl>
+          <FormLabel>Context Requirements</FormLabel>
+          <Input {...register('context_requirements')} placeholder="Context" />
+        </FormControl>
+        <FormControl isInvalid={!!errors.template_content}>
+          <FormLabel>Template Content</FormLabel>
+          <Textarea {...register('template_content')} rows={6} />
+          {errors.template_content && (
+            <FormErrorMessage>{errors.template_content.message}</FormErrorMessage>
+          )}
+        </FormControl>
+        <Button type="submit" isLoading={isSubmitting} colorScheme="blue">
+          Update Template
+        </Button>
+        <Button variant="ghost" onClick={onCancel} isDisabled={isSubmitting}>
+          Cancel
+        </Button>
+      </VStack>
+    </Box>
+  );
+};
+
+export default EditRuleTemplateForm;

--- a/frontend/src/components/forms/EditUniversalMandateForm.tsx
+++ b/frontend/src/components/forms/EditUniversalMandateForm.tsx
@@ -1,0 +1,109 @@
+'use client';
+import React from 'react';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Textarea,
+  VStack,
+  FormErrorMessage,
+  useToast,
+} from '@chakra-ui/react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  universalMandateUpdateSchema,
+  UniversalMandateUpdateData,
+  UniversalMandate,
+} from '@/types/rules';
+
+interface FormFields {
+  title?: string;
+  content?: string;
+  priority?: number;
+}
+
+interface EditUniversalMandateFormProps {
+  mandate: UniversalMandate;
+  onSubmit: (data: UniversalMandateUpdateData) => Promise<void>;
+  onCancel: () => void;
+}
+
+const EditUniversalMandateForm: React.FC<EditUniversalMandateFormProps> = ({
+  mandate,
+  onSubmit,
+  onCancel,
+}) => {
+  const toast = useToast();
+  const { register, handleSubmit, formState: { errors, isSubmitting } } = useForm<FormFields>({
+    resolver: zodResolver(universalMandateUpdateSchema as any),
+    defaultValues: {
+      title: mandate.title,
+      content: mandate.content,
+      priority: mandate.priority,
+    },
+  });
+
+  const submitHandler = async (fields: FormFields) => {
+    try {
+      const payload: UniversalMandateUpdateData = {
+        title: fields.title,
+        content: fields.content,
+        priority: fields.priority,
+        is_active: mandate.is_active,
+      };
+      await onSubmit(payload);
+    } catch (err) {
+      toast({
+        title: 'Error updating mandate',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  return (
+    <Box
+      as="form"
+      onSubmit={handleSubmit(submitHandler)}
+      p="6"
+      bg="bgSurface"
+      borderRadius="lg"
+      borderWidth="DEFAULT"
+      borderColor="borderDecorative"
+    >
+      <VStack spacing="4" align="stretch">
+        <FormControl isInvalid={!!errors.title}>
+          <FormLabel>Title</FormLabel>
+          <Input {...register('title')} placeholder="Title" />
+          {errors.title && (
+            <FormErrorMessage>{errors.title.message}</FormErrorMessage>
+          )}
+        </FormControl>
+        <FormControl isInvalid={!!errors.content}>
+          <FormLabel>Description</FormLabel>
+          <Textarea {...register('content')} rows={4} />
+          {errors.content && (
+            <FormErrorMessage>{errors.content.message}</FormErrorMessage>
+          )}
+        </FormControl>
+        <FormControl isInvalid={!!errors.priority}>
+          <FormLabel>Priority</FormLabel>
+          <Input type="number" {...register('priority', { valueAsNumber: true })} />
+        </FormControl>
+        <Button type="submit" isLoading={isSubmitting} colorScheme="blue">
+          Update Mandate
+        </Button>
+        <Button variant="ghost" onClick={onCancel} isDisabled={isSubmitting}>
+          Cancel
+        </Button>
+      </VStack>
+    </Box>
+  );
+};
+
+export default EditUniversalMandateForm;

--- a/frontend/src/components/rules/README.md
+++ b/frontend/src/components/rules/README.md
@@ -1,0 +1,14 @@
+# Rule Components (`frontend/src/components/rules/`)
+
+Components for displaying and editing rule templates and universal mandates.
+
+- `RuleTemplateList.tsx` – Table view of rule templates with edit/delete actions.
+- `UniversalMandateList.tsx` – Table view of mandates with edit/delete actions.
+
+<!-- File List Start -->
+
+## File List
+- `RuleTemplateList.tsx`
+- `UniversalMandateList.tsx`
+
+<!-- File List End -->

--- a/frontend/src/components/rules/RuleTemplateList.tsx
+++ b/frontend/src/components/rules/RuleTemplateList.tsx
@@ -1,0 +1,90 @@
+'use client';
+import React, { useEffect } from 'react';
+import Link from 'next/link';
+import {
+  Box,
+  Button,
+  Flex,
+  Heading,
+  IconButton,
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+  useToast,
+} from '@chakra-ui/react';
+import { DeleteIcon, EditIcon } from '@chakra-ui/icons';
+import { useRuleTemplateStore } from '@/store/ruleTemplateStore';
+
+const RuleTemplateList: React.FC = () => {
+  const templates = useRuleTemplateStore((s) => s.templates);
+  const fetchTemplates = useRuleTemplateStore((s) => s.fetchTemplates);
+  const removeTemplate = useRuleTemplateStore((s) => s.removeTemplate);
+  const toast = useToast();
+
+  useEffect(() => {
+    fetchTemplates();
+  }, [fetchTemplates]);
+
+  const handleDelete = async (id: string) => {
+    try {
+      await removeTemplate(id);
+      toast({ title: 'Template deleted', status: 'success', duration: 3000 });
+    } catch (err) {
+      toast({
+        title: 'Error deleting template',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+      });
+    }
+  };
+
+  return (
+    <Box p="4">
+      <Flex justify="space-between" align="center" mb="4">
+        <Heading size="md">Rule Templates</Heading>
+        <Button as={Link} href="/rules/templates/new" colorScheme="blue">
+          Create Template
+        </Button>
+      </Flex>
+      <Table variant="simple">
+        <Thead>
+          <Tr>
+            <Th>Name</Th>
+            <Th>Agent Role</Th>
+            <Th>Actions</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {templates.map((t) => (
+            <Tr key={t.id} data-testid="rule-template-row">
+              <Td>{t.template_name}</Td>
+              <Td>{t.agent_role_id}</Td>
+              <Td>
+                <IconButton
+                  as={Link}
+                  href={`/rules/templates/${t.id}/edit`}
+                  aria-label="Edit"
+                  icon={<EditIcon />}
+                  size="sm"
+                  mr="2"
+                />
+                <IconButton
+                  aria-label="Delete"
+                  icon={<DeleteIcon />}
+                  size="sm"
+                  onClick={() => handleDelete(t.id)}
+                />
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </Box>
+  );
+};
+
+export default RuleTemplateList;

--- a/frontend/src/components/rules/UniversalMandateList.tsx
+++ b/frontend/src/components/rules/UniversalMandateList.tsx
@@ -1,0 +1,90 @@
+'use client';
+import React, { useEffect } from 'react';
+import Link from 'next/link';
+import {
+  Box,
+  Button,
+  Flex,
+  Heading,
+  IconButton,
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+  useToast,
+} from '@chakra-ui/react';
+import { DeleteIcon, EditIcon } from '@chakra-ui/icons';
+import { useUniversalMandateStore } from '@/store/universalMandateStore';
+
+const UniversalMandateList: React.FC = () => {
+  const mandates = useUniversalMandateStore((s) => s.mandates);
+  const fetchMandates = useUniversalMandateStore((s) => s.fetchMandates);
+  const removeMandate = useUniversalMandateStore((s) => s.removeMandate);
+  const toast = useToast();
+
+  useEffect(() => {
+    fetchMandates();
+  }, [fetchMandates]);
+
+  const handleDelete = async (id: string) => {
+    try {
+      await removeMandate(id);
+      toast({ title: 'Mandate deleted', status: 'success', duration: 3000 });
+    } catch (err) {
+      toast({
+        title: 'Error deleting mandate',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+      });
+    }
+  };
+
+  return (
+    <Box p="4">
+      <Flex justify="space-between" align="center" mb="4">
+        <Heading size="md">Universal Mandates</Heading>
+        <Button as={Link} href="/rules/mandates/new" colorScheme="blue">
+          Create Mandate
+        </Button>
+      </Flex>
+      <Table variant="simple">
+        <Thead>
+          <Tr>
+            <Th>Title</Th>
+            <Th>Priority</Th>
+            <Th>Actions</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {mandates.map((m) => (
+            <Tr key={m.id} data-testid="mandate-row">
+              <Td>{m.title}</Td>
+              <Td>{m.priority}</Td>
+              <Td>
+                <IconButton
+                  as={Link}
+                  href={`/rules/mandates/${m.id}/edit`}
+                  aria-label="Edit"
+                  icon={<EditIcon />}
+                  size="sm"
+                  mr="2"
+                />
+                <IconButton
+                  aria-label="Delete"
+                  icon={<DeleteIcon />}
+                  size="sm"
+                  onClick={() => handleDelete(m.id)}
+                />
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </Box>
+  );
+};
+
+export default UniversalMandateList;

--- a/frontend/src/components/rules/__tests__/RuleTemplateList.test.tsx
+++ b/frontend/src/components/rules/__tests__/RuleTemplateList.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, TestWrapper } from '@/__tests__/utils/test-utils';
+import RuleTemplateList from '../RuleTemplateList';
+import { useRuleTemplateStore } from '@/store/ruleTemplateStore';
+
+vi.mock('@/store/ruleTemplateStore');
+
+const mockUseRuleTemplateStore = useRuleTemplateStore as vi.MockedFunction<typeof useRuleTemplateStore>;
+
+describe('RuleTemplateList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseRuleTemplateStore.mockImplementation((selector: any) =>
+      selector({
+        templates: [
+          { id: 'rt1', template_name: 'Temp1', agent_role_id: 'role1', template_content: '', is_active: true },
+        ],
+        fetchTemplates: vi.fn(),
+        removeTemplate: vi.fn(),
+      } as any)
+    );
+  });
+
+  it('calls removeTemplate when delete button clicked', () => {
+    const state = {
+      templates: [
+        { id: 'rt1', template_name: 'Temp1', agent_role_id: 'role1', template_content: '', is_active: true },
+      ],
+      fetchTemplates: vi.fn(),
+      removeTemplate: vi.fn(),
+    };
+    mockUseRuleTemplateStore.mockImplementation((selector: any) => selector(state as any));
+
+    render(<RuleTemplateList />, { wrapper: TestWrapper });
+
+    const deleteBtn = screen.getByLabelText('Delete');
+    fireEvent.click(deleteBtn);
+
+    expect(state.removeTemplate).toHaveBeenCalledWith('rt1');
+  });
+});

--- a/frontend/src/components/rules/__tests__/UniversalMandateList.test.tsx
+++ b/frontend/src/components/rules/__tests__/UniversalMandateList.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, TestWrapper } from '@/__tests__/utils/test-utils';
+import UniversalMandateList from '../UniversalMandateList';
+import { useUniversalMandateStore } from '@/store/universalMandateStore';
+
+vi.mock('@/store/universalMandateStore');
+
+const mockUseMandateStore = useUniversalMandateStore as vi.MockedFunction<typeof useUniversalMandateStore>;
+
+describe('UniversalMandateList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseMandateStore.mockImplementation((selector: any) =>
+      selector({
+        mandates: [
+          { id: 'm1', title: 'M1', content: '', priority: 5, is_active: true },
+        ],
+        fetchMandates: vi.fn(),
+        removeMandate: vi.fn(),
+      } as any)
+    );
+  });
+
+  it('calls removeMandate when delete button clicked', () => {
+    const state = {
+      mandates: [
+        { id: 'm1', title: 'M1', content: '', priority: 5, is_active: true },
+      ],
+      fetchMandates: vi.fn(),
+      removeMandate: vi.fn(),
+    };
+    mockUseMandateStore.mockImplementation((selector: any) => selector(state as any));
+
+    render(<UniversalMandateList />, { wrapper: TestWrapper });
+
+    const deleteBtn = screen.getByLabelText('Delete');
+    fireEvent.click(deleteBtn);
+
+    expect(state.removeMandate).toHaveBeenCalledWith('m1');
+  });
+});

--- a/frontend/src/services/api/rules.ts
+++ b/frontend/src/services/api/rules.ts
@@ -12,7 +12,11 @@ import type {
   UniversalMandateFilters,
   AgentRuleFilters,
 } from "@/types/rules";
-import type { AgentPromptTemplate } from "@/types/agent_prompt_template";
+import type {
+  AgentPromptTemplate,
+  AgentPromptTemplateCreateData,
+  AgentPromptTemplateUpdateData,
+} from "@/types/agent_prompt_template";
 
 export const rulesApi = {
   // --- Universal Mandate APIs ---
@@ -164,6 +168,51 @@ export const rulesApi = {
         buildApiUrl(API_CONFIG.ENDPOINTS.RULES, "/templates")
       );
       return response.data;
+    },
+
+    // Get single rule template
+    get: async (templateId: string): Promise<AgentPromptTemplate> => {
+      const response = await request<{ data: AgentPromptTemplate }>(
+        buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/templates/${templateId}`)
+      );
+      return response.data;
+    },
+
+    // Create a new rule template
+    create: async (
+      data: AgentPromptTemplateCreateData
+    ): Promise<AgentPromptTemplate> => {
+      const response = await request<{ data: AgentPromptTemplate }>(
+        buildApiUrl(API_CONFIG.ENDPOINTS.RULES, "/templates"),
+        {
+          method: "POST",
+          body: JSON.stringify(data),
+        }
+      );
+      return response.data;
+    },
+
+    // Update an existing template
+    update: async (
+      templateId: string,
+      data: AgentPromptTemplateUpdateData
+    ): Promise<AgentPromptTemplate> => {
+      const response = await request<{ data: AgentPromptTemplate }>(
+        buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/templates/${templateId}`),
+        {
+          method: "PUT",
+          body: JSON.stringify(data),
+        }
+      );
+      return response.data;
+    },
+
+    // Delete a template
+    delete: async (templateId: string): Promise<void> => {
+      await request(
+        buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/templates/${templateId}`),
+        { method: "DELETE" }
+      );
     },
 
     // Apply a template to an agent

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -5,3 +5,5 @@ export * from './baseStore';
 export * from './authStore';
 export * from './memoryStore';
 export * from './templateStore';
+export * from './ruleTemplateStore';
+export * from './universalMandateStore';

--- a/frontend/src/store/ruleTemplateStore.ts
+++ b/frontend/src/store/ruleTemplateStore.ts
@@ -1,0 +1,58 @@
+import { createBaseStore, BaseState, withLoading } from './baseStore';
+import { rulesApi } from '@/services/api';
+import {
+  AgentPromptTemplate,
+  AgentPromptTemplateCreateData,
+  AgentPromptTemplateUpdateData,
+} from '@/types/agent_prompt_template';
+
+export interface RuleTemplateState extends BaseState {
+  templates: AgentPromptTemplate[];
+  fetchTemplates: () => Promise<void>;
+  addTemplate: (data: AgentPromptTemplateCreateData) => Promise<void>;
+  updateTemplate: (id: string, data: AgentPromptTemplateUpdateData) => Promise<void>;
+  removeTemplate: (id: string) => Promise<void>;
+}
+
+const initialData: Omit<
+  RuleTemplateState,
+  | keyof BaseState
+  | 'fetchTemplates'
+  | 'addTemplate'
+  | 'updateTemplate'
+  | 'removeTemplate'
+> = {
+  templates: [],
+};
+
+const actionsCreator = (set: any, get: any) => ({
+  fetchTemplates: async () =>
+    withLoading(set, async () => {
+      const templates = await rulesApi.templates.list();
+      set({ templates });
+    }),
+  addTemplate: async (data: AgentPromptTemplateCreateData) =>
+    withLoading(set, async () => {
+      const t = await rulesApi.templates.create(data);
+      set((state: RuleTemplateState) => ({ templates: [...state.templates, t] }));
+    }),
+  updateTemplate: async (id: string, data: AgentPromptTemplateUpdateData) =>
+    withLoading(set, async () => {
+      const updated = await rulesApi.templates.update(id, data);
+      set((state: RuleTemplateState) => ({
+        templates: state.templates.map((t) => (t.id === id ? updated : t)),
+      }));
+    }),
+  removeTemplate: async (id: string) =>
+    withLoading(set, async () => {
+      await rulesApi.templates.delete(id);
+      set((state: RuleTemplateState) => ({
+        templates: state.templates.filter((t) => t.id !== id),
+      }));
+    }),
+});
+
+export const useRuleTemplateStore = createBaseStore<
+  RuleTemplateState,
+  ReturnType<typeof actionsCreator>
+>(initialData as any, actionsCreator, { name: 'rule-template-store' });

--- a/frontend/src/store/universalMandateStore.ts
+++ b/frontend/src/store/universalMandateStore.ts
@@ -1,0 +1,56 @@
+import { createBaseStore, BaseState, withLoading } from './baseStore';
+import { rulesApi } from '@/services/api';
+import {
+  UniversalMandate,
+  UniversalMandateCreateData,
+  UniversalMandateUpdateData,
+} from '@/types/rules';
+
+export interface UniversalMandateState extends BaseState {
+  mandates: UniversalMandate[];
+  fetchMandates: () => Promise<void>;
+  addMandate: (data: UniversalMandateCreateData) => Promise<void>;
+  updateMandate: (id: string, data: UniversalMandateUpdateData) => Promise<void>;
+  removeMandate: (id: string) => Promise<void>;
+}
+
+const initialData: Omit<
+  UniversalMandateState,
+  | keyof BaseState
+  | 'fetchMandates'
+  | 'addMandate'
+  | 'updateMandate'
+  | 'removeMandate'
+> = { mandates: [] };
+
+const actionsCreator = (set: any, get: any) => ({
+  fetchMandates: async () =>
+    withLoading(set, async () => {
+      const res = await rulesApi.mandates.list();
+      set({ mandates: res.data });
+    }),
+  addMandate: async (data: UniversalMandateCreateData) =>
+    withLoading(set, async () => {
+      const m = await rulesApi.mandates.create(data);
+      set((s: UniversalMandateState) => ({ mandates: [...s.mandates, m] }));
+    }),
+  updateMandate: async (id: string, data: UniversalMandateUpdateData) =>
+    withLoading(set, async () => {
+      const updated = await rulesApi.mandates.update(id, data);
+      set((s: UniversalMandateState) => ({
+        mandates: s.mandates.map((m) => (m.id === id ? updated : m)),
+      }));
+    }),
+  removeMandate: async (id: string) =>
+    withLoading(set, async () => {
+      await rulesApi.mandates.delete(id);
+      set((s: UniversalMandateState) => ({
+        mandates: s.mandates.filter((m) => m.id !== id),
+      }));
+    }),
+});
+
+export const useUniversalMandateStore = createBaseStore<
+  UniversalMandateState,
+  ReturnType<typeof actionsCreator>
+>(initialData as any, actionsCreator, { name: 'universal-mandate-store' });


### PR DESCRIPTION
## Summary
- add API helpers for rule template CRUD
- add store for rule templates and mandates
- create list/detail pages for templates and mandates
- implement forms and components for management
- include unit tests for new lists

## Testing
- `npm run lint`
- `npm test` *(fails: TypeError observer.observe is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6841e5f76570832cbe7b910cfa4f1aee