### PR TITLE
Finalize audit doc and export status helpers

### DIFF
--- a/frontend/COMPONENT_AUDIT_AND_REFACTOR_PLAN.md
+++ b/frontend/COMPONENT_AUDIT_AND_REFACTOR_PLAN.md
@@ -96,7 +96,15 @@ Based on a `grep_search` for `var(--...)`, the following files have been identif
   - **DONE - Remove CSS Modules References:** Commented-out `className` attributes removed from `page.tsx`.
   - **DONE - Audit `FilterSidebar` component**: Reviewed for legacy styles and replaced remaining `rem` values with `sizing` tokens.
   - **DONE - Audit `frontend/src/app/globals.css`**: Migrated font and modal styles to Tailwind tokens.
-  - **TODO - Review remaining UI components** listed in `page.tsx` imports: `TaskList`, `
+  - **Status Map - UI components imported by `page.tsx`:**
+
+    | Component | Audit Status |
+    |-----------|--------------|
+    | `TaskList.tsx` | ✅ Reviewed & Compliant |
+    | `ProjectList.tsx` | ⚠️ Partially Refactored (legacy `var(--...)` tokens remain) |
+    | `AgentList.tsx` | ✅ Reviewed & Compliant |
+    | `Dashboard.tsx` | ✅ Reviewed & Compliant |
+    | `SettingsContent.tsx` | ✅ Reviewed & Compliant |
 
 ### 7. Tailwind CSS Configuration Audit (`frontend/tailwind.config.ts`) (2025-05-17)
 

--- a/frontend/src/components/task/TaskItem.tsx
+++ b/frontend/src/components/task/TaskItem.tsx
@@ -15,7 +15,7 @@ import { useProjectStore } from "@/store/projectStore";
 import { useTaskStore } from "@/store/taskStore";
 import { getDisplayableStatus, StatusID, StatusAttributeObject } from "@/lib/statusUtils";
 import { TaskItemProps } from "./TaskItem.types";
-import { getStatusAccentColor } from "./TaskItem.utils";
+import { getStatusAccentColor } from "@/components/task";
 import { useTaskItemStyles } from "../useTaskItemStyles";
 import TaskItemMainSection from "./TaskItemMainSection";
 import TaskItemModals from "../TaskItemModals";

--- a/frontend/src/components/task/index.ts
+++ b/frontend/src/components/task/index.ts
@@ -1,0 +1,2 @@
+export { getStatusAccentColor, getStatusTagColors } from './TaskItem.utils';
+

--- a/frontend/src/components/useTaskItemStyles.ts
+++ b/frontend/src/components/useTaskItemStyles.ts
@@ -1,6 +1,6 @@
 import { useTheme, useToken } from "@chakra-ui/react";
 import { StatusID } from "@/lib/statusUtils";
-import { getStatusTagColors } from "./task/TaskItem.utils";
+import { getStatusTagColors } from "@/components/task";
 
 export function useTaskItemStyles(currentStatusId: StatusID, compact: boolean) {
   const theme = useTheme();


### PR DESCRIPTION
## Summary
- replace TODO placeholder with status map in component audit plan
- expose task item helper functions via new index module
- update task components to import helpers from new index

## Testing
- `npm --prefix frontend run test` *(fails: vitest not found)*
- `npm --prefix frontend run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e5d008f0832c88dd7eb06e32d352