### PR TITLE
Add logout menu and persist auth token

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -18,6 +18,7 @@ import AgentList from "@/components/AgentList";
 import { useTaskStore } from "@/store/taskStore";
 import { useProjectStore } from "@/store/projectStore";
 import { useAgentStore } from "../store/agentStore";
+import { useAuthStore } from "../store/authStore";
 import { createProject, createAgent } from "../services/api";
 import { ProjectCreateData } from "../types/project";
 import Dashboard from "../components/Dashboard";
@@ -215,6 +216,12 @@ export default function Home() {
       label: "Dev Tools",
       icon: <SettingsIcon />,
       action: onOpenDevTools,
+    },
+    {
+      id: "logout",
+      label: "Logout",
+      icon: <AppIcon name="logout" />,
+      action: () => useAuthStore.getState().logout(),
     },
   ];
 

--- a/frontend/src/components/common/AppIcon.tsx
+++ b/frontend/src/components/common/AppIcon.tsx
@@ -51,6 +51,7 @@ const standardIcons: Record<string, React.ElementType> = {
   arrowup: ArrowUpIcon,
   settings: SettingsIcon,
   close: CloseIcon,
+  logout: ViewOffIcon,
   filter: SettingsIcon,
   title: ChatIcon,
   description: InfoOutlineIcon,

--- a/frontend/src/store/__tests__/authStore.test.ts
+++ b/frontend/src/store/__tests__/authStore.test.ts
@@ -23,10 +23,25 @@ describe("authStore", () => {
       token: "xyz",
       setToken: useAuthStore.getState().setToken,
       clearToken: useAuthStore.getState().clearToken,
+      logout: useAuthStore.getState().logout,
     });
     act(() => {
       useAuthStore.getState().clearToken();
     });
     expect(useAuthStore.getState().token).toBeNull();
+  });
+
+  it("logout clears stored token", () => {
+    useAuthStore.setState({
+      token: "xyz",
+      setToken: useAuthStore.getState().setToken,
+      clearToken: useAuthStore.getState().clearToken,
+      logout: useAuthStore.getState().logout,
+    });
+    act(() => {
+      useAuthStore.getState().logout();
+    });
+    expect(useAuthStore.getState().token).toBeNull();
+    expect(localStorage.getItem("token")).toBeNull();
   });
 });

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -1,6 +1,16 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
+const COOKIE_OPTIONS = 'path=/; secure; samesite=strict';
+
+const setCookie = (token: string) => {
+  document.cookie = `token=${token}; ${COOKIE_OPTIONS}`;
+};
+
+const clearCookie = () => {
+  document.cookie = `token=; ${COOKIE_OPTIONS}; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+};
+
 interface AuthState {
   token: string | null;
   setToken: (token: string) => void;
@@ -15,18 +25,21 @@ export const useAuthStore = create<AuthState>()(
       setToken: (token: string) => {
         if (typeof window !== 'undefined') {
           localStorage.setItem('token', token);
+          setCookie(token);
         }
         set({ token });
       },
       clearToken: () => {
         if (typeof window !== 'undefined') {
           localStorage.removeItem('token');
+          clearCookie();
         }
         set({ token: null });
       },
       logout: () => {
         if (typeof window !== 'undefined') {
           localStorage.removeItem('token');
+          clearCookie();
         }
         set({ token: null });
       },


### PR DESCRIPTION
## Summary
- store auth token in localStorage and secure cookie
- expose logout method and add Logout option in sidebar
- map Logout icon in AppIcon component
- cover logout in auth store tests

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*
- `pytest tests/test_simple.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e5f5cff8832ca74217d09aa43606