### PR TITLE
Add user roles management view

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -33,6 +33,7 @@ import AddAgentModal from "../components/modals/AddAgentModal";
 import DevToolsDrawer from "../components/modals/DevToolsDrawer";
 import FilterPanel from "../components/common/FilterPanel";
 import AppIcon from "../components/common/AppIcon";
+import UserRolesPage from "./user-roles/page";
 
 import type { TaskState } from "../store/taskStore";
 import type { ProjectState } from "../store/projectStore";
@@ -153,6 +154,8 @@ export default function Home() {
         return <ProjectList />;
       case "Registry":
         return <AgentList />;
+      case "User Roles":
+        return <UserRolesPage />;
       case "Settings":
         return <SettingsContent />;
       default:
@@ -165,6 +168,7 @@ export default function Home() {
     { view: "Workboard", label: "Workboard", icon: <EditIcon /> },
     { view: "Portfolio", label: "Portfolio", icon: <SearchIcon /> },
     { view: "Registry", label: "Registry", icon: <TimeIcon /> },
+    { view: "User Roles", label: "User Roles", icon: <ViewIcon /> },
   ];
 
   const actionNavItems = [

--- a/frontend/src/components/__tests__/UserRolesPage.test.tsx
+++ b/frontend/src/components/__tests__/UserRolesPage.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@/__tests__/utils/test-utils';
+import userEvent from '@testing-library/user-event';
+import { TestWrapper } from '@/__tests__/utils/test-utils';
+import UserRolesPage from '@/app/user-roles/page';
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual('@chakra-ui/react');
+  return {
+    ...actual,
+    useToast: () => vi.fn(),
+    useColorModeValue: (light: any, dark: any) => light,
+  };
+});
+
+describe('UserRolesPage', () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders without crashing', () => {
+    render(
+      <TestWrapper>
+        <UserRolesPage />
+      </TestWrapper>
+    );
+    expect(document.body).toBeInTheDocument();
+  });
+
+  it('handles simple interactions', async () => {
+    render(
+      <TestWrapper>
+        <UserRolesPage />
+      </TestWrapper>
+    );
+
+    const buttons = screen.queryAllByRole('button');
+    if (buttons.length > 0) {
+      await user.click(buttons[0]);
+    }
+    expect(document.body).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add User Roles page to navigation
- render `UserRolesPage` when view is active
- test rendering of UserRolesPage

## Testing
- `flake8 backend`
- `npm --prefix frontend run fix` *(fails: 12 errors)*
- `npm --prefix frontend run format`
- `pytest backend/tests/test_user_roles.py -q` *(fails: ModuleNotFoundError: sqlalchemy)*
- `npm --prefix frontend test` *(fails: tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6841e5f0d744832c9228887a02fb58be