### PR TITLE
Update CI linting and coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,10 @@ jobs:
       - name: Test with coverage
         run: |
           cd backend
-          pytest --cov=. --cov-report=xml
+          pytest --cov=. --cov-report=xml --cov-fail-under=90
 
       - name: Upload Python coverage artifact
+        if: ${{ success() }}
         uses: actions/upload-artifact@v4
         with:
           name: backend-coverage
@@ -63,6 +64,16 @@ jobs:
           cd frontend
           npm install
 
+      - name: Prettier check
+        run: |
+          cd frontend
+          npx prettier --check "src/**/*.{js,jsx,ts,tsx,json,css,md}"
+
+      - name: Lint
+        run: |
+          cd frontend
+          npm run lint
+
       - name: Type check
         run: |
           cd frontend
@@ -71,9 +82,10 @@ jobs:
       - name: Test with coverage
         run: |
           cd frontend
-          npm run test:coverage
+          npx vitest --coverage.v8 --coverage-threshold=90
 
       - name: Upload frontend coverage artifact
+        if: ${{ success() }}
         uses: actions/upload-artifact@v4
         with:
           name: frontend-coverage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,11 @@ pytest
 
 All tests and linters must pass locally before submitting a PR.
 
+The CI pipeline also runs `prettier --check`, `npm run lint`, and `flake8`.
+Coverage thresholds are enforced: `pytest --cov-fail-under=90` and
+`vitest --coverage.v8 --coverage-threshold=90`. Coverage artifacts are uploaded
+only when these checks succeed.
+
 ---
 
 ## 🤝 Thank You


### PR DESCRIPTION
## Summary
- run flake8, prettier and eslint in CI
- enforce test coverage thresholds
- document CI expectations

## Testing
- `flake8 .` *(fails: ImportError and style errors)*
- `pytest --cov=. --cov-report=xml --cov-fail-under=90` *(fails: ImportError)*
- `npx prettier --check "src/**/*.{js,jsx,ts,tsx,json,css,md}"` *(fails: code style issues)*
- `npm run lint` *(fails: next not found)*
- `npx vitest --coverage.v8 --coverage-threshold=90` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421cd12718832c9cc9b95c9da95b5b