### PR TITLE
Add system endpoints

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,1 +1,9 @@
 # Make this directory a package
+
+"""Backend package for the MCP Project Manager."""
+
+__all__ = ["__version__"]
+
+# Application version. Keep in sync with `create_app` definition.
+__version__ = "2.0.1"
+

--- a/backend/app_factory.py
+++ b/backend/app_factory.py
@@ -196,6 +196,13 @@ def include_app_routers(application: FastAPI) -> None:
     except ImportError as e:
         logger.warning(f"Could not import audit_logs router: {e}")
 
+    try:
+        from .routers import system
+        application.include_router(system.router, prefix="/api/v1", tags=["system"])
+        logger.info("System router included successfully")
+    except ImportError as e:
+        logger.warning(f"Could not import system router: {e}")
+
     logger.info("Router inclusion completed")
 
 

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -1,1 +1,7 @@
-# Task ID: <taskId>  # Agent Role: ImplementationSpecialist  # Request ID: <requestId>  # Project: task-manager  # Timestamp: <timestamp>  # This makes 'routers' a Python package  # Import and include modular routers
+# Router package initialization
+
+"""Expose router modules used by :mod:`backend.app_factory`."""
+
+__all__ = [
+    "system",
+]

--- a/backend/routers/system.py
+++ b/backend/routers/system.py
@@ -1,0 +1,31 @@
+from fastapi import APIRouter, Depends, Response, status
+from sqlalchemy.orm import Session
+from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
+from sqlalchemy import text
+
+from ..database import get_db
+from .. import __version__
+
+router = APIRouter(tags=["system"])
+
+@router.get("/health", status_code=status.HTTP_200_OK)
+def health_check(db: Session = Depends(get_db)):
+    """Return basic health information."""
+    try:
+        db.execute(text("SELECT 1"))
+        db_status = "connected"
+    except Exception:
+        db_status = "error"
+    return {"status": "healthy", "database": db_status}
+
+
+@router.get("/metrics", include_in_schema=False)
+def metrics() -> Response:
+    """Expose Prometheus metrics."""
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+
+@router.get("/version")
+def version() -> dict:
+    """Return the running application version."""
+    return {"version": __version__}

--- a/backend/tests/test_system_endpoints.py
+++ b/backend/tests/test_system_endpoints.py
@@ -1,0 +1,26 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from backend.app_factory import create_app
+
+
+@pytest.mark.asyncio
+async def test_system_version_and_health_endpoints():
+    app = create_app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        health = await client.get("/api/v1/health")
+        assert health.status_code == 200
+        data = health.json()
+        assert data["status"] == "healthy"
+
+        version = await client.get("/api/v1/version")
+        assert version.status_code == 200
+        assert "version" in version.json()
+
+
+@pytest.mark.asyncio
+async def test_system_metrics_endpoint():
+    app = create_app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/v1/metrics")
+        assert resp.status_code == 200
+        assert b"http_requests_total" in resp.content


### PR DESCRIPTION
## Summary
- implement system router with health, metrics and version endpoints
- wire up router in application factory
- expose backend version constant
- add tests for new endpoints

## Testing
- `npm run lint` *(fails: flake8 not found)*
- `npm run test` *(fails: ModuleNotFoundError: sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68433f1568b4832caaebc2591c98a668