### PR TITLE
Implement slowapi rate limiting

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -60,6 +60,12 @@ flake8 .
 Fix any issues reported. The helper script `comprehensive_flake8_fixer.py` can
 automatically clean common violations.
 
+## 🛡️ Rate Limiting
+
+The API uses **slowapi** to enforce per-endpoint rate limits. Login endpoints
+are limited to `5` requests per minute and memory ingestion endpoints allow up
+to `10` requests per minute. Exceeding these limits results in a `429` error.
+
 ## 📁 Project Structure
 
 ```

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -23,6 +23,7 @@ aiohttp = "*"
 httpx = "*"
 prometheus-client = "*"
 authlib = "*"
+slowapi = "*"
 
 [tool.poetry.group.dev.dependencies]
 flake8 = "*"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,6 +12,7 @@ aiosqlite
 aiohttp
 prometheus-client
 authlib
+slowapi
 
 # For CI/Dev
 flake8

--- a/backend/routers/memory/core/core.py
+++ b/backend/routers/memory/core/core.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, status, Query, Path
+from fastapi import APIRouter, Depends, HTTPException, status, Query, Path, Request
 from sqlalchemy.orm import Session
 from typing import List, Optional, Dict, Any
 from pydantic import BaseModel, Field
@@ -14,6 +14,7 @@ from ....services.exceptions import (
 )
 from ....auth import get_current_active_user
 from ....models import User as UserModel
+from ....security import limiter
 
 router = APIRouter(
     prefix="/entities",
@@ -157,7 +158,9 @@ class TextIngestInput(BaseModel):
     response_model=MemoryEntity,
     status_code=status.HTTP_201_CREATED,
 )
+@limiter.limit("10/minute")
 def ingest_file_endpoint(
+    request: Request,
     ingest_input: FileIngestInput,
     memory_service: MemoryService = Depends(get_memory_service),
     current_user: UserModel = Depends(get_current_active_user),
@@ -180,7 +183,9 @@ def ingest_file_endpoint(
     response_model=MemoryEntity,
     status_code=status.HTTP_201_CREATED,
 )
+@limiter.limit("10/minute")
 def ingest_url_endpoint(
+    request: Request,
     ingest_input: UrlIngestInput,
     memory_service: MemoryService = Depends(get_memory_service),
     current_user: UserModel = Depends(get_current_active_user),
@@ -199,7 +204,9 @@ def ingest_url_endpoint(
     response_model=MemoryEntity,
     status_code=status.HTTP_201_CREATED,
 )
+@limiter.limit("10/minute")
 def ingest_text_endpoint(
+    request: Request,
     ingest_input: TextIngestInput,
     memory_service: MemoryService = Depends(get_memory_service),
     current_user: UserModel = Depends(get_current_active_user),

--- a/backend/routers/users/auth/auth.py
+++ b/backend/routers/users/auth/auth.py
@@ -9,7 +9,7 @@ from backend.services.audit_log_service import AuditLogService
 from backend.services.exceptions import AuthorizationError
 from backend.config import ACCESS_TOKEN_EXPIRE_MINUTES, OAUTH_REDIRECT_URI
 from backend.auth import create_access_token
-from backend.security import login_tracker, oauth
+from backend.security import login_tracker, oauth, limiter
 from backend.schemas.user import UserCreate
 from backend.enums import UserRoleEnum
 import uuid
@@ -40,7 +40,9 @@ class LoginRequest(BaseModel):
 
 
 @router.post("/token", response_model=Token)
+@limiter.limit("5/minute")
 async def login_for_access_token_form(
+    request: Request,
     form_data: OAuth2PasswordRequestForm = Depends(),
     user_service: UserService = Depends(get_user_service),
     audit_log_service: AuditLogService = Depends(get_audit_log_service)
@@ -55,7 +57,9 @@ async def login_for_access_token_form(
 
 
 @router.post("/login", response_model=Token)
+@limiter.limit("5/minute")
 async def login_for_access_token_json(
+    request: Request,
     login_data: LoginRequest,
     user_service: UserService = Depends(get_user_service),
     audit_log_service: AuditLogService = Depends(get_audit_log_service)

--- a/backend/security.py
+++ b/backend/security.py
@@ -2,6 +2,9 @@
 Security utilities for the application.
 """
 from fastapi import HTTPException, Request, status
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.util import get_remote_address
+from slowapi.errors import RateLimitExceeded
 from datetime import datetime, timedelta
 from typing import Dict
 import asyncio
@@ -121,6 +124,7 @@ class LoginAttemptTracker:
 # Global instances
 rate_limiter = RateLimiter()
 login_tracker = LoginAttemptTracker()
+limiter = Limiter(key_func=get_remote_address)
 
 # OAuth configuration
 oauth = OAuth()


### PR DESCRIPTION
## Summary
- integrate `slowapi` in backend
- add login and ingestion limits
- document limits in backend README

## Testing
- `flake8 security.py main.py routers/users/auth/auth.py routers/memory/core/core.py`
- `pytest tests/test_simple.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e5d626c8832c979ccdfcd2fc132c