### PR TITLE
Add CI linting and coverage thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Test with coverage
         run: |
           cd backend
-          pytest --cov=. --cov-report=xml
+          pytest --cov=. --cov-report=xml --cov-fail-under=90
 
       - name: Upload Python coverage artifact
         uses: actions/upload-artifact@v4
@@ -63,6 +63,16 @@ jobs:
           cd frontend
           npm install
 
+      - name: Prettier check
+        run: |
+          cd frontend
+          npx prettier --check ..
+
+      - name: Lint
+        run: |
+          cd frontend
+          npm run lint
+
       - name: Type check
         run: |
           cd frontend
@@ -71,7 +81,7 @@ jobs:
       - name: Test with coverage
         run: |
           cd frontend
-          npm run test:coverage
+          npx vitest --coverage.v8 --coverage-threshold=90
 
       - name: Upload frontend coverage artifact
         uses: actions/upload-artifact@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,13 @@ Thank you for taking the time to contribute to **MCP Project Manager**! This pro
 ## 🔧 Install Dependencies
 
 ### 1. Backend (Python)
+
 ```bash
 cd backend
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
+```
 ````
 
 ### 2. Frontend (Node.js)
@@ -39,9 +41,9 @@ pre-commit install
 
 ### What gets checked:
 
-* **Backend**: `flake8` runs on Python files
-* **Frontend**: `npm run lint` and `npm run type-check` run on JS/TS files (the type check can also be triggered from the repo root with `npm run type-check`)
-* **Lint Staged Files**: `npx lint-staged` automatically fixes and formats only the files you commit using the config in `frontend/package.json`
+- **Backend**: `flake8` runs on Python files
+- **Frontend**: `npm run lint` and `npm run type-check` run on JS/TS files (the type check can also be triggered from the repo root with `npm run type-check`)
+- **Lint Staged Files**: `npx lint-staged` automatically fixes and formats only the files you commit using the config in `frontend/package.json`
 
 These checks will automatically run on every commit.
 
@@ -69,14 +71,15 @@ This writes `frontend/src/types/generatedEnums.ts`.
 
 ## 📐 Coding Standards
 
-* Follow existing code structure and conventions.
-* Keep code self-explanatory and remove unused code.
-* **Frontend**:
+- Follow existing code structure and conventions.
+- Keep code self-explanatory and remove unused code.
+- **Frontend**:
 
-  * Run: `npm run lint`, `npm run type-check`, `npm run fix`, and `npm run format` before committing.
-* **Backend**:
+  - Run: `npx prettier --check .`, `npm run lint`, `npm run type-check`, `npm run fix`, and `npm run format` before committing.
 
-  * Run: `flake8` and ensure no style violations or unused imports remain.
+- **Backend**:
+
+  - Run: `flake8` and ensure no style violations or unused imports remain.
 
 ---
 
@@ -105,15 +108,17 @@ Before opening a Pull Request, ensure the following tests and linters pass:
 
 ```bash
 cd frontend
+npx prettier --check ..
 npm run lint
-npm test
+vitest --coverage.v8 --coverage-threshold=90
 ```
 
 ### Backend
 
 ```bash
 cd backend
-pytest
+flake8 .
+pytest --cov=. --cov-fail-under=90
 ```
 
 All tests and linters must pass locally before submitting a PR.
@@ -126,4 +131,5 @@ Your contributions help make this project better.
 Whether it's fixing a bug, improving documentation, or adding a new feature—we appreciate your effort.
 
 ```
+
 ```


### PR DESCRIPTION
## Summary
- enforce lint and style checks in CI
- add coverage thresholds for backend and frontend
- document linting and coverage expectations

## Testing
- `npx prettier --check CONTRIBUTING.md .github/workflows/ci.yml`
- `flake8 .` *(fails: F401 in add_task_indexes.py, etc.)*
- `pytest --cov=. --cov-report=xml --cov-fail-under=90` *(fails: ImportError: cannot import name 'ENCODERS_BY_TYPE')*
- `npx vitest --coverage.enabled --coverage.v8 --coverage.threshold=90` *(fails: Duplicate key warning and test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68421d45ac1c832c802f24aa4fb86ad9