### PR TITLE
Normalize API wrapper parsing

### DIFF
--- a/frontend/src/services/api/agents.ts
+++ b/frontend/src/services/api/agents.ts
@@ -34,7 +34,7 @@ export const getAgents = async (skip: number = 0, limit: number = 100, search?: 
   if (is_archived !== undefined) queryParams.append("is_archived", String(is_archived));
   const queryString = queryParams.toString();
   const url = buildApiUrl(API_CONFIG.ENDPOINTS.AGENTS, `?${queryString}`);
-  const rawAgents = await request<RawAgent[]>(url);
+  const { data: rawAgents } = await request<{ data: RawAgent[] }>(url);
   return rawAgents.map((rawAgent) => ({
     ...rawAgent,
     id: String(rawAgent.id),
@@ -49,7 +49,7 @@ export const getAgents = async (skip: number = 0, limit: number = 100, search?: 
 };
 
 export const getAgentById = async (agent_id: string): Promise<Agent> => {
-  const rawAgent = await request<RawAgent>(
+  const { data: rawAgent } = await request<{ data: RawAgent }>(
     buildApiUrl(API_CONFIG.ENDPOINTS.AGENTS, `/id/${agent_id}`)
   );
   return {
@@ -62,7 +62,7 @@ export const getAgentById = async (agent_id: string): Promise<Agent> => {
 };
 
 export const getAgentByName = async (agent_name: string): Promise<Agent> => {
-  const rawAgent = await request<RawAgent>(
+  const { data: rawAgent } = await request<{ data: RawAgent }>(
     buildApiUrl(API_CONFIG.ENDPOINTS.AGENTS, `/${agent_name}`)
   );
   return {
@@ -75,7 +75,7 @@ export const getAgentByName = async (agent_name: string): Promise<Agent> => {
 };
 
 export const createAgent = async (agentData: AgentCreateData): Promise<Agent> => {
-  const rawAgent = await request<RawAgent>(
+  const { data: rawAgent } = await request<{ data: RawAgent }>(
     buildApiUrl(API_CONFIG.ENDPOINTS.AGENTS, "/"),
     { method: "POST", body: JSON.stringify(agentData) },
   );
@@ -92,7 +92,7 @@ export const updateAgentById = async (
   agent_id: string,
   agentData: AgentUpdateDataType,
 ): Promise<Agent> => {
-  const rawAgent = await request<RawAgent>(
+  const { data: rawAgent } = await request<{ data: RawAgent }>(
     buildApiUrl(API_CONFIG.ENDPOINTS.AGENTS, `/${agent_id}`),
     { method: "PUT", body: JSON.stringify(agentData) },
   );

--- a/frontend/src/services/api/forbidden_actions.ts
+++ b/frontend/src/services/api/forbidden_actions.ts
@@ -15,7 +15,7 @@ export const forbiddenActionsApi = {
     roleId: string,
     data: AgentForbiddenActionCreateData,
   ): Promise<AgentForbiddenAction> {
-    return request<AgentForbiddenAction>(
+    const { data: action } = await request<{ data: AgentForbiddenAction }>(
       buildApiUrl(
         API_CONFIG.ENDPOINTS.RULES,
         `/roles/${roleId}/forbidden-actions`,
@@ -25,26 +25,29 @@ export const forbiddenActionsApi = {
         body: JSON.stringify(data),
       },
     );
+    return action;
   },
 
   /** Retrieve forbidden actions for a role */
   async list(roleId: string): Promise<AgentForbiddenAction[]> {
-    return request<AgentForbiddenAction[]>(
+    const { data } = await request<{ data: AgentForbiddenAction[] }>(
       buildApiUrl(
         API_CONFIG.ENDPOINTS.RULES,
         `/roles/${roleId}/forbidden-actions`,
       ),
     );
+    return data;
   },
 
   /** Get a single forbidden action by ID */
   async get(actionId: string): Promise<AgentForbiddenAction> {
-    return request<AgentForbiddenAction>(
+    const { data } = await request<{ data: AgentForbiddenAction }>(
       buildApiUrl(
         API_CONFIG.ENDPOINTS.RULES,
         `/roles/forbidden-actions/${actionId}`,
       ),
     );
+    return data;
   },
 
   /** Update a forbidden action */
@@ -52,23 +55,25 @@ export const forbiddenActionsApi = {
     actionId: string,
     data: AgentForbiddenActionUpdateData,
   ): Promise<AgentForbiddenAction> {
-    return request<AgentForbiddenAction>(
+    const { data } = await request<{ data: AgentForbiddenAction }>(
       buildApiUrl(
         API_CONFIG.ENDPOINTS.RULES,
         `/roles/forbidden-actions/${actionId}`,
       ),
       { method: 'PUT', body: JSON.stringify(data) },
     );
+    return data;
   },
 
   /** Delete a forbidden action */
   async delete(actionId: string): Promise<{ message: string }> {
-    return request<{ message: string }>(
+    const resp = await request<{ message: string }>(
       buildApiUrl(
         API_CONFIG.ENDPOINTS.RULES,
         `/roles/forbidden-actions/${actionId}`
       ),
       { method: 'DELETE' }
     );
+    return resp;
   },
 };

--- a/frontend/src/services/api/project_templates.ts
+++ b/frontend/src/services/api/project_templates.ts
@@ -22,21 +22,24 @@ export async function deleteTemplate(
 export const projectTemplatesApi = {
   /** Create a new project template */
   async create(data: ProjectTemplateCreateData): Promise<ProjectTemplate> {
-    return request<ProjectTemplate>(buildApiUrl("/project-templates/"), {
+    const { data: template } = await request<{ data: ProjectTemplate }>(buildApiUrl("/project-templates/"), {
       method: "POST",
       body: JSON.stringify(data),
     });
+    return template;
   },
 
   /** List project templates with basic pagination */
   async list(skip = 0, limit = 100): Promise<ProjectTemplate[]> {
     const params = new URLSearchParams({ skip: String(skip), limit: String(limit) });
-    return request<ProjectTemplate[]>(buildApiUrl("/project-templates/", `?${params}`));
+    const { data } = await request<{ data: ProjectTemplate[] }>(buildApiUrl("/project-templates/", `?${params}`));
+    return data;
   },
 
   /** Retrieve a single project template */
   async get(templateId: string): Promise<ProjectTemplate> {
-    return request<ProjectTemplate>(buildApiUrl("/project-templates/", `/${templateId}`));
+    const { data } = await request<{ data: ProjectTemplate }>(buildApiUrl("/project-templates/", `/${templateId}`));
+    return data;
   },
 
   /** Update a project template */
@@ -44,10 +47,11 @@ export const projectTemplatesApi = {
     templateId: string,
     data: ProjectTemplateUpdateData,
   ): Promise<ProjectTemplate> {
-    return request<ProjectTemplate>(buildApiUrl("/project-templates/", `/${templateId}`), {
+    const { data: tpl } = await request<{ data: ProjectTemplate }>(buildApiUrl("/project-templates/", `/${templateId}`), {
       method: "PUT",
       body: JSON.stringify(data),
     });
+    return tpl;
   },
 
   /** Delete a project template */

--- a/frontend/src/services/api/projects.ts
+++ b/frontend/src/services/api/projects.ts
@@ -38,8 +38,8 @@ export const getProjects = async (
     API_CONFIG.ENDPOINTS.PROJECTS,
     queryString ? `?${queryString}` : ''
   );
-  const rawProjects = await request<RawProject[]>(url);
-  return rawProjects.map((rawProject) => ({
+  const resp = await request<{ data: RawProject[] }>(url);
+  return resp.data.map((rawProject) => ({
     ...rawProject,
     id: String(rawProject.id),
     name: String(rawProject.name || ''),
@@ -65,7 +65,7 @@ export const getProjectById = async (
     API_CONFIG.ENDPOINTS.PROJECTS,
     `/${projectId}${queryString ? `?${queryString}` : ''}`
   );
-  const rawProject = await request<RawProject>(url);
+  const { data: rawProject } = await request<{ data: RawProject }>(url);
   return {
     ...rawProject,
     id: String(rawProject.id),
@@ -82,7 +82,7 @@ export const getProjectById = async (
 export const createProject = async (
   projectData: ProjectCreateData
 ): Promise<Project> => {
-  const rawProject = await request<RawProject>(
+  const { data: rawProject } = await request<{ data: RawProject }>(
     buildApiUrl(API_CONFIG.ENDPOINTS.PROJECTS, '/'),
     { method: 'POST', body: JSON.stringify(projectData) }
   );
@@ -103,7 +103,7 @@ export const updateProject = async (
   project_id: string,
   projectData: ProjectUpdateData
 ): Promise<Project> => {
-  const rawProject = await request<RawProject>(
+  const { data: rawProject } = await request<{ data: RawProject }>(
     buildApiUrl(API_CONFIG.ENDPOINTS.PROJECTS, `/${project_id}`),
     { method: 'PUT', body: JSON.stringify(projectData) }
   );
@@ -121,7 +121,7 @@ export const updateProject = async (
 
 // Delete a project
 export const deleteProject = async (project_id: string): Promise<Project> => {
-  const rawProject = await request<RawProject>(
+  const { data: rawProject } = await request<{ data: RawProject }>(
     buildApiUrl(API_CONFIG.ENDPOINTS.PROJECTS, `/${project_id}`),
     { method: 'DELETE' }
   );
@@ -139,7 +139,7 @@ export const deleteProject = async (project_id: string): Promise<Project> => {
 
 // --- Project Archive/Unarchive ---
 export const archiveProject = async (projectId: string): Promise<Project> => {
-  const rawProject = await request<RawProject>(
+  const { data: rawProject } = await request<{ data: RawProject }>(
     buildApiUrl(API_CONFIG.ENDPOINTS.PROJECTS, `/${projectId}/archive`),
     { method: 'POST' }
   );
@@ -156,7 +156,7 @@ export const archiveProject = async (projectId: string): Promise<Project> => {
 };
 
 export const unarchiveProject = async (projectId: string): Promise<Project> => {
-  const rawProject = await request<RawProject>(
+  const { data: rawProject } = await request<{ data: RawProject }>(
     buildApiUrl(API_CONFIG.ENDPOINTS.PROJECTS, `/${projectId}/unarchive`),
     { method: 'POST' }
   );

--- a/frontend/src/services/api/request.ts
+++ b/frontend/src/services/api/request.ts
@@ -110,14 +110,5 @@ export async function request<T>(
   }
 
   const responseData = await response.json();
-
-  if (
-    responseData &&
-    typeof responseData === 'object' &&
-    'data' in responseData
-  ) {
-    return responseData.data as T;
-  }
-
   return responseData as T;
 }

--- a/frontend/src/services/api/tasks.ts
+++ b/frontend/src/services/api/tasks.ts
@@ -205,8 +205,8 @@ export const getTasks = async (
   }
   const queryString = queryParams.toString();
   const url = buildApiUrl(API_CONFIG.ENDPOINTS.PROJECTS, `/${projectId}/tasks${queryString ? `?${queryString}` : ""}`);
-  const rawTasks = await request<RawTask[]>(url);
-  return rawTasks.map((rawTask) => {
+  const resp = await request<{ data: RawTask[] }>(url);
+  return resp.data.map((rawTask) => {
     const statusId = normalizeToStatusID(rawTask.status, !!rawTask.completed);
     return {
       ...rawTask,
@@ -254,8 +254,8 @@ export const getAllTasks = async (
   }
   const queryString = queryParams.toString();
   const url = buildApiUrl(API_CONFIG.ENDPOINTS.TASKS, queryString ? `?${queryString}` : "");
-  const rawTasks = await request<RawTask[]>(url);
-  return rawTasks.map((rawTask) => {
+  const resp = await request<{ data: RawTask[] }>(url);
+  return resp.data.map((rawTask) => {
     const statusId = normalizeToStatusID(rawTask.status, !!rawTask.completed);
     return {
       ...rawTask,
@@ -289,7 +289,7 @@ export const getTaskById = async (
   }
   const queryString = queryParams.toString();
   const url = buildApiUrl(API_CONFIG.ENDPOINTS.PROJECTS, `/${project_id}/tasks/${task_number}${queryString ? `?${queryString}` : ""}`);
-  const rawTask = await request<RawTask>(url);
+  const { data: rawTask } = await request<{ data: RawTask }>(url);
   const statusId = normalizeToStatusID(rawTask.status, !!rawTask.completed);
   return {
     ...rawTask,
@@ -312,7 +312,7 @@ export const getTaskById = async (
 
 // Create a new task
 export const createTask = async (project_id: string, taskData: TaskCreateData): Promise<Task> => {
-  const rawTask = await request<RawTask>(
+  const { data: rawTask } = await request<{ data: RawTask }>(
     buildApiUrl(API_CONFIG.ENDPOINTS.PROJECTS, `/${project_id}/tasks/`),
     { method: "POST", body: JSON.stringify(taskData) },
   );
@@ -348,7 +348,7 @@ export const updateTask = async (
       : TaskStatus.TO_DO;
     delete payload.completed;
   }
-  const rawTask = await request<RawTask>(
+  const { data: rawTask } = await request<{ data: RawTask }>(
     buildApiUrl(API_CONFIG.ENDPOINTS.PROJECTS, `/${project_id}/tasks/${task_number}`),
     { method: "PUT", body: JSON.stringify(payload) },
   );
@@ -385,7 +385,7 @@ export const deleteTask = async (
   project_id: string,
   task_number: number,
 ): Promise<Task> => {
-  const rawTask = await request<RawTask>(
+  const { data: rawTask } = await request<{ data: RawTask }>(
     buildApiUrl(API_CONFIG.ENDPOINTS.PROJECTS, `/${project_id}/tasks/${task_number}`),
     { method: "DELETE" },
   );
@@ -419,12 +419,13 @@ export const getTaskComments = async (
   project_id: string,
   task_number: number
 ): Promise<Comment[]> => {
-  return request<Comment[]>(
+  const { data } = await request<{ data: Comment[] }>(
     buildApiUrl(
       API_CONFIG.ENDPOINTS.PROJECTS,
       `/${project_id}/tasks/${task_number}/comments/`
     )
   );
+  return data;
 };
 
 export const addTaskComment = async (
@@ -432,13 +433,14 @@ export const addTaskComment = async (
   task_number: number,
   commentData: CommentCreateData
 ): Promise<Comment> => {
-  return request<Comment>(
+  const { data } = await request<{ data: Comment }>(
     buildApiUrl(
       API_CONFIG.ENDPOINTS.PROJECTS,
       `/${project_id}/tasks/${task_number}/comments/`
     ),
     { method: "POST", body: JSON.stringify(commentData) }
   );
+  return data;
 };
 
 // --- Task Archive/Unarchive ---
@@ -446,7 +448,7 @@ export const archiveTask = async (
   project_id: string,
   task_number: number,
 ): Promise<Task> => {
-  const rawTask = await request<RawTask>(
+  const { data: rawTask } = await request<{ data: RawTask }>(
     buildApiUrl(API_CONFIG.ENDPOINTS.PROJECTS, `/${project_id}/tasks/${task_number}/archive`),
     { method: "POST" },
   );
@@ -472,7 +474,7 @@ export const unarchiveTask = async (
   project_id: string,
   task_number: number,
 ): Promise<Task> => {
-  const rawTask = await request<RawTask>(
+  const { data: rawTask } = await request<{ data: RawTask }>(
     buildApiUrl(API_CONFIG.ENDPOINTS.PROJECTS, `/${project_id}/tasks/${task_number}/unarchive`),
     { method: "POST" },
   );


### PR DESCRIPTION
## Summary
- stop auto-extracting `data` in request helper
- update task, project, agent API services to read `response.data`
- adjust forbidden actions and template APIs for new response shape

## Testing
- `npm --prefix frontend run lint` *(fails: next not found)*
- `npm --prefix frontend run test` *(fails: vitest not found)*
- `pytest` *(fails: ModuleNotFoundError: sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_6841e5e553f8832cb146f7b9f2e5db52