### PR TITLE
Refactor dashboard metrics component to use design tokens

### DIFF
--- a/frontend/src/components/dashboard/TopPerformersLists.tsx
+++ b/frontend/src/components/dashboard/TopPerformersLists.tsx
@@ -9,6 +9,7 @@ import {
   Text,
 } from "@chakra-ui/react";
 import AppIcon from "../common/AppIcon";
+import { sizing, typography, shadows } from "../../tokens";
 
 interface PerformerItem {
   name: string;
@@ -26,25 +27,25 @@ const TopPerformersLists: React.FC<TopPerformersListsProps> = ({
 }) => {
   return (
     <Grid
-      gap="var(--spacing-8)"
+      gap={sizing.spacing[8]}
       templateColumns={{ base: "repeat(1, 1fr)", md: "repeat(2, 1fr)" }}
     >
       <Box
-        p="var(--spacing-4)"
+        p={sizing.spacing[4]}
         bg="surface"
-        borderRadius="var(--radii-lg)"
-        boxShadow="var(--shadows-md)"
-        borderWidth="var(--borders-width-xs)"
-        borderStyle="var(--borders-style-solid)"
+        borderRadius={sizing.borderRadius.lg}
+        boxShadow={shadows.md}
+        borderWidth={sizing.borderWidth.DEFAULT}
+        borderStyle="solid"
         borderColor="borderDecorative"
         minHeight="13.75rem"
       >
         <Heading
           as="h3"
-          fontSize="var(--typography-fontSizes-md)"
-          fontWeight="var(--typography-fontWeights-semibold)"
-          lineHeight="var(--typography-lineHeights-condensed)"
-          mb="var(--spacing-4)"
+          fontSize={typography.fontSize.md}
+          fontWeight={typography.fontWeight.semibold}
+          lineHeight={typography.lineHeight.condensed}
+          mb={sizing.spacing[4]}
           color="textPrimary"
           display="flex"
           alignItems="center"
@@ -52,7 +53,7 @@ const TopPerformersLists: React.FC<TopPerformersListsProps> = ({
           <AppIcon name="star" boxSize={5} mr={2} />
           Top 3 Busiest Agents (All Active Projects)
         </Heading>
-        <List spacing="var(--spacing-2)">
+        <List spacing={sizing.spacing[2]}>
           {topAgents.length === 0 ? (
             <ListItem>
               <Text color="textSecondary">
@@ -63,7 +64,7 @@ const TopPerformersLists: React.FC<TopPerformersListsProps> = ({
             topAgents.map((agent) => (
               <ListItem key={agent.name} display="flex" alignItems="center">
                 <AppIcon name="trophy" boxSize={4} mr={2} />
-                <Text fontWeight="var(--typography-fontWeights-bold)">
+                <Text fontWeight={typography.fontWeight.bold}>
                   {agent.name}
                 </Text>
                 <Badge colorScheme="purple">{agent.value} tasks</Badge>
@@ -73,21 +74,21 @@ const TopPerformersLists: React.FC<TopPerformersListsProps> = ({
         </List>
       </Box>
       <Box
-        p="var(--spacing-4)"
+        p={sizing.spacing[4]}
         bg="surface"
-        borderRadius="var(--radii-lg)"
-        boxShadow="var(--shadows-md)"
-        borderWidth="var(--borders-width-xs)"
-        borderStyle="var(--borders-style-solid)"
+        borderRadius={sizing.borderRadius.lg}
+        boxShadow={shadows.md}
+        borderWidth={sizing.borderWidth.DEFAULT}
+        borderStyle="solid"
         borderColor="borderDecorative"
         minHeight="13.75rem"
       >
         <Heading
           as="h3"
-          fontSize="var(--typography-fontSizes-md)"
-          fontWeight="var(--typography-fontWeights-semibold)"
-          lineHeight="var(--typography-lineHeights-condensed)"
-          mb="var(--spacing-4)"
+          fontSize={typography.fontSize.md}
+          fontWeight={typography.fontWeight.semibold}
+          lineHeight={typography.lineHeight.condensed}
+          mb={sizing.spacing[4]}
           color="textPrimary"
           display="flex"
           alignItems="center"
@@ -95,7 +96,7 @@ const TopPerformersLists: React.FC<TopPerformersListsProps> = ({
           <AppIcon name="star" boxSize={5} mr={2} />
           Top 3 Projects by Workload (All Active Projects)
         </Heading>
-        <List spacing="var(--spacing-2)">
+        <List spacing={sizing.spacing[2]}>
           {topProjects.length === 0 ? (
             <ListItem>
               <Text color="textSecondary">
@@ -106,7 +107,7 @@ const TopPerformersLists: React.FC<TopPerformersListsProps> = ({
             topProjects.map((project) => (
               <ListItem key={project.name} display="flex" alignItems="center">
                 <AppIcon name="trophy" boxSize={4} mr={2} />
-                <Text fontWeight="var(--typography-fontWeights-bold)">
+                <Text fontWeight={typography.fontWeight.bold}>
                   {project.name}
                 </Text>
                 <Badge colorScheme="blue">{project.value} tasks</Badge>


### PR DESCRIPTION
## Summary
- remove CSS variable usage from `TopPerformersLists`
- use Chakra/Tailwind tokens for spacing, typography and borders

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e5d2f37c832c965703db77b94c14