### PR TITLE
Add role and capability management pages

### DIFF
--- a/frontend/src/app/agent-capabilities/page.tsx
+++ b/frontend/src/app/agent-capabilities/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+import React from 'react';
+import CapabilityManager from '@/components/roles/CapabilityManager';
+
+const AgentCapabilitiesPage: React.FC = () => {
+  return <CapabilityManager />;
+};
+
+export default AgentCapabilitiesPage;

--- a/frontend/src/app/agent-roles/page.tsx
+++ b/frontend/src/app/agent-roles/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+import React from 'react';
+import RoleManager from '@/components/roles/RoleManager';
+
+const AgentRolesPage: React.FC = () => {
+  return <RoleManager />;
+};
+
+export default AgentRolesPage;

--- a/frontend/src/components/forms/AddCapabilityForm.tsx
+++ b/frontend/src/components/forms/AddCapabilityForm.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import React, { useState } from 'react';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Checkbox,
+  VStack,
+  useToast,
+} from '@chakra-ui/react';
+import type { AgentCapabilityCreateData } from '@/types/agents';
+
+interface AddCapabilityFormProps {
+  onSubmit: (data: AgentCapabilityCreateData) => Promise<void>;
+  onClose: () => void;
+}
+
+const AddCapabilityForm: React.FC<AddCapabilityFormProps> = ({
+  onSubmit,
+  onClose,
+}) => {
+  const [capability, setCapability] = useState('');
+  const [description, setDescription] = useState('');
+  const [isActive, setIsActive] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const toast = useToast();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!capability.trim()) {
+      toast({
+        title: 'Capability name is required',
+        status: 'warning',
+        duration: 3000,
+        isClosable: true,
+      });
+      return;
+    }
+    setLoading(true);
+    try {
+      await onSubmit({ capability, description, is_active: isActive });
+      onClose();
+    } catch (err) {
+      toast({
+        title: 'Error creating capability',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box as="form" onSubmit={handleSubmit} p={4}>
+      <VStack spacing={4} align="stretch">
+        <FormControl isRequired>
+          <FormLabel>Capability</FormLabel>
+          <Input
+            value={capability}
+            onChange={(e) => setCapability(e.target.value)}
+          />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Description</FormLabel>
+          <Input
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+        </FormControl>
+        <Checkbox
+          isChecked={isActive}
+          onChange={(e) => setIsActive(e.target.checked)}
+        >
+          Is Active
+        </Checkbox>
+        <Button
+          type="submit"
+          isLoading={loading}
+          isDisabled={!capability.trim()}
+        >
+          Create Capability
+        </Button>
+        <Button variant="ghost" onClick={onClose} isDisabled={loading}>
+          Cancel
+        </Button>
+      </VStack>
+    </Box>
+  );
+};
+
+export default AddCapabilityForm;

--- a/frontend/src/components/forms/AddRoleForm.tsx
+++ b/frontend/src/components/forms/AddRoleForm.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import React, { useState } from 'react';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Checkbox,
+  VStack,
+  useToast,
+} from '@chakra-ui/react';
+import type { AgentRoleCreateData } from '@/types/agent_role';
+
+interface AddRoleFormProps {
+  onSubmit: (data: AgentRoleCreateData) => Promise<void>;
+  onClose: () => void;
+}
+
+const AddRoleForm: React.FC<AddRoleFormProps> = ({ onSubmit, onClose }) => {
+  const [name, setName] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [primaryPurpose, setPrimaryPurpose] = useState('');
+  const [isActive, setIsActive] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const toast = useToast();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim() || !displayName.trim()) {
+      toast({
+        title: 'Name and Display Name are required',
+        status: 'warning',
+        duration: 3000,
+        isClosable: true,
+      });
+      return;
+    }
+    setLoading(true);
+    try {
+      await onSubmit({
+        name,
+        display_name: displayName,
+        primary_purpose: primaryPurpose,
+        is_active: isActive,
+      });
+      onClose();
+    } catch (err) {
+      toast({
+        title: 'Error creating role',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box as="form" onSubmit={handleSubmit} p={4}>
+      <VStack spacing={4} align="stretch">
+        <FormControl isRequired>
+          <FormLabel>Name</FormLabel>
+          <Input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Unique role name"
+          />
+        </FormControl>
+        <FormControl isRequired>
+          <FormLabel>Display Name</FormLabel>
+          <Input
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            placeholder="Display name"
+          />
+        </FormControl>
+        <FormControl isRequired>
+          <FormLabel>Primary Purpose</FormLabel>
+          <Input
+            value={primaryPurpose}
+            onChange={(e) => setPrimaryPurpose(e.target.value)}
+            placeholder="Primary purpose"
+          />
+        </FormControl>
+        <Checkbox
+          isChecked={isActive}
+          onChange={(e) => setIsActive(e.target.checked)}
+        >
+          Is Active
+        </Checkbox>
+        <Button
+          type="submit"
+          isLoading={loading}
+          isDisabled={!name.trim() || !displayName.trim()}
+        >
+          Create Role
+        </Button>
+        <Button variant="ghost" onClick={onClose} isDisabled={loading}>
+          Cancel
+        </Button>
+      </VStack>
+    </Box>
+  );
+};
+
+export default AddRoleForm;

--- a/frontend/src/components/forms/EditCapabilityForm.tsx
+++ b/frontend/src/components/forms/EditCapabilityForm.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Checkbox,
+  VStack,
+  useToast,
+} from '@chakra-ui/react';
+import type {
+  AgentCapability,
+  AgentCapabilityUpdateData,
+} from '@/types/agents';
+
+interface EditCapabilityFormProps {
+  capability: AgentCapability;
+  onClose: () => void;
+  onSubmit: (id: string, data: AgentCapabilityUpdateData) => Promise<void>;
+}
+
+const EditCapabilityForm: React.FC<EditCapabilityFormProps> = ({
+  capability,
+  onClose,
+  onSubmit,
+}) => {
+  const [name, setName] = useState(capability.capability);
+  const [description, setDescription] = useState(capability.description || '');
+  const [isActive, setIsActive] = useState(capability.is_active);
+  const [loading, setLoading] = useState(false);
+  const toast = useToast();
+
+  useEffect(() => {
+    setName(capability.capability);
+    setDescription(capability.description || '');
+    setIsActive(capability.is_active);
+  }, [capability]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) {
+      toast({
+        title: 'Capability name is required',
+        status: 'warning',
+        duration: 3000,
+        isClosable: true,
+      });
+      return;
+    }
+    setLoading(true);
+    try {
+      await onSubmit(capability.id, {
+        capability: name,
+        description,
+        is_active: isActive,
+      });
+      onClose();
+    } catch (err) {
+      toast({
+        title: 'Error updating capability',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box as="form" onSubmit={handleSubmit} p={4}>
+      <VStack spacing={4} align="stretch">
+        <FormControl isRequired>
+          <FormLabel>Capability</FormLabel>
+          <Input value={name} onChange={(e) => setName(e.target.value)} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Description</FormLabel>
+          <Input
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+        </FormControl>
+        <Checkbox
+          isChecked={isActive}
+          onChange={(e) => setIsActive(e.target.checked)}
+        >
+          Is Active
+        </Checkbox>
+        <Button type="submit" isLoading={loading} isDisabled={!name.trim()}>
+          Update Capability
+        </Button>
+        <Button variant="ghost" onClick={onClose} isDisabled={loading}>
+          Cancel
+        </Button>
+      </VStack>
+    </Box>
+  );
+};
+
+export default EditCapabilityForm;

--- a/frontend/src/components/forms/EditRoleForm.tsx
+++ b/frontend/src/components/forms/EditRoleForm.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Checkbox,
+  VStack,
+  useToast,
+} from '@chakra-ui/react';
+import type { AgentRole, AgentRoleUpdateData } from '@/types/agent_role';
+
+interface EditRoleFormProps {
+  role: AgentRole;
+  onClose: () => void;
+  onSubmit: (id: string, data: AgentRoleUpdateData) => Promise<void>;
+}
+
+const EditRoleForm: React.FC<EditRoleFormProps> = ({
+  role,
+  onClose,
+  onSubmit,
+}) => {
+  const [name, setName] = useState(role.name);
+  const [displayName, setDisplayName] = useState(role.display_name);
+  const [primaryPurpose, setPrimaryPurpose] = useState(role.primary_purpose);
+  const [isActive, setIsActive] = useState(role.is_active);
+  const [loading, setLoading] = useState(false);
+  const toast = useToast();
+
+  useEffect(() => {
+    setName(role.name);
+    setDisplayName(role.display_name);
+    setPrimaryPurpose(role.primary_purpose);
+    setIsActive(role.is_active);
+  }, [role]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim() || !displayName.trim()) {
+      toast({
+        title: 'Name and Display Name are required',
+        status: 'warning',
+        duration: 3000,
+        isClosable: true,
+      });
+      return;
+    }
+    setLoading(true);
+    try {
+      await onSubmit(role.id, {
+        name,
+        display_name: displayName,
+        primary_purpose: primaryPurpose,
+        is_active: isActive,
+      });
+      onClose();
+    } catch (err) {
+      toast({
+        title: 'Error updating role',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box as="form" onSubmit={handleSubmit} p={4}>
+      <VStack spacing={4} align="stretch">
+        <FormControl isRequired>
+          <FormLabel>Name</FormLabel>
+          <Input value={name} onChange={(e) => setName(e.target.value)} />
+        </FormControl>
+        <FormControl isRequired>
+          <FormLabel>Display Name</FormLabel>
+          <Input
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+          />
+        </FormControl>
+        <FormControl isRequired>
+          <FormLabel>Primary Purpose</FormLabel>
+          <Input
+            value={primaryPurpose}
+            onChange={(e) => setPrimaryPurpose(e.target.value)}
+          />
+        </FormControl>
+        <Checkbox
+          isChecked={isActive}
+          onChange={(e) => setIsActive(e.target.checked)}
+        >
+          Is Active
+        </Checkbox>
+        <Button
+          type="submit"
+          isLoading={loading}
+          isDisabled={!name.trim() || !displayName.trim()}
+        >
+          Update Role
+        </Button>
+        <Button variant="ghost" onClick={onClose} isDisabled={loading}>
+          Cancel
+        </Button>
+      </VStack>
+    </Box>
+  );
+};
+
+export default EditRoleForm;

--- a/frontend/src/components/role/AddCapabilityModal.tsx
+++ b/frontend/src/components/role/AddCapabilityModal.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import React from 'react';
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalCloseButton,
+  ModalBody,
+} from '@chakra-ui/react';
+import AddCapabilityForm from '../forms/AddCapabilityForm';
+import type { AgentCapabilityCreateData } from '@/types/agents';
+
+interface AddCapabilityModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (data: AgentCapabilityCreateData) => Promise<void>;
+}
+
+const AddCapabilityModal: React.FC<AddCapabilityModalProps> = ({
+  isOpen,
+  onClose,
+  onSubmit,
+}) => (
+  <Modal isOpen={isOpen} onClose={onClose} size="xl">
+    <ModalOverlay />
+    <ModalContent
+      bg="bgModal"
+      color="onSurface"
+      borderColor="borderDecorative"
+      borderWidth="DEFAULT"
+    >
+      <ModalCloseButton
+        color="iconPrimary"
+        _hover={{ bg: 'interactiveNeutralHover', color: 'iconAccent' }}
+      />
+      <ModalBody pb={6} pt={3}>
+        <AddCapabilityForm onSubmit={onSubmit} onClose={onClose} />
+      </ModalBody>
+    </ModalContent>
+  </Modal>
+);
+
+export default AddCapabilityModal;

--- a/frontend/src/components/role/AddRoleModal.tsx
+++ b/frontend/src/components/role/AddRoleModal.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import React from 'react';
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalCloseButton,
+  ModalBody,
+} from '@chakra-ui/react';
+import AddRoleForm from '../forms/AddRoleForm';
+import type { AgentRoleCreateData } from '@/types/agent_role';
+
+interface AddRoleModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (data: AgentRoleCreateData) => Promise<void>;
+}
+
+const AddRoleModal: React.FC<AddRoleModalProps> = ({
+  isOpen,
+  onClose,
+  onSubmit,
+}) => (
+  <Modal isOpen={isOpen} onClose={onClose} size="xl">
+    <ModalOverlay />
+    <ModalContent
+      bg="bgModal"
+      color="onSurface"
+      borderColor="borderDecorative"
+      borderWidth="DEFAULT"
+    >
+      <ModalCloseButton
+        color="iconPrimary"
+        _hover={{ bg: 'interactiveNeutralHover', color: 'iconAccent' }}
+      />
+      <ModalBody pb={6} pt={3}>
+        <AddRoleForm onSubmit={onSubmit} onClose={onClose} />
+      </ModalBody>
+    </ModalContent>
+  </Modal>
+);
+
+export default AddRoleModal;

