### PR TITLE
Add file upload to task details

### DIFF
--- a/frontend/src/components/modals/TaskDetailsModal.tsx
+++ b/frontend/src/components/modals/TaskDetailsModal.tsx
@@ -35,6 +35,7 @@ import { useTaskStore } from "@/store/taskStore"; // To potentially get project/
 import { getDisplayableStatus, StatusID } from "@/lib/statusUtils"; // Added import
 import { DeleteIcon, DownloadIcon, RepeatClockIcon } from "@chakra-ui/icons";
 import AppIcon from "../common/AppIcon";
+import TaskFiles from "../task/TaskFiles";
 import { typography, sizing, shadows } from "@/tokens"; // Added tokens
 
 interface TaskDetailsModalProps {
@@ -438,6 +439,7 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({
                       : "N/A"}
                   </Text>
                 </Box>
+                <TaskFiles projectId={task.project_id} taskNumber={task.task_number} />
               </VStack>
             )}
           </ModalBody>

--- a/frontend/src/components/task/TaskFiles.tsx
+++ b/frontend/src/components/task/TaskFiles.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { Box, Button, Input, List, ListItem, useToast } from '@chakra-ui/react';
+import { memoryApi } from '@/services/api';
+import {
+  getFilesAssociatedWithTask,
+  associateFileWithTask,
+  disassociateFileFromTask,
+} from '@/services/api/tasks';
+import type { TaskFileAssociation } from '@/types/task';
+
+interface TaskFilesProps {
+  projectId: string;
+  taskNumber: number;
+}
+
+const TaskFiles: React.FC<TaskFilesProps> = ({ projectId, taskNumber }) => {
+  const toast = useToast();
+  const [files, setFiles] = useState<TaskFileAssociation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [filePath, setFilePath] = useState('');
+  const [uploading, setUploading] = useState(false);
+
+  const fetchFiles = async () => {
+    setLoading(true);
+    try {
+      const data = await getFilesAssociatedWithTask(projectId, taskNumber);
+      setFiles(data);
+    } catch (err) {
+      setError('Failed to fetch task files');
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchFiles();
+  }, [projectId, taskNumber]);
+
+  const handleUpload = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!filePath) return;
+    setUploading(true);
+    try {
+      const entity = await memoryApi.ingestFile(filePath);
+      await associateFileWithTask(projectId, taskNumber, {
+        file_id: String(entity.id),
+      });
+      setFilePath('');
+      toast({ title: 'File uploaded', status: 'success', duration: 3000, isClosable: true });
+      fetchFiles();
+    } catch (err) {
+      console.error(err);
+      toast({ title: 'Upload failed', status: 'error', duration: 5000, isClosable: true });
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleRemove = async (fileId: string) => {
+    try {
+      await disassociateFileFromTask(projectId, taskNumber, fileId);
+      fetchFiles();
+    } catch (err) {
+      console.error(err);
+      toast({ title: 'Remove failed', status: 'error', duration: 5000, isClosable: true });
+    }
+  };
+
+  const handleDownload = async (fileId: string) => {
+    try {
+      const entity = await memoryApi.getEntity(Number(fileId));
+      const content = entity.content || '';
+      const filename = (entity.metadata as any)?.filename || `file_${fileId}`;
+      const blob = new Blob([content], { type: 'text/plain' });
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      a.click();
+      window.URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error(err);
+      toast({ title: 'Download failed', status: 'error', duration: 5000, isClosable: true });
+    }
+  };
+
+  if (loading) {
+    return <div>Loading files...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error}</div>;
+  }
+
+  return (
+    <Box>
+      <h3>Task Files</h3>
+      {files.length === 0 ? (
+        <p>No files associated.</p>
+      ) : (
+        <List>
+          {files.map((file) => (
+            <ListItem key={file.file_id} display="flex" gap={2} alignItems="center">
+              <span>{file.file_id}</span>
+              <Button size="xs" onClick={() => handleDownload(file.file_id)}>
+                Download
+              </Button>
+              <Button size="xs" onClick={() => handleRemove(file.file_id)}>
+                Delete
+              </Button>
+            </ListItem>
+          ))}
+        </List>
+      )}
+      <form onSubmit={handleUpload} style={{ marginTop: '1rem' }}>
+        <Input
+          value={filePath}
+          onChange={(e) => setFilePath(e.target.value)}
+          placeholder="/path/to/file.txt"
+        />
+        <Button type="submit" mt={2} isLoading={uploading}>
+          Upload
+        </Button>
+      </form>
+    </Box>
+  );
+};
+
+export default TaskFiles;
+

