### PR TITLE
feat: validate memory ingestion APIs

### DIFF
--- a/validate_alignment.py
+++ b/validate_alignment.py
@@ -339,6 +339,71 @@ class FeatureAlignmentValidator:
                     )
                 )
 
+                # Test ingestion endpoints
+                async with session.post(
+                    f"{self.backend_url}/api/memory/ingest-text",
+                    json={"text": "integration check"},
+                    headers={"Authorization": f"Bearer {self.auth_token}"},
+                ) as resp:
+                    if resp.status == 201:
+                        data = await resp.json()
+                        valid = (
+                            isinstance(data.get("id"), int)
+                            and data.get("entity_type") == "text"
+                        )
+                        results.append(
+                            (
+                                "Ingest text",
+                                valid,
+                                ("✅" if valid else "❌")
+                                + " POST /api/memory/ingest-text - Status: "
+                                + str(resp.status),
+                            )
+                        )
+                    else:
+                        results.append(
+                            (
+                                "Ingest text",
+                                False,
+                                (
+                                    "❌ POST /api/memory/ingest-text - "
+                                    f"Status: {resp.status}"
+                                ),
+                            )
+                        )
+
+                async with session.post(
+                    f"{self.backend_url}/api/memory/ingest-url",
+                    json={"url": "http://example.com"},
+                    headers={"Authorization": f"Bearer {self.auth_token}"},
+                ) as resp:
+                    if resp.status == 201:
+                        data = await resp.json()
+                        valid = (
+                            isinstance(data.get("id"), int)
+                            and data.get("entity_type") == "url"
+                        )
+                        results.append(
+                            (
+                                "Ingest url",
+                                valid,
+                                ("✅" if valid else "❌")
+                                + " POST /api/memory/ingest-url - Status: "
+                                + str(resp.status),
+                            )
+                        )
+                    else:
+                        results.append(
+                            (
+                                "Ingest url",
+                                False,
+                                (
+                                    "❌ POST /api/memory/ingest-url - "
+                                    f"Status: {resp.status}"
+                                ),
+                            )
+                        )
+
         except Exception as e:
             results.append(("Memory features validation", False, f"Error: {e}"))
 


### PR DESCRIPTION
## Summary
- extend integration validator to invoke `/api/memory/ingest-text` and `/api/memory/ingest-url`
- verify response schema for ingestion endpoints

## Testing
- `flake8 ../validate_alignment.py`
- `pytest -q` *(fails: 11 failed, 3 errors)*
- `npm --prefix frontend install` *(failed: Command was interrupted due to timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6841e5ccb654832cba4200072275f550