### PR TITLE
Add integration tests for templates, logs, and file links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,11 @@ jobs:
           cd frontend
           npm run type-check
 
+      - name: Integration tests
+        run: |
+          cd frontend
+          npm run test:integration
+
       - name: Test with coverage
         run: |
           cd frontend

--- a/backend/tests/integration/test_audit_logs_integration.py
+++ b/backend/tests/integration/test_audit_logs_integration.py
@@ -1,0 +1,23 @@
+import pytest
+
+from backend.services.audit_log_service import AuditLogService
+from backend.schemas.audit_log import AuditLogUpdate
+
+
+@pytest.mark.asyncio
+async def test_audit_log_service(async_db_session):
+    service = AuditLogService(async_db_session)
+    log = await service.create_log(action="test", user_id="u1", details={"x": 1})
+    assert log.action_type == "test"
+
+    fetched = await service.get_log(log.id)
+    assert fetched is not None and fetched.id == log.id
+
+    logs = await service.get_logs(user_id="u1")
+    assert any(entry.id == log.id for entry in logs)
+
+    updated = await service.update_log(log.id, AuditLogUpdate(action="updated"))
+    assert updated is not None and updated.action_type == "updated"
+
+    deleted = await service.delete_log(log.id)
+    assert deleted is True

--- a/backend/tests/integration/test_file_associations_integration.py
+++ b/backend/tests/integration/test_file_associations_integration.py
@@ -1,0 +1,50 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from backend.app_factory import create_app
+from backend.database import get_sync_db as get_db
+from backend.auth import create_access_token
+
+
+@pytest.mark.asyncio
+async def test_project_file_association_flow(async_db_session, test_user, test_project):
+    app = create_app()
+
+    async def override_db():
+        yield async_db_session
+
+    app.dependency_overrides[get_db] = override_db
+
+    token = create_access_token(data={"sub": test_user.username})
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        client.headers.update({"Authorization": f"Bearer {token}"})
+
+        resp = await client.post(
+            "/api/memory/entities/ingest/text",
+            json={"text": "hello"},
+        )
+        assert resp.status_code == 201
+        file_id = resp.json()["id"]
+
+        resp = await client.post(
+            f"/api/v1/projects/{test_project.id}/files/",
+            json={"file_id": file_id},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["data"]["file_memory_entity_id"] == file_id
+
+        resp = await client.get(
+            f"/api/v1/projects/{test_project.id}/files/"
+        )
+        assert resp.status_code == 200
+        assert any(f["file_memory_entity_id"] == file_id for f in resp.json()["data"])
+
+        resp = await client.delete(
+            f"/api/v1/projects/{test_project.id}/files/{file_id}"
+        )
+        assert resp.status_code == 200
+        assert resp.json()["data"] is True

--- a/backend/tests/integration/test_project_templates_integration.py
+++ b/backend/tests/integration/test_project_templates_integration.py
@@ -1,0 +1,44 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from backend.app_factory import create_app
+from backend.database import get_sync_db as get_db
+from backend.auth import create_access_token
+
+
+@pytest.mark.asyncio
+async def test_project_template_crud(async_db_session, test_user):
+    app = create_app()
+
+    async def override_db():
+        yield async_db_session
+
+    app.dependency_overrides[get_db] = override_db
+
+    token = create_access_token(data={"sub": test_user.username})
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        client.headers.update({"Authorization": f"Bearer {token}"})
+
+        create_data = {"name": "Integration Template", "description": "desc"}
+        resp = await client.post("/api/templates/", json=create_data)
+        assert resp.status_code == 201
+        template_id = resp.json()["id"]
+
+        resp = await client.get("/api/templates/")
+        assert resp.status_code == 200
+        assert any(t["id"] == template_id for t in resp.json())
+
+        resp = await client.put(
+            f"/api/templates/{template_id}",
+            json={"description": "updated"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["description"] == "updated"
+
+        resp = await client.delete(f"/api/templates/{template_id}")
+        assert resp.status_code == 200
+        assert resp.json()["message"] == "Project template deleted successfully"

--- a/frontend/test-runner.js
+++ b/frontend/test-runner.js
@@ -1,6 +1,19 @@
 const { spawn, exec } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const TEST_TYPES = {
+  unit: "Unit tests",
+  integration: "Integration tests",
+  e2e: "End-to-End tests",
+  api: "API tests",
+  coverage: "Coverage report",
+  all: "Complete test suite"
+};
+
+function displayHelp() {
+  Help();
+}
+
 
 (function() {
   Help() {
@@ -60,7 +73,7 @@ const path = require('path');
   async function runIntegrationTests() {
     console.log('🔗 Running Integration Tests...')
     try {
-      await runCommand('npm', ['run', 'test:run', '--', 'src/__tests__/integration'])
+      await runCommand('npm', ['run', 'test:run', '--', 'src/__tests__/integration', 'tests/integration'])
       console.log('✅ Integration tests completed successfully')
       return true
     } catch (error) {

--- a/frontend/tests/integration/apiFunctions.test.ts
+++ b/frontend/tests/integration/apiFunctions.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { projectTemplatesApi } from '../../src/services/api/project_templates'
+import { getAuditLogById } from '../../src/services/api/audit_logs'
+import { associateFileWithProject } from '../../src/services/api/projects'
+import { request } from '../../src/services/api/request'
+
+vi.mock('../../src/services/api/request', () => ({
+  request: vi.fn(() => Promise.resolve({}))
+}))
+
+describe('frontend api functions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('creates project template via API', async () => {
+    await projectTemplatesApi.create({ name: 't', description: 'd' })
+    expect(request).toHaveBeenCalledWith(
+      expect.stringContaining('/project-templates'),
+      expect.objectContaining({ method: 'POST' })
+    )
+  })
+
+  it('fetches audit log by id', async () => {
+    await getAuditLogById('1')
+    expect(request).toHaveBeenCalledWith(
+      expect.stringContaining('/audit-logs/1')
+    )
+  })
+
+  it('associates file with project', async () => {
+    await associateFileWithProject('p1', { file_id: '3' })
+    expect(request).toHaveBeenCalledWith(
+      expect.stringContaining('/projects'),
+      expect.objectContaining({ method: 'POST' })
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- add backend integration tests for project templates, audit log service and file associations
- create vitest tests for frontend API wrappers
- extend test runner and CI workflow to run integration tests

## Testing
- `flake8 tests/integration/test_project_templates_integration.py`
- `flake8 tests/integration/test_audit_logs_integration.py tests/integration/test_file_associations_integration.py`
- `npx vitest run tests/integration/apiFunctions.test.ts`
- `pytest tests/integration/test_project_templates_integration.py` *(fails: ImportError ENCODERS_BY_TYPE)*

------
https://chatgpt.com/codex/tasks/task_e_68421cd8c56c832cadbeac768be1353d