--- a/frontend/src/components/task/__tests__/TaskFiles.test.tsx
+++ b/frontend/src/components/task/__tests__/TaskFiles.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor } from '@/__tests__/utils/test-utils';
+import { TestWrapper } from '@/__tests__/utils/test-utils';
+import TaskFiles from '../TaskFiles';
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual('@chakra-ui/react');
+  return {
+    ...actual,
+    useToast: () => vi.fn(),
+    useColorModeValue: (l: any, d: any) => l,
+  };
+});
+
+vi.mock('@/services/api', () => ({
+  memoryApi: {
+    ingestFile: vi.fn(),
+    getEntity: vi.fn(),
+  },
+}));
+
+vi.mock('@/services/api/tasks', () => ({
+  getFilesAssociatedWithTask: vi.fn(),
+  associateFileWithTask: vi.fn(),
+  disassociateFileFromTask: vi.fn(),
+}));
+
+const { memoryApi } = await import('@/services/api');
+const tasksApi = await import('@/services/api/tasks');
+
+describe('TaskFiles', () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (tasksApi.getFilesAssociatedWithTask as any).mockResolvedValue([]);
+  });
+
+  it('refreshes list after upload', async () => {
+    (memoryApi.ingestFile as any).mockResolvedValue({ id: 1 });
+    render(
+      <TestWrapper>
+        <TaskFiles projectId="p1" taskNumber={1} />
+      </TestWrapper>
+    );
+    await waitFor(() =>
+      expect(tasksApi.getFilesAssociatedWithTask).toHaveBeenCalledWith('p1', 1)
+    );
+    const input = screen.getByPlaceholderText('/path/to/file.txt');
+    await user.type(input, '/tmp/file.txt');
+    await user.click(screen.getByRole('button', { name: /upload/i }));
+    await waitFor(() => expect(memoryApi.ingestFile).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(tasksApi.associateFileWithTask).toHaveBeenCalledWith('p1', 1, {
+        file_id: '1',
+      })
+    );
+    await waitFor(() =>
+      expect(tasksApi.getFilesAssociatedWithTask).toHaveBeenCalledTimes(2)
+    );
+  });
+
+  it('refreshes list after deletion', async () => {
+    (tasksApi.getFilesAssociatedWithTask as any)
+      .mockResolvedValueOnce([{ file_id: '1', task_project_id: 'p1', task_number: 1 }])
+      .mockResolvedValueOnce([]);
+    render(
+      <TestWrapper>
+        <TaskFiles projectId="p1" taskNumber={1} />
+      </TestWrapper>
+    );
+    await waitFor(() =>
+      expect(tasksApi.getFilesAssociatedWithTask).toHaveBeenCalledWith('p1', 1)
+    );
+    await user.click(screen.getByRole('button', { name: /delete/i }));
+    await waitFor(() =>
+      expect(tasksApi.disassociateFileFromTask).toHaveBeenCalledWith('p1', 1, '1')
+    );
+    await waitFor(() =>
+      expect(tasksApi.getFilesAssociatedWithTask).toHaveBeenCalledTimes(2)
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `TaskFiles` component for uploading and managing task attachments
- show file upload area in `TaskDetailsModal`
- test task file uploads and removals

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test:components` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e5e79a28832cac58120f5d1696ac