### PR TITLE
Add token context with refresh

### DIFF
--- a/frontend/src/contexts/README.md
+++ b/frontend/src/contexts/README.md
@@ -9,6 +9,7 @@ This directory (`frontend/src/contexts/`) contains React Context providers and h
 Key files:
 
 *   `ThemeContext.tsx`: Provides context for managing the application's theme (light/dark mode).
+*   `TokenContext.tsx`: Manages the authentication token and refresh logic.
 *   `README.md`: This file.
 
 ## Files
@@ -27,6 +28,7 @@ graph TD
 ## File List
 
 - `ThemeContext.tsx`
+- `TokenContext.tsx`
 
 <!-- File List End -->
 

--- a/frontend/src/contexts/TokenContext.tsx
+++ b/frontend/src/contexts/TokenContext.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useState, ReactNode } from "react";
+import { request } from "@/services/api/request";
+import { TokenResponse } from "@/types/user";
+
+interface TokenContextProps {
+  token: string | null;
+  setToken: (token: string) => void;
+  clearToken: () => void;
+}
+
+const TokenContext = createContext<TokenContextProps | undefined>(undefined);
+
+interface TokenProviderProps {
+  children: ReactNode;
+}
+
+const REFRESH_THRESHOLD_SECONDS = 5 * 60; // refresh 5 minutes before expiry
+
+export const TokenProvider: React.FC<TokenProviderProps> = ({ children }) => {
+  const [token, setTokenState] = useState<string | null>(null);
+  const [refreshTimer, setRefreshTimer] = useState<ReturnType<typeof setTimeout> | null>(null);
+
+  const parseExpiry = (tok: string): number | null => {
+    try {
+      const [, payload] = tok.split(".");
+      const decoded = JSON.parse(atob(payload));
+      return typeof decoded.exp === "number" ? decoded.exp : null;
+    } catch {
+      return null;
+    }
+  };
+
+  const scheduleRefresh = (tok: string) => {
+    const exp = parseExpiry(tok);
+    if (!exp) return;
+    const nowSec = Math.floor(Date.now() / 1000);
+    const timeoutSec = exp - nowSec - REFRESH_THRESHOLD_SECONDS;
+    if (timeoutSec <= 0) {
+      refreshToken(tok);
+    } else {
+      if (refreshTimer) clearTimeout(refreshTimer);
+      const id = setTimeout(() => refreshToken(tok), timeoutSec * 1000);
+      setRefreshTimer(id);
+    }
+  };
+
+  const setToken = (tok: string) => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem("token", tok);
+    }
+    setTokenState(tok);
+    scheduleRefresh(tok);
+  };
+
+  const clearToken = () => {
+    if (refreshTimer) clearTimeout(refreshTimer);
+    if (typeof window !== "undefined") {
+      localStorage.removeItem("token");
+    }
+    setTokenState(null);
+  };
+
+  const refreshToken = async (current: string) => {
+    try {
+      const response = await request<TokenResponse>("/api/v1/auth/refresh", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${current}` },
+      });
+      setToken(response.access_token);
+    } catch {
+      clearToken();
+    }
+  };
+
+  useEffect(() => {
+    const existing = typeof window !== "undefined" ? localStorage.getItem("token") : null;
+    if (existing) {
+      setTokenState(existing);
+      scheduleRefresh(existing);
+    }
+  }, []);
+
+  return (
+    <TokenContext.Provider value={{ token, setToken, clearToken }}>
+      {children}
+    </TokenContext.Provider>
+  );
+};
+
+export const useToken = (): TokenContextProps => {
+  const context = useContext(TokenContext);
+  if (!context) {
+    throw new Error("useToken must be used within a TokenProvider");
+  }
+  return context;
+};

--- a/frontend/src/contexts/__tests__/TokenContext.test.tsx
+++ b/frontend/src/contexts/__tests__/TokenContext.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@/__tests__/utils/test-utils';
+import userEvent from '@testing-library/user-event';
+import { TestWrapper } from '@/__tests__/utils/test-utils';
+import { TokenProvider, useToken } from '../TokenContext';
+
+const Dummy = () => {
+  const { token, setToken, clearToken } = useToken();
+  return (
+    <div>
+      <span data-testid="token-value">{token}</span>
+      <button onClick={() => setToken('new-token')} data-testid="set-button" />
+      <button onClick={clearToken} data-testid="clear-button" />
+    </div>
+  );
+};
+
+describe('TokenContext', () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('initializes from localStorage and updates token', async () => {
+    localStorage.setItem('token', 'stored');
+    render(
+      <TestWrapper>
+        <TokenProvider>
+          <Dummy />
+        </TokenProvider>
+      </TestWrapper>
+    );
+    expect(screen.getByTestId('token-value').textContent).toBe('stored');
+    await user.click(screen.getByTestId('set-button'));
+    expect(screen.getByTestId('token-value').textContent).toBe('new-token');
+    await user.click(screen.getByTestId('clear-button'));
+    expect(screen.getByTestId('token-value').textContent).toBe('');
+  });
+});

--- a/frontend/src/providers/ChakraProviderWrapper.tsx
+++ b/frontend/src/providers/ChakraProviderWrapper.tsx
@@ -5,6 +5,7 @@ import { ChakraProvider, useColorMode } from "@chakra-ui/react";
 import baseAppTheme from "../theme/chakra-theme"; // Import our new custom theme
 import ModalProvider from "./ModalProvider";
 import { ThemeProvider, useTheme } from "../contexts/ThemeContext";
+import { TokenProvider } from "../contexts/TokenContext";
 
 interface ChakraProviderWrapperProps {
   children: React.ReactNode;
@@ -29,9 +30,11 @@ export default function ChakraProviderWrapper({
   children,
 }: ChakraProviderWrapperProps) {
   return (
-    <ThemeProvider>
-      <ChakraInternalProvider>{children}</ChakraInternalProvider>
-    </ThemeProvider>
+    <TokenProvider>
+      <ThemeProvider>
+        <ChakraInternalProvider>{children}</ChakraInternalProvider>
+      </ThemeProvider>
+    </TokenProvider>
   );
 }
 


### PR DESCRIPTION
## Summary
- provide `TokenContext` to manage auth token and auto-refresh
- wrap `ChakraProviderWrapper` with `TokenProvider`
- document new context in README
- add unit tests for `TokenContext`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test:run` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e5f65ffc832c977b2c9c543048c2