### PR TITLE
Add lint and coverage checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,10 @@ jobs:
       - name: Test with coverage
         run: |
           cd backend
-          pytest --cov=. --cov-report=xml
+          pytest --cov=. --cov-report=xml --cov-fail-under=90
 
       - name: Upload Python coverage artifact
+        if: success()
         uses: actions/upload-artifact@v4
         with:
           name: backend-coverage
@@ -63,6 +64,15 @@ jobs:
           cd frontend
           npm install
 
+      - name: Prettier check
+        run: |
+          npx prettier --check .
+
+      - name: Lint
+        run: |
+          cd frontend
+          npm run lint
+
       - name: Type check
         run: |
           cd frontend
@@ -71,13 +81,15 @@ jobs:
       - name: Test with coverage
         run: |
           cd frontend
-          npm run test:coverage
+          npx vitest run --coverage.v8 --coverage-threshold=90
 
       - name: Upload frontend coverage artifact
+        if: success()
         uses: actions/upload-artifact@v4
         with:
           name: frontend-coverage
           path: frontend/coverage
+
 
       - name: Audit packages
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,24 +99,31 @@ Reference related issues when applicable (e.g. `fix: #42`).
 
 ## ✅ Test Requirements
 
-Before opening a Pull Request, ensure the following tests and linters pass:
+Before opening a Pull Request, run these checks and ensure they succeed:
+
+### Formatting
+
+```bash
+npm run prettier:check
+```
 
 ### Frontend
 
 ```bash
 cd frontend
 npm run lint
-npm test
+npx vitest run --coverage.v8 --coverage-threshold=90
 ```
 
 ### Backend
 
 ```bash
 cd backend
-pytest
+flake8 .
+pytest --cov=. --cov-report=xml --cov-fail-under=90
 ```
 
-All tests and linters must pass locally before submitting a PR.
+All linters and tests must pass locally before submitting a PR.
 
 ---
 


### PR DESCRIPTION
## Summary
- run flake8, prettier and lint in CI
- enforce 90% coverage for backend and frontend tests
- only upload coverage after checks succeed
- document required local checks

## Testing
- `npx prettier --check .` *(fails: code style issues in repository)*
- `npm run lint` in `frontend`
- `npx vitest run --coverage.v8 --coverage.threshold=90` *(fails: tests errors)*
- `flake8 .` *(fails: many style violations)*
- `pytest --cov=. --cov-report=xml --cov-fail-under=90` *(fails: ImportError)*


------
https://chatgpt.com/codex/tasks/task_e_68421d4e4e74832c975def07c02bb0df