### PR TITLE
Add formatting and coverage checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,10 @@ jobs:
       - name: Test with coverage
         run: |
           cd backend
-          pytest --cov=. --cov-report=xml
+          pytest --cov=. --cov-report=xml --cov-fail-under=90
 
       - name: Upload Python coverage artifact
+        if: success()
         uses: actions/upload-artifact@v4
         with:
           name: backend-coverage
@@ -63,6 +64,14 @@ jobs:
           cd frontend
           npm install
 
+      - name: Prettier check
+        run: npm run prettier:check
+
+      - name: Lint
+        run: |
+          cd frontend
+          npm run lint
+
       - name: Type check
         run: |
           cd frontend
@@ -71,9 +80,10 @@ jobs:
       - name: Test with coverage
         run: |
           cd frontend
-          npm run test:coverage
+          npx vitest run --coverage.v8 --coverage-threshold=90
 
       - name: Upload frontend coverage artifact
+        if: success()
         uses: actions/upload-artifact@v4
         with:
           name: frontend-coverage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,10 +73,10 @@ This writes `frontend/src/types/generatedEnums.ts`.
 * Keep code self-explanatory and remove unused code.
 * **Frontend**:
 
-  * Run: `npm run lint`, `npm run type-check`, `npm run fix`, and `npm run format` before committing.
+  * Run: `npm run prettier:check`, `npm run lint`, `npm run type-check`, `npm run fix`, and `npm run format` before committing.
 * **Backend**:
 
-  * Run: `flake8` and ensure no style violations or unused imports remain.
+  * Run: `flake8` and ensure no style violations or unused imports remain. You can run `npm run prettier:check` from the repo root to verify formatting of Markdown and config files.
 
 ---
 
@@ -106,14 +106,14 @@ Before opening a Pull Request, ensure the following tests and linters pass:
 ```bash
 cd frontend
 npm run lint
-npm test
+npx vitest run --coverage.v8 --coverage-threshold=90
 ```
 
 ### Backend
 
 ```bash
 cd backend
-pytest
+pytest --cov=. --cov-fail-under=90
 ```
 
 All tests and linters must pass locally before submitting a PR.


### PR DESCRIPTION
## Summary
- enforce prettier, lint, and flake8 in CI
- fail CI if coverage under 90%
- only upload coverage on success
- document prettier and coverage requirements in CONTRIBUTING

## Testing
- `npm run prettier:check` *(fails: code style issues)*
- `npm run lint` *(fails: `next` not found)*
- `flake8 .` *(fails: many style errors)*
- `pytest --cov=. --cov-report=xml --cov-fail-under=90` *(fails: ModuleNotFoundError: 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68421ce223d0832c80fcbbc648558dae