### PR TITLE
Add integration tests and frontend API tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,11 @@ jobs:
           cd frontend
           npm run test:coverage
 
+      - name: Run frontend test suite
+        run: |
+          cd frontend
+          npm run test:all
+
       - name: Upload frontend coverage artifact
         uses: actions/upload-artifact@v4
         with:

--- a/backend/tests/integration/README.md
+++ b/backend/tests/integration/README.md
@@ -19,6 +19,9 @@ graph TD
 ## File List
 
 - `test_project_task_flow.py`
+- `test_project_template_service.py`
+- `test_audit_log_service.py`
+- `test_memory_file_associations.py`
 
 <!-- File List End -->
 

--- a/backend/tests/integration/test_audit_log_service.py
+++ b/backend/tests/integration/test_audit_log_service.py
@@ -1,0 +1,14 @@
+import pytest
+from backend.services.audit_log_service import AuditLogService
+
+
+@pytest.mark.asyncio
+async def test_create_and_get_audit_log(async_db_session):
+    service = AuditLogService(async_db_session)
+    log = await service.create_log(action='test', user_id='user1', details={'x': 1})
+    assert log.id
+    fetched = await service.get_log(log.id)
+    assert fetched is not None
+    assert fetched.action_type == 'test'
+    logs = await service.get_logs(user_id='user1')
+    assert len(logs) >= 1

--- a/backend/tests/integration/test_memory_file_associations.py
+++ b/backend/tests/integration/test_memory_file_associations.py
@@ -1,0 +1,31 @@
+import pytest
+from backend.services.memory_service import MemoryService
+from backend.services.task_file_association_service import TaskFileAssociationService
+from backend.schemas.memory import MemoryEntityCreate
+
+
+@pytest.mark.asyncio
+async def test_associate_memory_file_with_task(async_db_session, test_task):
+    memory_service = MemoryService(async_db_session)
+    file_entity = await memory_service.create_entity(
+        MemoryEntityCreate(entity_type='file', content='data')
+    )
+
+    assoc_service = TaskFileAssociationService(async_db_session)
+    association = await assoc_service.associate_file_with_task(
+        str(test_task.project_id),
+        test_task.task_number,
+        file_entity.id,
+    )
+    assert association.file_memory_entity_id == file_entity.id
+    fetched = await assoc_service.get_association(
+        str(test_task.project_id), test_task.task_number, file_entity.id
+    )
+    assert fetched is not None
+    await assoc_service.disassociate_file_from_task(
+        str(test_task.project_id), test_task.task_number, file_entity.id
+    )
+    removed = await assoc_service.get_association(
+        str(test_task.project_id), test_task.task_number, file_entity.id
+    )
+    assert removed is None

--- a/backend/tests/integration/test_project_template_service.py
+++ b/backend/tests/integration/test_project_template_service.py
@@ -1,0 +1,37 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.database import Base
+from backend.services.project_template_service import ProjectTemplateService
+from backend.schemas.project_template import ProjectTemplateCreate
+
+
+@pytest.fixture()
+def sync_session():
+    engine = create_engine('sqlite:///:memory:')
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(engine)
+
+
+def test_create_and_retrieve_template(sync_session):
+    service = ProjectTemplateService(sync_session)
+    tpl = service.create_template(
+        ProjectTemplateCreate(
+            name='Template 1',
+            description='demo',
+            template_data={'default_tasks': []}
+        )
+    )
+    assert tpl.id
+    fetched = service.get_template(tpl.id)
+    assert fetched is not None
+    assert fetched.name == 'Template 1'
+    templates = service.get_templates()
+    assert len(templates) == 1

--- a/frontend/src/services/__tests__/project_templates.test.ts
+++ b/frontend/src/services/__tests__/project_templates.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as templatesApi from '../api/project_templates'
+import { request } from '../api/request'
+import { buildApiUrl } from '../api/config'
+
+vi.mock('../api/request')
+vi.mock('../api/config')
+
+const mockRequest = vi.mocked(request)
+const mockBuildApiUrl = vi.mocked(buildApiUrl)
+
+describe('Project Templates API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockBuildApiUrl.mockReturnValue('http://test/api')
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  it('creates a template', async () => {
+    mockRequest.mockResolvedValue({ id: 't1', name: 'T' })
+    const data = { name: 'T', description: 'd', template_data: {} }
+    const result = await templatesApi.projectTemplatesApi.create(data)
+    expect(mockBuildApiUrl).toHaveBeenCalled()
+    expect(mockRequest).toHaveBeenCalledWith('http://test/api', expect.any(Object))
+    expect(result).toEqual({ id: 't1', name: 'T' })
+  })
+
+  it('lists templates with pagination', async () => {
+    mockRequest.mockResolvedValue([])
+    await templatesApi.projectTemplatesApi.list(5, 20)
+    expect(mockBuildApiUrl).toHaveBeenCalledWith(expect.any(String), '?skip=5&limit=20')
+  })
+})

--- a/frontend/src/services/__tests__/task_file_association.test.ts
+++ b/frontend/src/services/__tests__/task_file_association.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as tasksApi from '../api/tasks'
+import { request } from '../api/request'
+import { buildApiUrl } from '../api/config'
+
+vi.mock('../api/request')
+vi.mock('../api/config')
+
+const mockRequest = vi.mocked(request)
+const mockBuildApiUrl = vi.mocked(buildApiUrl)
+
+describe('Task file association API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockBuildApiUrl.mockReturnValue('http://test/endpoint')
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  it('associates file with task', async () => {
+    mockRequest.mockResolvedValue({ file_memory_entity_id: 1 })
+    const res = await tasksApi.associateFileWithTask('p1', 2, { file_memory_entity_id: 1 })
+    expect(mockBuildApiUrl).toHaveBeenCalled()
+    expect(mockRequest).toHaveBeenCalled()
+    expect(res.file_memory_entity_id).toBe(1)
+  })
+
+  it('disassociates file from task', async () => {
+    mockRequest.mockResolvedValue(undefined)
+    await tasksApi.disassociateFileFromTask('p1', 2, '3')
+    expect(mockBuildApiUrl).toHaveBeenCalledWith('http://test/endpoint', '/p1/tasks/2/files/3')
+  })
+})

--- a/frontend/test-runner.js
+++ b/frontend/test-runner.js
@@ -2,6 +2,15 @@ const { spawn, exec } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
+const TEST_TYPES = {
+  unit: 'Unit Tests',
+  integration: 'Integration Tests',
+  e2e: 'End-to-End Tests',
+  api: 'API Tests',
+  coverage: 'Coverage Report',
+  all: 'Complete Suite'
+};
+
 (function() {
   Help() {
     console.log('Available test commands:')


### PR DESCRIPTION
## Summary
- add backend integration tests for project templates, audit logs and memory file associations
- create vitest tests for corresponding frontend API modules
- expose test types in `test-runner.js`
- run full frontend test suite in CI

## Testing
- `flake8 tests/integration/test_memory_file_associations.py tests/integration/test_audit_log_service.py tests/integration/test_project_template_service.py`
- `npm run format`
- `pytest backend/tests/integration/test_project_template_service.py backend/tests/integration/test_audit_log_service.py backend/tests/integration/test_memory_file_associations.py` *(fails: ImportError)*
- `npx vitest run frontend/src/services/__tests__/project_templates.test.ts frontend/src/services/api/__tests__/audit_logs.test.tsx frontend/src/services/__tests__/task_file_association.test.ts` *(fails: needs packages)*

------
https://chatgpt.com/codex/tasks/task_e_68421d05c8f4832ca85ba71d182f2c28