### PR TITLE
Add validation checks for templates and rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ npm run type-check
 ```bash
 python final_integration.py --mode all
 ```
+This runs a comprehensive validation including checks for project template and agent rule features.
 
 ---
 

--- a/final_integration.py
+++ b/final_integration.py
@@ -89,6 +89,8 @@ class TheBuilderSystemIntegrator:
             ("Database initialization", self._check_database),
             ("Backend models integrity", self._check_models),
             ("API routers completeness", self._check_routers),
+            ("Project template features", self._check_project_template_features),
+            ("Agent rule features", self._check_agent_rule_features),
         ]
         
         for check_name, check_func in backend_checks:
@@ -186,9 +188,31 @@ class TheBuilderSystemIntegrator:
         routers_dir = self.backend_dir / "routers"
         if not routers_dir.exists():
             return False
-        
+
         key_routers = ['projects.py', 'tasks.py', 'agents.py', 'users.py']
         return all((routers_dir / router).exists() for router in key_routers)
+
+    def _check_project_template_features(self):
+        """Verify project template features exist on both backend and frontend."""
+        backend_router = (
+            self.backend_dir / "routers" / "project_templates" / "project_templates.py"
+        )
+        backend_service = self.backend_dir / "services" / "project_template_service.py"
+        frontend_service = (
+            self.frontend_dir / "src" / "services" / "api" / "project_templates.ts"
+        )
+        return backend_router.exists() and backend_service.exists() and frontend_service.exists()
+
+    def _check_agent_rule_features(self):
+        """Verify agent rule capabilities are present."""
+        backend_service = self.backend_dir / "services" / "rules_service.py"
+        backend_router = self.backend_dir / "routers" / "rules"
+        frontend_service = self.frontend_dir / "src" / "services" / "api" / "rules.ts"
+        return (
+            backend_service.exists()
+            and backend_router.exists()
+            and frontend_service.exists()
+        )
     
     def _check_frontend_structure(self):
         """Check frontend directory structure."""


### PR DESCRIPTION
## Summary
- extend `final_integration.py` validation
- add project template and agent rule checks
- document new checks in `README`

## Testing
- `flake8 ..` *(fails: ModuleNotFoundError and style errors)*
- `npm run lint` *(fails: next not found)*
- `node --test tests/cli/help.test.js` *(fails: expected exit code 0)*
- `npm run type-check` *(fails: missing type declarations)*
- `pytest backend/tests/test_simple.py` *(fails: ModuleNotFoundError: 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6841e5cc3f20832caee1ce6e3a6f7afb