### PR TITLE
Add archive endpoint tests

### DIFF
--- a/backend/tests/test_project_archive_endpoints.py
+++ b/backend/tests/test_project_archive_endpoints.py
@@ -1,0 +1,30 @@
+import uuid
+import pytest
+
+from backend.models import Project as ProjectModel
+
+
+@pytest.mark.asyncio
+async def test_archive_and_unarchive_project(authenticated_client, async_db_session, test_project):
+    # Archive the project
+    resp = await authenticated_client.post(f"/api/v1/projects/{test_project.id}/archive")
+    assert resp.status_code == 200
+    assert resp.json()["data"]["is_archived"] is True
+
+    refreshed = await async_db_session.get(ProjectModel, test_project.id)
+    assert refreshed.is_archived is True
+
+    # Unarchive the project
+    resp = await authenticated_client.post(f"/api/v1/projects/{test_project.id}/unarchive")
+    assert resp.status_code == 200
+    assert resp.json()["data"]["is_archived"] is False
+
+    refreshed = await async_db_session.get(ProjectModel, test_project.id)
+    assert refreshed.is_archived is False
+
+
+@pytest.mark.asyncio
+async def test_archive_project_not_found(authenticated_client):
+    missing_id = uuid.uuid4()
+    resp = await authenticated_client.post(f"/api/v1/projects/{missing_id}/archive")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- add integration tests for project archive/unarchive endpoints

## Testing
- `pytest tests/test_project_archive_endpoints.py::test_archive_and_unarchive_project -q` *(fails: OperationalError index already exists)*

------
https://chatgpt.com/codex/tasks/task_e_6841e5ddeae8832caecb52bfaa260aad