### PR TITLE
Add memory search page

### DIFF
--- a/frontend/src/app/memory/search/page.tsx
+++ b/frontend/src/app/memory/search/page.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import React from 'react';
+import MemorySearch from '@/components/memory/MemorySearch';
+
+const MemorySearchPage: React.FC = () => {
+  return <MemorySearch />;
+};
+
+export default MemorySearchPage;

--- a/frontend/src/components/__tests__/MemorySearch.test.tsx
+++ b/frontend/src/components/__tests__/MemorySearch.test.tsx
@@ -13,14 +13,12 @@ vi.mock('@chakra-ui/react', async () => {
 });
 
 vi.mock('@/services/api', () => ({
-  mcpApi: {
-    memory: {
-      searchGraph: vi.fn(),
-    },
+  memoryApi: {
+    searchGraph: vi.fn(),
   },
 }));
 
-const { mcpApi } = await import('@/services/api');
+const { memoryApi } = await import('@/services/api');
 
 describe('MemorySearch', () => {
   const user = userEvent.setup();
@@ -30,7 +28,7 @@ describe('MemorySearch', () => {
   });
 
   it('sends search request and renders results', async () => {
-    (mcpApi.memory.searchGraph as any).mockResolvedValue({
+    (memoryApi.searchGraph as any).mockResolvedValue({
       data: [
         { id: 1, entity_type: 'file', content: 'doc', created_at: '2024' },
       ],
@@ -47,7 +45,7 @@ describe('MemorySearch', () => {
     await user.click(screen.getByTestId('memory-search-button'));
 
     await waitFor(() =>
-      expect(mcpApi.memory.searchGraph).toHaveBeenCalledWith('query')
+      expect(memoryApi.searchGraph).toHaveBeenCalledWith('query')
     );
     await waitFor(() => expect(screen.getByRole('link')).toHaveAttribute('href', '/memory/1'));
   });

--- a/frontend/src/components/memory/MemorySearch.tsx
+++ b/frontend/src/components/memory/MemorySearch.tsx
@@ -12,7 +12,7 @@ import {
   Link,
 } from "@chakra-ui/react";
 import NextLink from "next/link";
-import { mcpApi } from "@/services/api";
+import { memoryApi } from "@/services/api";
 import type { MemoryEntity } from "@/types/memory";
 
 const MemorySearch: React.FC = () => {
@@ -27,9 +27,9 @@ const MemorySearch: React.FC = () => {
     setLoading(true);
     setError(null);
     try {
-      const resp = await mcpApi.memory.searchGraph(query);
-      const data = (resp as any).data as MemoryEntity[];
-      setResults(data || []);
+      const resp = await memoryApi.searchGraph(query);
+      const data = (resp as any).data ?? resp;
+      setResults((data as MemoryEntity[]) || []);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Search failed");
     } finally {


### PR DESCRIPTION
## Summary
- use memoryApi for memory search
- add page to render `MemorySearch`
- update tests for new API

## Testing
- `npm run lint --prefix frontend` *(fails: next not found)*
- `npm test --prefix frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e5ec3bf8832c925208ec341c223a