### PR TITLE
Add pagination for project files

### DIFF
--- a/backend/routers/projects/files.py
+++ b/backend/routers/projects/files.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status, Query
 from sqlalchemy.orm import Session
 from typing import List  # Import logging at the top of the file
 import logging
@@ -40,8 +40,8 @@ def get_audit_log_service(db: Session = Depends(get_db)) -> AuditLogService:
 
 async def get_project_files_endpoint(
     project_id: str,
-    skip: int = 0,
-    limit: int = 100,
+    skip: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1),
     project_file_service: ProjectFileAssociationService = Depends(get_project_file_association_service)
 ):
     """Get files associated with a project with pagination."""

--- a/frontend/src/components/project/ProjectFiles.tsx
+++ b/frontend/src/components/project/ProjectFiles.tsx
@@ -2,8 +2,11 @@
 
 import React, { useEffect, useState } from 'react';
 import { Box, Button, Input, List, ListItem, useToast } from '@chakra-ui/react';
-import { mcpApi, memoryApi } from '@/services/api';
-import type { ProjectFileAssociation } from '@/services/api/projects';
+import { mcpApi, memoryApi, getProjectFiles } from '@/services/api';
+import type {
+  ProjectFileAssociation,
+  ProjectFileAssociationListResponse,
+} from '@/types/project';
 import TaskPagination from '../task/TaskPagination';
 
 interface ProjectFilesProps {
@@ -18,17 +21,20 @@ const ProjectFiles: React.FC<ProjectFilesProps> = ({ projectId }) => {
   const [filePath, setFilePath] = useState('');
   const [uploading, setUploading] = useState(false);
   const [currentPage, setCurrentPage] = useState(0);
+  const [total, setTotal] = useState(0);
   const itemsPerPage = 10;
 
   const fetchFiles = async () => {
     setLoading(true);
     try {
-      const data = await mcpApi.projectFile.list(
-        projectId,
-        currentPage * itemsPerPage,
-        itemsPerPage
-      );
-      setFiles(data);
+      const response: ProjectFileAssociationListResponse =
+        await getProjectFiles(
+          projectId,
+          currentPage * itemsPerPage,
+          itemsPerPage
+        );
+      setFiles(response.data);
+      setTotal(response.total);
     } catch (err) {
       setError('Failed to fetch project files');
       console.error(err);
@@ -133,10 +139,12 @@ const ProjectFiles: React.FC<ProjectFilesProps> = ({ projectId }) => {
       <TaskPagination
         currentPage={currentPage}
         itemsPerPage={itemsPerPage}
-        totalItems={files.length + currentPage * itemsPerPage}
+        totalItems={total}
         onPrevious={() => setCurrentPage((p) => Math.max(0, p - 1))}
         onNext={() =>
-          setCurrentPage((p) => (files.length < itemsPerPage ? p : p + 1))
+          setCurrentPage((p) =>
+            Math.min(Math.ceil(total / itemsPerPage) - 1, p + 1)
+          )
         }
       />
     </Box>

--- a/frontend/src/services/api/projects.ts
+++ b/frontend/src/services/api/projects.ts
@@ -5,6 +5,8 @@ import {
   ProjectFilters,
   ProjectMember,
   ProjectMemberCreateData,
+  ProjectFileAssociation,
+  ProjectFileAssociationListResponse,
 } from '@/types';
 import { request } from './request';
 import { buildApiUrl, API_CONFIG } from './config';
@@ -208,12 +210,6 @@ export const removeMemberFromProject = async (
   );
 };
 
-export interface ProjectFileAssociation {
-  project_id: string;
-  file_id: string;
-  // Potentially add file details here if the backend relation includes them, or fetch separately
-}
-
 export interface AssociateFileWithProjectData {
   file_id: string;
 }
@@ -222,12 +218,12 @@ export const getProjectFiles = async (
   projectId: string,
   skip = 0,
   limit = 100
-): Promise<ProjectFileAssociation[]> => {
+): Promise<ProjectFileAssociationListResponse> => {
   const params = new URLSearchParams();
   params.append('skip', String(skip));
   params.append('limit', String(limit));
   const query = params.toString();
-  return request<ProjectFileAssociation[]>(
+  return request<ProjectFileAssociationListResponse>(
     buildApiUrl(API_CONFIG.ENDPOINTS.PROJECTS, `/${projectId}/files?${query}`)
   );
 };

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -129,3 +129,17 @@ export const projectMemberSchema = projectMemberBaseSchema.extend({
 });
 
 export type ProjectMember = z.infer<typeof projectMemberSchema>;
+
+// --- Project File Association Types ---
+export interface ProjectFileAssociation {
+  project_id: string;
+  file_id: string;
+}
+
+export interface ProjectFileAssociationListResponse {
+  data: ProjectFileAssociation[];
+  total: number;
+  page: number;
+  pageSize: number;
+  error?: ProjectError;
+}


### PR DESCRIPTION
## Summary
- enable skip/limit query params for project file list endpoint
- expose project file list metadata in the frontend API
- paginate project file listing in the UI
- adjust unit tests

## Testing
- `flake8 backend/routers/projects/files.py`
- `pytest backend/tests/test_project_file_service.py::test_get_project_files_passes_pagination -q`
- `npm run lint` *(fails: SyntaxError due to JSON parse error? but final log shows lint success)*

------
https://chatgpt.com/codex/tasks/task_e_6841e5e44f74832cb46ff67136bf3b73