### PR TITLE
Add service tests and enforce auth

### DIFF
--- a/backend/routers/rules/roles/capabilities.py
+++ b/backend/routers/rules/roles/capabilities.py
@@ -1,8 +1,10 @@
 from typing import List
 from sqlalchemy.ext.asyncio import AsyncSession
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Path
 
 from ....database import get_db
+from ....auth import get_current_active_user
+from ....models import User as UserModel
 from ....services.agent_capability_service import AgentCapabilityService
 from ....schemas.agent_capability import (
     AgentCapability,
@@ -17,19 +19,24 @@ async def get_service(db: AsyncSession = Depends(get_db)) -> AgentCapabilityServ
     return AgentCapabilityService(db)
 
 
-@router.get("/{role_id}/capabilities", response_model=List[AgentCapability])
+@router.get(
+    "/{role_id}/capabilities",
+    response_model=List[AgentCapability],
+)
 async def list_capabilities(
-    role_id: str,
+    role_id: str = Path(..., min_length=32, max_length=32),
     service: AgentCapabilityService = Depends(get_service),
+    current_user: UserModel = Depends(get_current_active_user),
 ):
     return await service.list_capabilities(agent_role_id=role_id)
 
 
 @router.post("/{role_id}/capabilities", response_model=AgentCapability)
 async def create_capability(
-    role_id: str,
+    role_id: str = Path(..., min_length=32, max_length=32),
     capability_in: AgentCapabilityCreate,
     service: AgentCapabilityService = Depends(get_service),
+    current_user: UserModel = Depends(get_current_active_user),
 ):
     data = capability_in.copy(update={"agent_role_id": role_id})
     return await service.create_capability(data)
@@ -37,9 +44,10 @@ async def create_capability(
 
 @router.put("/capabilities/{capability_id}", response_model=AgentCapability)
 async def update_capability(
-    capability_id: str,
+    capability_id: str = Path(..., min_length=32, max_length=32),
     capability_update: AgentCapabilityUpdate,
     service: AgentCapabilityService = Depends(get_service),
+    current_user: UserModel = Depends(get_current_active_user),
 ):
     updated = await service.update_capability(capability_id, capability_update)
     if not updated:
@@ -49,8 +57,9 @@ async def update_capability(
 
 @router.delete("/capabilities/{capability_id}")
 async def delete_capability(
-    capability_id: str,
+    capability_id: str = Path(..., min_length=32, max_length=32),
     service: AgentCapabilityService = Depends(get_service),
+    current_user: UserModel = Depends(get_current_active_user),
 ):
     success = await service.delete_capability(capability_id)
     if not success:

--- a/backend/routers/rules/roles/forbidden_actions.py
+++ b/backend/routers/rules/roles/forbidden_actions.py
@@ -1,9 +1,11 @@
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Path
 from sqlalchemy.orm import Session
 
 from ....database import get_sync_db as get_db
+from ....auth import get_current_active_user
+from ....models import User as UserModel
 from ....schemas.agent_forbidden_action import (
     AgentForbiddenAction,
     AgentForbiddenActionCreate,
@@ -25,8 +27,9 @@ def get_service(db: Session = Depends(get_db)) -> AgentForbiddenActionService:
     operation_id="list_forbidden_actions",
 )
 async def list_forbidden_actions_endpoint(
-    agent_role_id: str,
+    agent_role_id: str = Path(..., min_length=32, max_length=32),
     service: AgentForbiddenActionService = Depends(get_service),
+    current_user: UserModel = Depends(get_current_active_user),
 ):
     actions = await service.list_forbidden_actions(agent_role_id)
     return ListResponse[AgentForbiddenAction](
@@ -46,9 +49,10 @@ async def list_forbidden_actions_endpoint(
     operation_id="create_forbidden_action",
 )
 async def create_forbidden_action_endpoint(
-    agent_role_id: str,
+    agent_role_id: str = Path(..., min_length=32, max_length=32),
     action_data: AgentForbiddenActionCreate,
     service: AgentForbiddenActionService = Depends(get_service),
+    current_user: UserModel = Depends(get_current_active_user),
 ):
     action = await service.create_forbidden_action(
         agent_role_id,
@@ -68,8 +72,9 @@ async def create_forbidden_action_endpoint(
     operation_id="delete_forbidden_action",
 )
 async def delete_forbidden_action_endpoint(
-    action_id: str,
+    action_id: str = Path(..., min_length=32, max_length=32),
     service: AgentForbiddenActionService = Depends(get_service),
+    current_user: UserModel = Depends(get_current_active_user),
 ):
     success = await service.delete_forbidden_action(action_id)
     if not success:

--- a/backend/tests/test_agent_capability_and_forbidden_services.py
+++ b/backend/tests/test_agent_capability_and_forbidden_services.py
@@ -1,0 +1,107 @@
+import uuid
+import pytest
+import types
+import sys
+
+sys.modules.setdefault("backend.crud.rules", types.ModuleType("crud_rules"))
+sys.modules.setdefault("backend.schemas.rules", types.ModuleType("rules"))
+_crud_stub = sys.modules["backend.crud.rules"]
+_rules_module = sys.modules["backend.schemas.rules"]
+
+for name in ["add_forbidden_action", "get_forbidden_actions", "remove_forbidden_action"]:
+    setattr(_crud_stub, name, None)
+for _n in [
+    "AgentRoleCreate",
+    "AgentRoleUpdate",
+    "ConstraintCreate",
+    "ConstraintUpdate",
+    "CapabilityCreate",
+    "CapabilityUpdate",
+    "MandateCreate",
+    "MandateUpdate",
+    "ErrorProtocolCreate",
+    "ErrorProtocolUpdate",
+    "ValidationResult",
+]:
+    setattr(_rules_module, _n, type(_n, (), {}))
+
+from backend.services.agent_capability_service import AgentCapabilityService
+from backend.services.agent_forbidden_action_service import AgentForbiddenActionService
+from backend.schemas.agent_capability import AgentCapabilityCreate, AgentCapabilityUpdate
+from backend.schemas.agent_forbidden_action import AgentForbiddenActionCreate
+from backend.models.agent import AgentRole
+
+
+@pytest.mark.asyncio
+async def test_agent_capability_service_crud(async_db_session):
+    role = AgentRole(
+        name="Role",
+        display_name="Role",
+        primary_purpose="test",
+        is_active=True,
+    )
+    async_db_session.add(role)
+    await async_db_session.commit()
+    await async_db_session.refresh(role)
+
+    service = AgentCapabilityService(async_db_session)
+    cap_create = AgentCapabilityCreate(
+        agent_role_id=role.id,
+        capability="do",
+        description="desc",
+        is_active=True,
+    )
+    created = await service.create_capability(cap_create)
+    assert created.capability == "do"
+
+    fetched = await service.get_capability(created.id)
+    assert fetched.id == created.id
+
+    listed = await service.list_capabilities(role.id)
+    assert len(listed) == 1 and listed[0].id == created.id
+
+    updated = await service.update_capability(created.id, AgentCapabilityUpdate(description="new"))
+    assert updated.description == "new"
+
+    assert await service.delete_capability(created.id) is True
+    assert await service.get_capability(created.id) is None
+
+
+@pytest.mark.asyncio
+async def test_agent_forbidden_action_service_crud(monkeypatch, async_db_session):
+    calls = {}
+
+    async def fake_add(db, role_id, action, reason=None):
+        calls["add"] = (role_id, action, reason)
+        return types.SimpleNamespace(id="1", action=action)
+
+    async def fake_list(db, role_id):
+        calls["list"] = role_id
+        return [types.SimpleNamespace(id="1", action="jump")]
+
+    async def fake_remove(db, action_id):
+        calls["remove"] = action_id
+        return True
+
+    fake_crud = types.SimpleNamespace(
+        add_forbidden_action=fake_add,
+        get_forbidden_actions=fake_list,
+        remove_forbidden_action=fake_remove,
+    )
+
+    monkeypatch.setattr(
+        "backend.services.agent_forbidden_action_service.crud_rules", fake_crud
+    )
+
+    service = AgentForbiddenActionService(async_db_session)
+    created = await service.create_forbidden_action("r1", "jump", reason="no")
+    assert created.action == "jump"
+    assert calls["add"] == ("r1", "jump", "no")
+
+    actions = await service.list_forbidden_actions("r1")
+    assert len(actions) == 1
+    assert calls["list"] == "r1"
+
+    assert await service.delete_forbidden_action("1") is True
+    assert calls["remove"] == "1"
+

--- a/backend/tests/test_agent_rule_endpoints.py
+++ b/backend/tests/test_agent_rule_endpoints.py
@@ -1,0 +1,73 @@
+import types
+import uuid
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient, ASGITransport
+from backend.routers.rules.roles import capabilities as cap_router
+from backend.routers.rules.roles import forbidden_actions as forbid_router
+
+
+class DummyCapService:
+    async def list_capabilities(self, agent_role_id=None):
+        return []
+
+    async def create_capability(self, data):
+        return {}
+
+    async def update_capability(self, capability_id, update):
+        return {}
+
+    async def delete_capability(self, capability_id):
+        return True
+
+
+class DummyForbidService:
+    async def list_forbidden_actions(self, role_id):
+        return []
+
+    async def create_forbidden_action(self, role_id, action, reason=None):
+        return {}
+
+    async def delete_forbidden_action(self, action_id):
+        return True
+
+
+dummy_user = types.SimpleNamespace(id="u1")
+
+def override_user():
+    return dummy_user
+
+
+@pytest.mark.asyncio
+async def test_capabilities_require_auth():
+    app = FastAPI()
+    app.include_router(cap_router.router)
+    app.dependency_overrides[cap_router.get_service] = lambda: DummyCapService()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.get(f"/{uuid.uuid4().hex}/capabilities")
+        assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_capabilities_invalid_id():
+    app = FastAPI()
+    app.include_router(cap_router.router)
+    app.dependency_overrides[cap_router.get_service] = lambda: DummyCapService()
+    app.dependency_overrides[cap_router.get_current_active_user] = override_user
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.get("/bad/capabilities")
+        assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_forbidden_actions_require_auth():
+    app = FastAPI()
+    app.include_router(forbid_router.router)
+    app.dependency_overrides[forbid_router.get_service] = lambda: DummyForbidService()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.get(f"/{uuid.uuid4().hex}/forbidden-actions")
+        assert resp.status_code == 401
+


### PR DESCRIPTION
## Summary
- test AgentCapabilityService CRUD operations
- mock AgentForbiddenActionService interactions
- require auth for capability and forbidden action routes
- check endpoint auth and validation

## Testing
- `flake8` *(fails: many unrelated style errors)*
- `pytest backend/tests/test_agent_capability_and_forbidden_services.py::test_agent_capability_service_crud -q` *(fails: OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_6841e5efee34832ca4deabe712234bca