### PR TITLE
feat: add memory hooks

### DIFF
--- a/frontend/src/components/devtools/MemoryViewer.tsx
+++ b/frontend/src/components/devtools/MemoryViewer.tsx
@@ -1,28 +1,12 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { Box, Heading, Spinner, Text, VStack } from "@chakra-ui/react";
-import { memoryApi } from "@/services/api";
 import type { MemoryEntity } from "@/types/memory";
+import { useListMemory } from "@/hooks/useMemory";
 
 const MemoryViewer: React.FC = () => {
-  const [entities, setEntities] = useState<MemoryEntity[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    const fetchEntities = async () => {
-      try {
-        const resp = await memoryApi.listEntities({ skip: 0, limit: 20 });
-        setEntities(resp.data);
-      } catch (err) {
-        setError((err as Error).message);
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchEntities();
-  }, []);
+  const { entities, loading, error } = useListMemory({ skip: 0, limit: 20 });
 
   return (
     <Box>

--- a/frontend/src/components/memory/MemoryIngestForm.tsx
+++ b/frontend/src/components/memory/MemoryIngestForm.tsx
@@ -15,6 +15,7 @@ import {
   useToast,
 } from "@chakra-ui/react";
 import { memoryApi } from "@/services/api";
+import { useIngestFile } from "@/hooks/useMemory";
 
 const MemoryIngestForm: React.FC = () => {
   const toast = useToast();
@@ -23,13 +24,14 @@ const MemoryIngestForm: React.FC = () => {
   const [url, setUrl] = useState("");
   const [text, setText] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const { ingestFile } = useIngestFile();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsLoading(true);
     try {
       if (mode === "file") {
-        await memoryApi.ingestFile(filePath);
+        await ingestFile(filePath);
       } else if (mode === "url") {
         await memoryApi.ingestUrl(url);
       } else {

--- a/frontend/src/components/project/ProjectFiles.tsx
+++ b/frontend/src/components/project/ProjectFiles.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState } from 'react';
 import { Box, Button, Input, List, ListItem, useToast } from '@chakra-ui/react';
 import { mcpApi, memoryApi } from '@/services/api';
+import { useIngestFile } from '@/hooks/useMemory';
 import type { ProjectFileAssociation } from '@/services/api/projects';
 import TaskPagination from '../task/TaskPagination';
 
@@ -19,6 +20,7 @@ const ProjectFiles: React.FC<ProjectFilesProps> = ({ projectId }) => {
   const [uploading, setUploading] = useState(false);
   const [currentPage, setCurrentPage] = useState(0);
   const itemsPerPage = 10;
+  const { ingestFile } = useIngestFile();
 
   const fetchFiles = async () => {
     setLoading(true);
@@ -46,7 +48,7 @@ const ProjectFiles: React.FC<ProjectFilesProps> = ({ projectId }) => {
     if (!filePath) return;
     setUploading(true);
     try {
-      const entity = await memoryApi.ingestFile(filePath);
+      const entity = await ingestFile(filePath);
       await mcpApi.projectFile.add({
         project_id: projectId,
         file_id: String(entity.id),

--- a/frontend/src/hooks/__tests__/useMemory.test.tsx
+++ b/frontend/src/hooks/__tests__/useMemory.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@/__tests__/utils/test-utils';
+import { useListMemory, useIngestFile, useCreateMemory } from '../useMemory';
+import { memoryApi } from '@/services/api';
+
+vi.mock('@/services/api', () => ({
+  memoryApi: {
+    listEntities: vi.fn(),
+    ingestFile: vi.fn(),
+    createEntity: vi.fn(),
+  },
+}));
+
+const mockedApi = vi.mocked(memoryApi);
+
+describe('memory hooks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('useListMemory fetches entities', async () => {
+    const entities = [
+      { id: 1, entity_type: 'file', content: 'a', created_at: '2024' },
+    ];
+    mockedApi.listEntities.mockResolvedValueOnce({ data: entities } as any);
+    const { result } = renderHook(() => useListMemory());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.entities).toEqual(entities);
+    expect(mockedApi.listEntities).toHaveBeenCalled();
+  });
+
+  it('useIngestFile calls API', async () => {
+    const entity = { id: 2, entity_type: 'file', content: '', created_at: '2024' };
+    mockedApi.ingestFile.mockResolvedValueOnce(entity as any);
+    const { result } = renderHook(() => useIngestFile());
+
+    await act(async () => {
+      await result.current.ingestFile('/tmp/test.txt');
+    });
+
+    expect(mockedApi.ingestFile).toHaveBeenCalledWith('/tmp/test.txt');
+  });
+
+  it('useCreateMemory calls API', async () => {
+    const entity = { id: 3, entity_type: 'note', content: 'x', created_at: '2024' };
+    mockedApi.createEntity.mockResolvedValueOnce(entity as any);
+    const { result } = renderHook(() => useCreateMemory());
+
+    await act(async () => {
+      await result.current.createMemory({ entity_type: 'note', content: 'x' });
+    });
+
+    expect(mockedApi.createEntity).toHaveBeenCalledWith({ entity_type: 'note', content: 'x' });
+  });
+});

--- a/frontend/src/hooks/useMemory.ts
+++ b/frontend/src/hooks/useMemory.ts
@@ -1,0 +1,99 @@
+import { useState, useEffect, useCallback } from 'react';
+import { memoryApi } from '@/services/api';
+import type {
+  MemoryEntity,
+  MemoryEntityCreateData,
+  MemoryEntityFilters,
+} from '@/types/memory';
+
+export interface UseCreateMemoryResult {
+  createMemory: (data: MemoryEntityCreateData) => Promise<MemoryEntity>;
+  loading: boolean;
+  error: string | null;
+}
+
+export const useCreateMemory = (): UseCreateMemoryResult => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const createMemory = useCallback(async (data: MemoryEntityCreateData) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const entity = await memoryApi.createEntity(data);
+      return entity;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create memory');
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { createMemory, loading, error };
+};
+
+export interface UseIngestFileResult {
+  ingestFile: (path: string) => Promise<MemoryEntity>;
+  loading: boolean;
+  error: string | null;
+}
+
+export const useIngestFile = (): UseIngestFileResult => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const ingestFile = useCallback(async (path: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const entity = await memoryApi.ingestFile(path);
+      return entity;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to ingest file');
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { ingestFile, loading, error };
+};
+
+export interface UseListMemoryResult {
+  entities: MemoryEntity[];
+  loading: boolean;
+  error: string | null;
+  refresh: (f?: MemoryEntityFilters & { skip?: number; limit?: number }) => Promise<void>;
+}
+
+export const useListMemory = (
+  filters?: MemoryEntityFilters & { skip?: number; limit?: number },
+): UseListMemoryResult => {
+  const [entities, setEntities] = useState<MemoryEntity[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchEntities = useCallback(
+    async (f?: MemoryEntityFilters & { skip?: number; limit?: number }) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const resp = await memoryApi.listEntities({ ...filters, ...f });
+        setEntities(resp.data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load memory');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [filters],
+  );
+
+  useEffect(() => {
+    fetchEntities();
+  }, [fetchEntities]);
+
+  return { entities, loading, error, refresh: fetchEntities };
+};
+


### PR DESCRIPTION
## Summary
- add custom memory hooks (useCreateMemory, useListMemory, useIngestFile)
- reuse hooks in MemoryViewer, MemoryIngestForm and ProjectFiles
- add unit tests for the new hooks

## Testing
- `npm run lint` *(fails: `next` command not found until dependencies installed, then passes)*
- `npm run test` *(fails: various vitest failures)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6841e5e97b94832cbcd2f5f5aa77d255