### PR TITLE
Add project member services with toasts

### DIFF
--- a/frontend/src/components/project/ProjectDetail.tsx
+++ b/frontend/src/components/project/ProjectDetail.tsx
@@ -10,6 +10,7 @@ import ProjectFiles from './ProjectFiles';
 import { getAllTasksForProject } from '@/services/api/tasks';
 import { Task } from '@/types/task';
 import TaskItem from '@/components/task/TaskItem';
+import { useToast } from '@chakra-ui/react';
 
 const ProjectDetail: React.FC = () => {
   const { projectId } = useParams<{ projectId: string }>();
@@ -21,6 +22,7 @@ const ProjectDetail: React.FC = () => {
   const [planningPrompt, setPlanningPrompt] = useState<string | null>(null);
   const [planningLoading, setPlanningLoading] = useState(false);
   const [planningError, setPlanningError] = useState<string | null>(null);
+  const toast = useToast();
 
   const [tasks, setTasks] = useState<Task[]>([]);
   const [tasksLoading, setTasksLoading] = useState(true);
@@ -62,10 +64,21 @@ const ProjectDetail: React.FC = () => {
     if (confirm('Are you sure you want to delete this project?')) {
       try {
         await deleteProject(project.id);
-        alert('Project deleted successfully!');
+        toast({
+          title: 'Project deleted',
+          status: 'success',
+          duration: 3000,
+          isClosable: true,
+        });
         router.push('/projects');
       } catch (err) {
-        alert('Failed to delete project');
+        toast({
+          title: 'Failed to delete project',
+          description: err instanceof Error ? err.message : String(err),
+          status: 'error',
+          duration: 5000,
+          isClosable: true,
+        });
         console.error(err);
       }
     }
@@ -75,10 +88,10 @@ const ProjectDetail: React.FC = () => {
     if (!project) return;
     try {
       await archiveProject(project.id);
-      alert('Project archived successfully!');
+      toast({ title: 'Project archived', status: 'success', duration: 3000, isClosable: true });
       fetchProject();
     } catch (err) {
-      alert('Failed to archive project');
+      toast({ title: 'Failed to archive project', description: err instanceof Error ? err.message : String(err), status: 'error', duration: 5000, isClosable: true });
       console.error(err);
     }
   };
@@ -87,10 +100,10 @@ const ProjectDetail: React.FC = () => {
     if (!project) return;
     try {
       await unarchiveProject(project.id);
-      alert('Project unarchived successfully!');
+      toast({ title: 'Project unarchived', status: 'success', duration: 3000, isClosable: true });
       fetchProject();
     } catch (err) {
-      alert('Failed to unarchive project');
+      toast({ title: 'Failed to unarchive project', description: err instanceof Error ? err.message : String(err), status: 'error', duration: 5000, isClosable: true });
       console.error(err);
     }
   };

--- a/frontend/src/components/project/ProjectFiles.tsx
+++ b/frontend/src/components/project/ProjectFiles.tsx
@@ -2,7 +2,12 @@
 
 import React, { useEffect, useState } from 'react';
 import { Box, Button, Input, List, ListItem, useToast } from '@chakra-ui/react';
-import { mcpApi, memoryApi } from '@/services/api';
+import { memoryApi } from '@/services/api';
+import {
+  getProjectFiles,
+  associateFileWithProject,
+  disassociateFileFromProject,
+} from '@/services/projects';
 import type { ProjectFileAssociation } from '@/services/api/projects';
 import TaskPagination from '../task/TaskPagination';
 
@@ -23,7 +28,7 @@ const ProjectFiles: React.FC<ProjectFilesProps> = ({ projectId }) => {
   const fetchFiles = async () => {
     setLoading(true);
     try {
-      const data = await mcpApi.projectFile.list(
+      const data = await getProjectFiles(
         projectId,
         currentPage * itemsPerPage,
         itemsPerPage
@@ -47,8 +52,7 @@ const ProjectFiles: React.FC<ProjectFilesProps> = ({ projectId }) => {
     setUploading(true);
     try {
       const entity = await memoryApi.ingestFile(filePath);
-      await mcpApi.projectFile.add({
-        project_id: projectId,
+      await associateFileWithProject(projectId, {
         file_id: String(entity.id),
       });
       setFilePath('');
@@ -74,9 +78,12 @@ const ProjectFiles: React.FC<ProjectFilesProps> = ({ projectId }) => {
 
   const handleRemove = async (fileId: string) => {
     try {
-      await mcpApi.projectFile.remove({
-        project_id: projectId,
-        file_id: fileId,
+      await disassociateFileFromProject(projectId, fileId);
+      toast({
+        title: 'File removed',
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
       });
       fetchFiles();
     } catch (err) {

--- a/frontend/src/components/project/ProjectMembers.tsx
+++ b/frontend/src/components/project/ProjectMembers.tsx
@@ -1,8 +1,12 @@
 "use client";
 
 import React, { useEffect, useState } from 'react';
-import { getProjectMembers } from '@/services/api/projects';
-import { mcpApi } from '@/services/api/mcp';
+import {
+  getProjectMembers,
+  addMemberToProject,
+  removeMemberFromProject,
+} from '@/services/projects';
+import { useToast } from '@chakra-ui/react';
 import { ProjectMember, ProjectMemberRole } from '@/types/project';
 
 interface ProjectMembersProps {
@@ -10,6 +14,7 @@ interface ProjectMembersProps {
 }
 
 const ProjectMembers: React.FC<ProjectMembersProps> = ({ projectId }) => {
+  const toast = useToast();
   const [members, setMembers] = useState<ProjectMember[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -37,22 +42,49 @@ const ProjectMembers: React.FC<ProjectMembersProps> = ({ projectId }) => {
     if (!newMemberUserId || !newMemberRole) return;
 
     try {
-      await mcpApi.projectMember.add({ project_id: projectId, user_id: newMemberUserId, role: newMemberRole as ProjectMemberRole });
+      await addMemberToProject(projectId, {
+        user_id: newMemberUserId,
+        role: newMemberRole as ProjectMemberRole,
+      });
       setNewMemberUserId('');
       setNewMemberRole('');
-      fetchMembers(); // Refresh the list
+      toast({
+        title: 'Member added',
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+      });
+      fetchMembers();
     } catch (err) {
-      alert('Failed to add member');
+      toast({
+        title: 'Failed to add member',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
       console.error(err);
     }
   };
 
   const handleRemoveMember = async (userId: string) => {
     try {
-      await mcpApi.projectMember.remove({ project_id: projectId, user_id: userId });
-      fetchMembers(); // Refresh the list
+      await removeMemberFromProject(projectId, userId);
+      toast({
+        title: 'Member removed',
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+      });
+      fetchMembers();
     } catch (err) {
-      alert('Failed to remove member');
+      toast({
+        title: 'Failed to remove member',
+        description: err instanceof Error ? err.message : String(err),
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
       console.error(err);
     }
   };

--- a/frontend/src/services/projects.ts
+++ b/frontend/src/services/projects.ts
@@ -1,0 +1,8 @@
+export { 
+  getProjectMembers,
+  addMemberToProject,
+  removeMemberFromProject,
+  getProjectFiles,
+  associateFileWithProject,
+  disassociateFileFromProject,
+} from './api/projects';


### PR DESCRIPTION
## Summary
- expose project member/file APIs via new `projects.ts`
- update project components to use these APIs
- show toast feedback for project actions

## Testing
- `npm run lint`
- `npm test` *(fails: TypeError/observer.observe is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6841e5de38a8832c982780c71e1b4f85