--- a/frontend/src/components/role/EditCapabilityModal.tsx
+++ b/frontend/src/components/role/EditCapabilityModal.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import React from 'react';
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalCloseButton,
+  ModalBody,
+} from '@chakra-ui/react';
+import EditCapabilityForm from '../forms/EditCapabilityForm';
+import type {
+  AgentCapability,
+  AgentCapabilityUpdateData,
+} from '@/types/agents';
+
+interface EditCapabilityModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (id: string, data: AgentCapabilityUpdateData) => Promise<void>;
+  capability: AgentCapability | null;
+}
+
+const EditCapabilityModal: React.FC<EditCapabilityModalProps> = ({
+  isOpen,
+  onClose,
+  onSubmit,
+  capability,
+}) => {
+  if (!capability) return null;
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="xl">
+      <ModalOverlay />
+      <ModalContent
+        bg="bgModal"
+        color="onSurface"
+        borderColor="borderDecorative"
+        borderWidth="DEFAULT"
+      >
+        <ModalCloseButton
+          color="iconPrimary"
+          _hover={{ bg: 'interactiveNeutralHover', color: 'iconAccent' }}
+        />
+        <ModalBody pb={6} pt={3}>
+          <EditCapabilityForm
+            capability={capability}
+            onSubmit={onSubmit}
+            onClose={onClose}
+          />
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default EditCapabilityModal;

--- a/frontend/src/components/role/EditRoleModal.tsx
+++ b/frontend/src/components/role/EditRoleModal.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import React from 'react';
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalCloseButton,
+  ModalBody,
+} from '@chakra-ui/react';
+import EditRoleForm from '../forms/EditRoleForm';
+import type { AgentRole, AgentRoleUpdateData } from '@/types/agent_role';
+
+interface EditRoleModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (id: string, data: AgentRoleUpdateData) => Promise<void>;
+  role: AgentRole | null;
+}
+
+const EditRoleModal: React.FC<EditRoleModalProps> = ({
+  isOpen,
+  onClose,
+  onSubmit,
+  role,
+}) => {
+  if (!role) return null;
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="xl">
+      <ModalOverlay />
+      <ModalContent
+        bg="bgModal"
+        color="onSurface"
+        borderColor="borderDecorative"
+        borderWidth="DEFAULT"
+      >
+        <ModalCloseButton
+          color="iconPrimary"
+          _hover={{ bg: 'interactiveNeutralHover', color: 'iconAccent' }}
+        />
+        <ModalBody pb={6} pt={3}>
+          <EditRoleForm role={role} onSubmit={onSubmit} onClose={onClose} />
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default EditRoleModal;

--- a/frontend/src/components/roles/CapabilityManager.tsx
+++ b/frontend/src/components/roles/CapabilityManager.tsx
@@ -1,0 +1,254 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Flex,
+  Input,
+  Spinner,
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+  TableContainer,
+  Text,
+  useDisclosure,
+  useToast,
+  Select,
+  Checkbox,
+} from '@chakra-ui/react';
+import { AddIcon, EditIcon, DeleteIcon } from '@chakra-ui/icons';
+import { agentCapabilitiesApi } from '@/services/api/agent_capabilities';
+import { agentRolesApi } from '@/services/api/agent_roles';
+import type {
+  AgentCapability,
+  AgentCapabilityCreateData,
+  AgentCapabilityUpdateData,
+} from '@/types/agents';
+import type { AgentRole } from '@/types/agent_role';
+import AddCapabilityModal from '@/components/role/AddCapabilityModal';
+import EditCapabilityModal from '@/components/role/EditCapabilityModal';
+
+const CapabilityManager: React.FC = () => {
+  const [roles, setRoles] = useState<AgentRole[]>([]);
+  const [selectedRole, setSelectedRole] = useState<string>('');
+  const [capabilities, setCapabilities] = useState<AgentCapability[] | null>(
+    null
+  );
+  const [selectedCapability, setSelectedCapability] =
+    useState<AgentCapability | null>(null);
+  const toast = useToast();
+
+  const {
+    isOpen: isAddOpen,
+    onOpen: onAddOpen,
+    onClose: onAddClose,
+  } = useDisclosure();
+  const {
+    isOpen: isEditOpen,
+    onOpen: onEditOpen,
+    onClose: onEditClose,
+  } = useDisclosure();
+
+  const loadRoles = async () => {
+    try {
+      const data = await agentRolesApi.list(false);
+      setRoles(data);
+      if (data.length > 0 && !selectedRole) {
+        setSelectedRole(data[0].id);
+      }
+    } catch (err) {
+      toast({
+        title: 'Failed to load roles',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  const loadCapabilities = async (roleId: string) => {
+    try {
+      const data = await agentCapabilitiesApi.list(roleId);
+      setCapabilities(data);
+    } catch (err) {
+      toast({
+        title: 'Failed to load capabilities',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  useEffect(() => {
+    loadRoles();
+  }, []);
+
+  useEffect(() => {
+    if (selectedRole) {
+      loadCapabilities(selectedRole);
+    }
+  }, [selectedRole]);
+
+  const handleAdd = async (data: AgentCapabilityCreateData) => {
+    if (!selectedRole) return;
+    try {
+      await agentCapabilitiesApi.create(selectedRole, data);
+      await loadCapabilities(selectedRole);
+      toast({
+        title: 'Capability created',
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+      });
+    } catch (err) {
+      toast({
+        title: 'Failed to create capability',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  const handleEdit = async (id: string, data: AgentCapabilityUpdateData) => {
+    try {
+      await agentCapabilitiesApi.update(id, data);
+      if (selectedRole) await loadCapabilities(selectedRole);
+      toast({
+        title: 'Capability updated',
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+      });
+    } catch (err) {
+      toast({
+        title: 'Failed to update capability',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await agentCapabilitiesApi.delete(id);
+      if (selectedRole) await loadCapabilities(selectedRole);
+      toast({
+        title: 'Capability deleted',
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+      });
+    } catch (err) {
+      toast({
+        title: 'Failed to delete capability',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  return (
+    <Box p={4}>
+      <Flex mb={4} gap={2} align="center">
+        <Select
+          value={selectedRole}
+          onChange={(e) => setSelectedRole(e.target.value)}
+          maxW="250px"
+        >
+          {roles.map((r) => (
+            <option key={r.id} value={r.id}>
+              {r.display_name}
+            </option>
+          ))}
+        </Select>
+        <Button
+          leftIcon={<AddIcon />}
+          onClick={onAddOpen}
+          size="sm"
+          isDisabled={!selectedRole}
+        >
+          Add Capability
+        </Button>
+      </Flex>
+      {!capabilities ? (
+        <Flex justify="center" align="center" minH="100px">
+          <Spinner />
+        </Flex>
+      ) : capabilities.length === 0 ? (
+        <Text>No capabilities found.</Text>
+      ) : (
+        <TableContainer>
+          <Table size="sm" variant="simple">
+            <Thead>
+              <Tr>
+                <Th>Capability</Th>
+                <Th>Description</Th>
+                <Th>Active</Th>
+                <Th>Actions</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {capabilities.map((cap) => (
+                <Tr key={cap.id}>
+                  <Td>{cap.capability}</Td>
+                  <Td>{cap.description || '-'}</Td>
+                  <Td>{cap.is_active ? 'Yes' : 'No'}</Td>
+                  <Td>
+                    <Button
+                      size="sm"
+                      mr={2}
+                      leftIcon={<EditIcon />}
+                      onClick={() => {
+                        setSelectedCapability(cap);
+                        onEditOpen();
+                      }}
+                    >
+                      Edit
+                    </Button>
+                    <Button
+                      size="sm"
+                      colorScheme="red"
+                      leftIcon={<DeleteIcon />}
+                      onClick={() => handleDelete(cap.id)}
+                    >
+                      Delete
+                    </Button>
+                  </Td>
+                </Tr>
+              ))}
+            </Tbody>
+          </Table>
+        </TableContainer>
+      )}
+      <AddCapabilityModal
+        isOpen={isAddOpen}
+        onClose={onAddClose}
+        onSubmit={handleAdd}
+      />
+      <EditCapabilityModal
+        isOpen={isEditOpen}
+        onClose={() => {
+          setSelectedCapability(null);
+          onEditClose();
+        }}
+        onSubmit={handleEdit}
+        capability={selectedCapability}
+      />
+    </Box>
+  );
+};
+
+export default CapabilityManager;

--- a/frontend/src/components/roles/RoleManager.tsx
+++ b/frontend/src/components/roles/RoleManager.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Flex,
+  List,
+  ListItem,
+  Spinner,
+  Text,
+  useDisclosure,
+  useToast,
+} from '@chakra-ui/react';
+import { AddIcon, EditIcon } from '@chakra-ui/icons';
+import { agentRolesApi } from '@/services/api/agent_roles';
+import type {
+  AgentRole,
+  AgentRoleCreateData,
+  AgentRoleUpdateData,
+} from '@/types/agent_role';
+import AddRoleModal from '@/components/role/AddRoleModal';
+import EditRoleModal from '@/components/role/EditRoleModal';
+
+const RoleManager: React.FC = () => {
+  const [roles, setRoles] = useState<AgentRole[] | null>(null);
+  const [selectedRole, setSelectedRole] = useState<AgentRole | null>(null);
+  const toast = useToast();
+
+  const {
+    isOpen: isAddOpen,
+    onOpen: onAddOpen,
+    onClose: onAddClose,
+  } = useDisclosure();
+  const {
+    isOpen: isEditOpen,
+    onOpen: onEditOpen,
+    onClose: onEditClose,
+  } = useDisclosure();
+
+  const fetchRoles = async () => {
+    try {
+      const data = await agentRolesApi.list(false);
+      setRoles(data);
+    } catch (err) {
+      toast({
+        title: 'Failed to load roles',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  useEffect(() => {
+    fetchRoles();
+  }, []);
+
+  const handleAdd = async (data: AgentRoleCreateData) => {
+    try {
+      await agentRolesApi.create(data);
+      await fetchRoles();
+      toast({
+        title: 'Role created',
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+      });
+    } catch (err) {
+      toast({
+        title: 'Failed to create role',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  const handleEdit = async (id: string, data: AgentRoleUpdateData) => {
+    try {
+      await agentRolesApi.update(id, data);
+      await fetchRoles();
+      toast({
+        title: 'Role updated',
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+      });
+    } catch (err) {
+      toast({
+        title: 'Failed to update role',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  if (!roles) {
+    return (
+      <Flex justify="center" align="center" p="10" minH="300px">
+        <Spinner />
+      </Flex>
+    );
+  }
+
+  return (
+    <Box p={4} maxW="600px" mx="auto">
+      <Flex justify="space-between" mb={4} align="center">
+        <Text fontSize="xl" fontWeight="bold">
+          Agent Roles
+        </Text>
+        <Button leftIcon={<AddIcon />} onClick={onAddOpen} size="sm">
+          Add Role
+        </Button>
+      </Flex>
+      {roles.length === 0 ? (
+        <Text>No roles found.</Text>
+      ) : (
+        <List spacing={3}>
+          {roles.map((role) => (
+            <ListItem key={role.id} borderWidth="1px" borderRadius="md" p={2}>
+              <Flex justify="space-between" align="center">
+                <Text>{role.display_name}</Text>
+                <Button
+                  size="sm"
+                  leftIcon={<EditIcon />}
+                  onClick={() => {
+                    setSelectedRole(role);
+                    onEditOpen();
+                  }}
+                >
+                  Edit
+                </Button>
+              </Flex>
+            </ListItem>
+          ))}
+        </List>
+      )}
+      <AddRoleModal
+        isOpen={isAddOpen}
+        onClose={onAddClose}
+        onSubmit={handleAdd}
+      />
+      <EditRoleModal
+        isOpen={isEditOpen}
+        onClose={() => {
+          setSelectedRole(null);
+          onEditClose();
+        }}
+        onSubmit={handleEdit}
+        role={selectedRole}
+      />
+    </Box>
+  );
+};
+
+export default RoleManager;

--- a/frontend/src/services/api/agent_roles.ts
+++ b/frontend/src/services/api/agent_roles.ts
@@ -1,0 +1,50 @@
+import { request } from './request';
+import { buildApiUrl, API_CONFIG } from './config';
+import type {
+  AgentRole,
+  AgentRoleCreateData,
+  AgentRoleUpdateData,
+  AgentRoleListResponse,
+  AgentRoleResponse,
+} from '@/types/agent_role';
+
+export const agentRolesApi = {
+  async list(activeOnly = true): Promise<AgentRole[]> {
+    const params = new URLSearchParams();
+    params.append('active_only', String(activeOnly));
+    const res = await request<AgentRole[]>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/roles/?${params.toString()}`)
+    );
+    return res;
+  },
+
+  async get(name: string): Promise<AgentRole> {
+    const res = await request<AgentRole>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/roles/${name}`)
+    );
+    return res;
+  },
+
+  async create(data: AgentRoleCreateData): Promise<AgentRole> {
+    const res = await request<AgentRoleResponse>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, '/roles/'),
+      { method: 'POST', body: JSON.stringify(data) }
+    );
+    return res.data;
+  },
+
+  async update(id: string, data: AgentRoleUpdateData): Promise<AgentRole> {
+    const res = await request<AgentRoleResponse>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/roles/${id}`),
+      { method: 'PUT', body: JSON.stringify(data) }
+    );
+    return res.data;
+  },
+
+  async delete(id: string): Promise<{ message: string }> {
+    return request<{ message: string }>(
+      buildApiUrl(API_CONFIG.ENDPOINTS.RULES, `/roles/${id}`),
+      { method: 'DELETE' }
+    );
+  },
+};

--- a/frontend/src/types/agent_role.ts
+++ b/frontend/src/types/agent_role.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+export const agentRoleBaseSchema = z.object({
+  name: z.string(),
+  display_name: z.string(),
+  primary_purpose: z.string(),
+  is_active: z.boolean().default(true),
+});
+
+export const agentRoleCreateSchema = agentRoleBaseSchema;
+export type AgentRoleCreateData = z.infer<typeof agentRoleCreateSchema>;
+
+export const agentRoleUpdateSchema = agentRoleBaseSchema.partial();
+export type AgentRoleUpdateData = z.infer<typeof agentRoleUpdateSchema>;
+
+export const agentRoleSchema = agentRoleBaseSchema.extend({
+  id: z.string(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+export type AgentRole = z.infer<typeof agentRoleSchema>;
+
+export interface AgentRoleResponse {
+  data: AgentRole;
+}
+
+export interface AgentRoleListResponse {
+  data: AgentRole[];
+  total: number;
+  page: number;
+  pageSize: number;
+}


### PR DESCRIPTION
## Summary
- add form components for managing agent roles and capabilities
- build RoleManager and CapabilityManager components
- expose new pages `/agent-roles` and `/agent-capabilities`
- create agent roles API client and related types

## Testing
- `npm run lint` (frontend)
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm --prefix frontend run test` *(fails: several component tests)*

------
https://chatgpt.com/codex/tasks/task_e_6841e5ed2d88832c8d99c8312b877e68